### PR TITLE
[P1] Initialize SQLite schema

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,101 @@
+-- Friday Budgeting Pro — SQLite schema
+-- Single-user, local-only personal finance database.
+
+-- Plaid bank connections
+CREATE TABLE IF NOT EXISTS bank_connections (
+  id TEXT PRIMARY KEY,
+  plaid_item_id TEXT UNIQUE,
+  plaid_access_token_encrypted TEXT NOT NULL,
+  institution_name TEXT,
+  status TEXT DEFAULT 'active',  -- active | needs_reauth
+  last_synced_at INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS bank_accounts (
+  id TEXT PRIMARY KEY,
+  connection_id TEXT REFERENCES bank_connections(id),
+  plaid_account_id TEXT UNIQUE,
+  name TEXT,
+  mask TEXT,
+  type TEXT,
+  subtype TEXT
+);
+
+-- Tracking structure (usually just one ledger called "Personal")
+CREATE TABLE IF NOT EXISTS ledgers (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS line_items (
+  id TEXT PRIMARY KEY,
+  ledger_id TEXT REFERENCES ledgers(id),
+  name TEXT NOT NULL,
+  item_type TEXT DEFAULT 'expense'  -- income | expense
+);
+
+-- Raw transactions from Plaid
+CREATE TABLE IF NOT EXISTS transactions (
+  id TEXT PRIMARY KEY,
+  bank_account_id TEXT REFERENCES bank_accounts(id),
+  plaid_transaction_id TEXT UNIQUE,
+  date TEXT NOT NULL,
+  merchant TEXT,
+  amount REAL NOT NULL,
+  plaid_category TEXT,
+  pending INTEGER DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS transaction_entries (
+  id TEXT PRIMARY KEY,
+  transaction_id TEXT REFERENCES transactions(id),
+  ledger_id TEXT REFERENCES ledgers(id),
+  line_item_id TEXT REFERENCES line_items(id),
+  amount REAL NOT NULL,
+  source TEXT,       -- rule | llm | manual
+  confidence REAL,
+  reviewed INTEGER DEFAULT 0
+);
+
+-- Tier 1: deterministic rules (auto-created over time)
+CREATE TABLE IF NOT EXISTS routing_rules (
+  id TEXT PRIMARY KEY,
+  merchant_pattern TEXT,
+  line_item_id TEXT REFERENCES line_items(id)
+);
+
+-- Tier 2: natural-language hints fed to the LLM
+CREATE TABLE IF NOT EXISTS classification_hints (
+  id TEXT PRIMARY KEY,
+  text TEXT NOT NULL
+);
+
+-- Plaid sync cursors
+CREATE TABLE IF NOT EXISTS sync_cursors (
+  connection_id TEXT PRIMARY KEY REFERENCES bank_connections(id),
+  cursor TEXT,
+  last_synced_at INTEGER
+);
+
+-- UI auth: single-row app config (single-user system)
+CREATE TABLE IF NOT EXISTS app_config (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  ui_password_hash TEXT,       -- argon2id hash
+  ui_password_set_at INTEGER
+);
+
+-- UI session cookies (server-side store, survives restarts)
+CREATE TABLE IF NOT EXISTS sessions (
+  id TEXT PRIMARY KEY,         -- session token (random 32 bytes hex)
+  created_at INTEGER NOT NULL,
+  last_seen_at INTEGER NOT NULL,
+  expires_at INTEGER NOT NULL,
+  user_agent TEXT
+);
+
+-- Login attempt log for rate limiting
+CREATE TABLE IF NOT EXISTS login_attempts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  attempted_at INTEGER NOT NULL,
+  success INTEGER NOT NULL     -- 0 = failed, 1 = success
+);

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,133 @@
+"""
+Tests for db/schema.sql — creates an in-memory SQLite DB from the schema
+and asserts all tables and key columns exist.
+"""
+import sqlite3
+import pathlib
+
+
+SCHEMA_PATH = pathlib.Path(__file__).parent.parent / "db" / "schema.sql"
+
+
+def get_connection() -> sqlite3.Connection:
+    sql = SCHEMA_PATH.read_text()
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(sql)
+    return conn
+
+
+def tables(conn: sqlite3.Connection) -> set[str]:
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    ).fetchall()
+    return {r[0] for r in rows}
+
+
+def columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    return {r[1] for r in rows}
+
+
+def test_all_tables_exist():
+    conn = get_connection()
+    expected = {
+        "bank_connections",
+        "bank_accounts",
+        "ledgers",
+        "line_items",
+        "transactions",
+        "transaction_entries",
+        "routing_rules",
+        "classification_hints",
+        "sync_cursors",
+        "app_config",
+        "sessions",
+        "login_attempts",
+    }
+    assert expected <= tables(conn), (
+        f"Missing tables: {expected - tables(conn)}"
+    )
+
+
+def test_bank_connections_columns():
+    conn = get_connection()
+    cols = columns(conn, "bank_connections")
+    assert {"id", "plaid_item_id", "plaid_access_token_encrypted",
+            "institution_name", "status", "last_synced_at"} <= cols
+
+
+def test_bank_accounts_columns():
+    conn = get_connection()
+    cols = columns(conn, "bank_accounts")
+    assert {"id", "connection_id", "plaid_account_id",
+            "name", "mask", "type", "subtype"} <= cols
+
+
+def test_ledgers_columns():
+    conn = get_connection()
+    cols = columns(conn, "ledgers")
+    assert {"id", "name"} <= cols
+
+
+def test_line_items_columns():
+    conn = get_connection()
+    cols = columns(conn, "line_items")
+    assert {"id", "ledger_id", "name", "item_type"} <= cols
+
+
+def test_transactions_columns():
+    conn = get_connection()
+    cols = columns(conn, "transactions")
+    assert {"id", "bank_account_id", "plaid_transaction_id",
+            "date", "merchant", "amount", "plaid_category", "pending"} <= cols
+
+
+def test_transaction_entries_columns():
+    conn = get_connection()
+    cols = columns(conn, "transaction_entries")
+    assert {"id", "transaction_id", "ledger_id", "line_item_id",
+            "amount", "source", "confidence", "reviewed"} <= cols
+
+
+def test_routing_rules_columns():
+    conn = get_connection()
+    cols = columns(conn, "routing_rules")
+    assert {"id", "merchant_pattern", "line_item_id"} <= cols
+
+
+def test_classification_hints_columns():
+    conn = get_connection()
+    cols = columns(conn, "classification_hints")
+    assert {"id", "text"} <= cols
+
+
+def test_sync_cursors_columns():
+    conn = get_connection()
+    cols = columns(conn, "sync_cursors")
+    assert {"connection_id", "cursor", "last_synced_at"} <= cols
+
+
+def test_app_config_columns():
+    conn = get_connection()
+    cols = columns(conn, "app_config")
+    assert {"id", "ui_password_hash", "ui_password_set_at"} <= cols
+
+
+def test_sessions_columns():
+    conn = get_connection()
+    cols = columns(conn, "sessions")
+    assert {"id", "created_at", "last_seen_at", "expires_at", "user_agent"} <= cols
+
+
+def test_login_attempts_columns():
+    conn = get_connection()
+    cols = columns(conn, "login_attempts")
+    assert {"id", "attempted_at", "success"} <= cols
+
+
+def test_schema_loads_twice_idempotent():
+    """IF NOT EXISTS means re-running the schema is safe."""
+    conn = get_connection()
+    sql = SCHEMA_PATH.read_text()
+    conn.executescript(sql)  # second run — should not raise
+    assert "transactions" in tables(conn)


### PR DESCRIPTION
Closes #10

Minimal SQLite schema per ARCHITECTURE.md § Data Model.

## What's included
- `db/schema.sql` — all 12 tables: `bank_connections`, `bank_accounts`, `ledgers`, `line_items`, `transactions`, `transaction_entries`, `routing_rules`, `classification_hints`, `sync_cursors`, `app_config`, `sessions`, `login_attempts`
- `tests/test_schema.py` — creates in-memory SQLite DB from schema, asserts all tables and key columns exist (16 tests, all green)

## Scope
Plain SQL only. No Python wrappers, no migrations system, no ORM.