### PR TITLE
[P7] SKILL.md for HAL discovery

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: friday-budgeting-pro
+description: >
+  An OpenClaw skill that lets the user manage personal finances by chatting with
+  HAL. Connects to banks via Plaid, auto-classifies transactions using a tiered
+  engine (rules → LLM → ask user), stores everything in a local SQLite file,
+  exports to Excel on request, and runs a daily sync. The user interacts
+  entirely through natural-language chat — no UI, no commands, no config files.
+version: "0.1"
+---
+
+# Friday Budgeting Pro
+
+## When to Use This Skill
+
+Invoke this skill when the user's message contains finance-related intent. Key
+trigger keywords include:
+
+**Banking / Accounts**
+- banks, bank account, banking, connect bank, add bank, Plaid, institution
+- balance, account balance, checking, savings, credit card
+
+**Transactions / Spending**
+- transactions, transaction, spending, charges, purchases
+- expenses, expense, expenditure
+- income, salary, paycheck, deposit
+
+**Budgeting / Tracking**
+- budget, budgeting, budget report
+- ledger, line item, category, categorize, classify
+- monthly report, weekly summary, spending summary
+
+**Actions / Exports**
+- export, Excel, spreadsheet, download
+- sync, refresh, update transactions
+- re-auth, reconnect bank
+
+## Example Trigger Phrases
+
+- "How much did I spend on groceries this month?"
+- "Connect my TD Bank account."
+- "Show me my transactions from last week."
+- "What's my budget looking like?"
+- "Export my expenses to Excel."
+- "Sync my bank transactions."
+- "I spent a lot on dining out — can you show me a breakdown?"
+- "What was that $47 charge from Amazon?"
+- "Add a rule: Starbucks is always Dining."
+- "How much income did I receive in April?"
+- "My Plaid connection needs re-authorization."
+- "Show me my top spending categories."
+
+## Do / Don't
+
+### ✅ Do
+
+- Invoke this skill for any question about personal finances, spending, or
+  banking.
+- Call the Friday Budgeting Pro MCP tools to answer finance questions.
+- Trigger conversational setup if this is the user's first time (DB empty).
+- Notify the user when a bank connection needs re-authorization.
+- Use the MCP `export` tool when the user asks for an Excel file.
+- Classify ambiguous transactions by asking the user directly.
+- Schedule or confirm the daily 6 AM sync via OpenClaw cron when requested.
+
+### ❌ Don't
+
+- Don't try to answer finance questions from general knowledge — always go
+  through the MCP tools which read the local DB.
+- Don't store or log Plaid tokens in plain text; the server handles encryption.
+- Don't expose internal implementation details (DB paths, encryption keys) to
+  the user.
+- Don't handle multi-user or business finance scenarios — this is personal
+  finance only.
+- Don't open a web browser or direct the user to any external URL except via
+  the Plaid Link flow managed by the MCP server.
+- Don't invoke this skill for generic money questions unrelated to the user's
+  own accounts (e.g., "what is inflation?").

--- a/tests/test_skill_md.py
+++ b/tests/test_skill_md.py
@@ -1,0 +1,70 @@
+"""Tests for SKILL.md — validate YAML frontmatter structure."""
+import pathlib
+
+
+SKILL_MD = pathlib.Path(__file__).parent.parent / "SKILL.md"
+
+
+def _parse_frontmatter(text: str) -> dict:
+    """Hand-parse YAML frontmatter delimited by '---' lines."""
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return {}
+    end = None
+    for i, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            end = i
+            break
+    if end is None:
+        return {}
+    fm: dict = {}
+    i = 1
+    while i < end:
+        line = lines[i]
+        if ":" in line and not line.startswith(" ") and not line.startswith("\t"):
+            key, _, rest = line.partition(":")
+            rest = rest.strip()
+            if rest == ">":
+                # Multi-line folded scalar — collect indented continuation lines
+                parts = []
+                i += 1
+                while i < end and (lines[i].startswith(" ") or lines[i].startswith("\t")):
+                    parts.append(lines[i].strip())
+                    i += 1
+                fm[key.strip()] = " ".join(parts)
+                continue
+            else:
+                fm[key.strip()] = rest.strip('"').strip("'")
+        i += 1
+    return fm
+
+
+def test_skill_md_exists():
+    assert SKILL_MD.exists(), "SKILL.md not found at repo root"
+
+
+def test_frontmatter_present():
+    content = SKILL_MD.read_text()
+    assert content.startswith("---"), "SKILL.md must start with YAML frontmatter (---)"
+
+
+def test_required_field_name():
+    content = SKILL_MD.read_text()
+    fm = _parse_frontmatter(content)
+    assert "name" in fm, "frontmatter missing 'name' field"
+    assert fm["name"].strip(), "'name' field must be non-empty"
+
+
+def test_required_field_description():
+    content = SKILL_MD.read_text()
+    fm = _parse_frontmatter(content)
+    assert "description" in fm, "frontmatter missing 'description' field"
+    assert fm["description"].strip(), "'description' field must be non-empty"
+
+
+def test_name_value():
+    content = SKILL_MD.read_text()
+    fm = _parse_frontmatter(content)
+    assert fm.get("name") == "friday-budgeting-pro", (
+        f"Expected name 'friday-budgeting-pro', got '{fm.get('name')}'"
+    )


### PR DESCRIPTION
Closes #26

SKILL.md so HAL knows when to invoke this skill.

- Added SKILL.md at repo root with YAML frontmatter (name: friday-budgeting-pro, description) and a 'When to use' section covering finance trigger keywords (banks, spending, transactions, budget, expenses, income, Plaid), example trigger phrases, and a do/don't list.
- Added tests/test_skill_md.py that hand-parses YAML frontmatter (no pyyaml dep needed) and asserts required fields are present and non-empty.
- All 30 tests pass.