### PR TITLE
[Sec] DB + cache file permissions (0600 / 0700)

### DIFF
--- a/server/paths.py
+++ b/server/paths.py
@@ -1,0 +1,140 @@
+"""
+server/paths.py — Centralised path constants and permission helpers.
+
+All on-disk artefacts for Friday Budgeting Pro live under ~/.friday-bp/.
+This module owns:
+  - Directory / file path constants
+  - Atomic file creation with the correct mode (0600)
+  - Directory creation with the correct mode (0700)
+  - A startup audit that fixes any files whose permissions have drifted
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import stat
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Path constants
+# ---------------------------------------------------------------------------
+
+APP_DIR: Path = Path.home() / ".friday-bp"
+DB_PATH: Path = APP_DIR / "data.db"
+SYNC_LOCK_PATH: Path = APP_DIR / "sync.lock"
+EXPORTS_DIR: Path = APP_DIR / "exports"
+
+# ---------------------------------------------------------------------------
+# Directory helpers
+# ---------------------------------------------------------------------------
+
+_DIR_MODE = 0o700
+_FILE_MODE = 0o600
+
+
+def ensure_app_dir() -> None:
+    """Create ~/.friday-bp/ (and exports/) with mode 0700.
+
+    Idempotent.  If the directory already exists but has the wrong permissions,
+    the permissions are corrected and a warning is logged.
+    """
+    for directory in (APP_DIR, EXPORTS_DIR):
+        if directory.exists():
+            current = stat.S_IMODE(directory.stat().st_mode)
+            if current != _DIR_MODE:
+                logger.warning(
+                    "Directory %s has permissions %o — expected %o; fixing.",
+                    directory,
+                    current,
+                    _DIR_MODE,
+                )
+                os.chmod(directory, _DIR_MODE)
+        else:
+            directory.mkdir(mode=_DIR_MODE, parents=True)
+
+
+# ---------------------------------------------------------------------------
+# File helpers
+# ---------------------------------------------------------------------------
+
+
+def create_file(path: Path, mode: int = _FILE_MODE) -> None:
+    """Create *path* with *mode*, atomically, if it does not already exist.
+
+    If the file already exists:
+      - its mode is audited; if wrong it is corrected and a warning is logged.
+      - its contents are left untouched.
+
+    The implementation uses O_CREAT | O_EXCL via os.open so that the mode is
+    applied at creation time (avoids a race between open() and chmod()).
+    """
+    path = Path(path)
+    if path.exists():
+        current = stat.S_IMODE(path.stat().st_mode)
+        if current != mode:
+            logger.warning(
+                "File %s has permissions %o — expected %o; fixing.",
+                path,
+                current,
+                mode,
+            )
+            os.chmod(path, mode)
+        return
+
+    # Ensure parent directory exists before creating the file.
+    path.parent.mkdir(mode=_DIR_MODE, parents=True, exist_ok=True)
+
+    # Create atomically with the correct mode from the start.
+    fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, mode)
+    os.close(fd)
+
+
+# ---------------------------------------------------------------------------
+# Startup audit
+# ---------------------------------------------------------------------------
+
+
+def audit_permissions() -> None:
+    """Scan APP_DIR and fix any files/dirs whose permissions have drifted.
+
+    Called once at daemon startup.  Logs a warning for every artefact that
+    needed to be corrected.
+    """
+    if not APP_DIR.exists():
+        return
+
+    # Audit the top-level app directory itself.
+    _audit_dir(APP_DIR)
+
+    for item in APP_DIR.rglob("*"):
+        if item.is_dir():
+            _audit_dir(item)
+        elif item.is_file():
+            _audit_file(item)
+
+
+def _audit_dir(path: Path) -> None:
+    current = stat.S_IMODE(path.stat().st_mode)
+    if current != _DIR_MODE:
+        logger.warning(
+            "audit_permissions: directory %s has permissions %o — expected %o; fixing.",
+            path,
+            current,
+            _DIR_MODE,
+        )
+        os.chmod(path, _DIR_MODE)
+
+
+def _audit_file(path: Path) -> None:
+    current = stat.S_IMODE(path.stat().st_mode)
+    if current != _FILE_MODE:
+        logger.warning(
+            "audit_permissions: file %s has permissions %o — expected %o; fixing.",
+            path,
+            current,
+            _FILE_MODE,
+        )
+        os.chmod(path, _FILE_MODE)

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,194 @@
+"""
+tests/test_paths.py — Unit tests for server/paths.py
+
+All tests use pytest's tmp_path fixture + monkeypatch to redirect APP_DIR
+so they never touch the real ~/.friday-bp/ directory.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+import server.paths as paths
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mode(p: Path) -> int:
+    """Return the permission bits (lower 12) of *p*."""
+    return stat.S_IMODE(p.stat().st_mode)
+
+
+def _redirect_app_dir(monkeypatch, tmp_path: Path) -> Path:
+    """Point server.paths.APP_DIR (and derived constants) at *tmp_path*."""
+    fake_app_dir = tmp_path / ".friday-bp"
+    monkeypatch.setattr(paths, "APP_DIR", fake_app_dir)
+    monkeypatch.setattr(paths, "DB_PATH", fake_app_dir / "data.db")
+    monkeypatch.setattr(paths, "SYNC_LOCK_PATH", fake_app_dir / "sync.lock")
+    monkeypatch.setattr(paths, "EXPORTS_DIR", fake_app_dir / "exports")
+    return fake_app_dir
+
+
+# ---------------------------------------------------------------------------
+# ensure_app_dir
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_app_dir_creates_with_0700(monkeypatch, tmp_path):
+    fake_app_dir = _redirect_app_dir(monkeypatch, tmp_path)
+
+    paths.ensure_app_dir()
+
+    assert fake_app_dir.is_dir(), "APP_DIR should be created"
+    assert _mode(fake_app_dir) == 0o700, "APP_DIR should have mode 0700"
+
+    exports = fake_app_dir / "exports"
+    assert exports.is_dir(), "exports/ should be created"
+    assert _mode(exports) == 0o700, "exports/ should have mode 0700"
+
+
+def test_ensure_app_dir_fixes_wrong_mode(monkeypatch, tmp_path, caplog):
+    fake_app_dir = _redirect_app_dir(monkeypatch, tmp_path)
+
+    # Pre-create the directory, then force the wrong mode with chmod
+    # (mkdir respects umask, so chmod is required to set an exact mode).
+    fake_app_dir.mkdir(parents=True)
+    os.chmod(fake_app_dir, 0o755)
+    assert _mode(fake_app_dir) == 0o755
+
+    with caplog.at_level(logging.WARNING, logger="server.paths"):
+        paths.ensure_app_dir()
+
+    assert _mode(fake_app_dir) == 0o700, "APP_DIR mode should be corrected to 0700"
+    assert any("fixing" in record.message for record in caplog.records), (
+        "A warning should be logged when the mode is corrected"
+    )
+
+
+def test_ensure_app_dir_idempotent(monkeypatch, tmp_path):
+    _redirect_app_dir(monkeypatch, tmp_path)
+    paths.ensure_app_dir()
+    # Second call must not raise.
+    paths.ensure_app_dir()
+
+
+# ---------------------------------------------------------------------------
+# create_file
+# ---------------------------------------------------------------------------
+
+
+def test_create_file_creates_with_0600(monkeypatch, tmp_path):
+    fake_app_dir = _redirect_app_dir(monkeypatch, tmp_path)
+    fake_app_dir.mkdir(mode=0o700, parents=True)
+
+    target = fake_app_dir / "data.db"
+    paths.create_file(target)
+
+    assert target.exists(), "File should be created"
+    assert _mode(target) == 0o600, "File should have mode 0600"
+
+
+def test_create_file_fixes_wrong_mode(monkeypatch, tmp_path, caplog):
+    fake_app_dir = _redirect_app_dir(monkeypatch, tmp_path)
+    fake_app_dir.mkdir(mode=0o700, parents=True)
+
+    target = fake_app_dir / "data.db"
+    # Pre-create with wrong mode.
+    target.touch()
+    os.chmod(target, 0o644)
+    assert _mode(target) == 0o644
+
+    with caplog.at_level(logging.WARNING, logger="server.paths"):
+        paths.create_file(target)
+
+    assert _mode(target) == 0o600, "File mode should be corrected to 0600"
+    assert any("fixing" in record.message for record in caplog.records), (
+        "A warning should be logged when the mode is corrected"
+    )
+
+
+def test_create_file_does_not_overwrite_contents(monkeypatch, tmp_path):
+    fake_app_dir = _redirect_app_dir(monkeypatch, tmp_path)
+    fake_app_dir.mkdir(mode=0o700, parents=True)
+
+    target = fake_app_dir / "data.db"
+    target.write_text("existing content")
+    os.chmod(target, 0o600)
+
+    paths.create_file(target)
+
+    assert target.read_text() == "existing content", (
+        "create_file should not overwrite existing file contents"
+    )
+
+
+# ---------------------------------------------------------------------------
+# audit_permissions
+# ---------------------------------------------------------------------------
+
+
+def test_audit_permissions_fixes_file(monkeypatch, tmp_path, caplog):
+    fake_app_dir = _redirect_app_dir(monkeypatch, tmp_path)
+    fake_app_dir.mkdir(mode=0o700, parents=True)
+
+    # Create a file with wrong permissions.
+    bad_file = fake_app_dir / "data.db"
+    bad_file.touch()
+    os.chmod(bad_file, 0o644)
+    assert _mode(bad_file) == 0o644
+
+    with caplog.at_level(logging.WARNING, logger="server.paths"):
+        paths.audit_permissions()
+
+    assert _mode(bad_file) == 0o600, "audit_permissions should fix 0644 → 0600"
+    assert any("fixing" in record.message for record in caplog.records), (
+        "A warning should be logged for the corrected file"
+    )
+
+
+def test_audit_permissions_fixes_dir(monkeypatch, tmp_path, caplog):
+    fake_app_dir = _redirect_app_dir(monkeypatch, tmp_path)
+
+    # Pre-create the directory, then force the wrong mode with chmod
+    # (mkdir respects umask, so chmod is required to set an exact mode).
+    fake_app_dir.mkdir(parents=True)
+    os.chmod(fake_app_dir, 0o755)
+    assert _mode(fake_app_dir) == 0o755
+
+    with caplog.at_level(logging.WARNING, logger="server.paths"):
+        paths.audit_permissions()
+
+    assert _mode(fake_app_dir) == 0o700, "audit_permissions should fix 0755 → 0700"
+    assert any("fixing" in record.message for record in caplog.records), (
+        "A warning should be logged for the corrected directory"
+    )
+
+
+def test_audit_permissions_no_op_when_correct(monkeypatch, tmp_path, caplog):
+    fake_app_dir = _redirect_app_dir(monkeypatch, tmp_path)
+    fake_app_dir.mkdir(mode=0o700, parents=True)
+
+    good_file = fake_app_dir / "data.db"
+    good_file.touch()
+    os.chmod(good_file, 0o600)
+
+    with caplog.at_level(logging.WARNING, logger="server.paths"):
+        paths.audit_permissions()
+
+    assert not caplog.records, "No warnings should be emitted when permissions are correct"
+
+
+def test_audit_permissions_noop_when_dir_absent(monkeypatch, tmp_path):
+    fake_app_dir = _redirect_app_dir(monkeypatch, tmp_path)
+    assert not fake_app_dir.exists()
+
+    # Should not raise.
+    paths.audit_permissions()


### PR DESCRIPTION
Closes #39

Centralized in server/paths.py: mkdir 0700, files 0600, startup audit fixes wrong perms with a logged warning.