### PR TITLE
[Sec] Token-at-rest encryption with macOS Keychain key

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 # Runtime deps will be added as we build each phase.
+fastmcp
+cryptography>=41.0
+keyring>=24.0
 # Test deps:
 pytest>=7.0

--- a/server/crypto.py
+++ b/server/crypto.py
@@ -1,0 +1,105 @@
+"""
+Token-at-rest encryption helpers for Friday Budgeting Pro.
+
+Design constraint #8: Secrets never live in plaintext on disk.
+Plaid access tokens are encrypted with Fernet; the key lives exclusively
+in macOS Keychain (via the `keyring` library).  The DB file alone is
+useless without Keychain access.
+
+Usage:
+    from server.crypto import init_crypto, encrypt, decrypt
+
+    init_crypto()   # call at daemon startup — raises RuntimeError if Keychain unavailable
+    token_ciphertext = encrypt(plaid_access_token)
+    plaid_access_token = decrypt(token_ciphertext)
+"""
+
+import keyring
+import keyring.errors
+from cryptography.fernet import Fernet, InvalidToken  # noqa: F401 (re-exported)
+
+_SERVICE = "friday-budgeting-pro"
+_USERNAME = "fernet-key"
+
+# Module-level cached Fernet instance; reset to None in tests via fixture.
+_fernet: Fernet | None = None
+
+
+def keychain_available() -> bool:
+    """Return True if the keyring backend is operational (quick health check)."""
+    try:
+        # A lightweight probe: reading a missing key returns None — that's fine.
+        keyring.get_password(_SERVICE, "__probe__")
+        return True
+    except (keyring.errors.KeyringError, Exception):
+        return False
+
+
+def get_or_create_key() -> bytes:
+    """
+    Return the Fernet key as raw bytes (url-safe-base64 encoded, 44 bytes).
+
+    ``Fernet.generate_key()`` returns a url-safe-base64 string that is
+    ready to pass directly to ``Fernet()``.  We store that string verbatim
+    in the Keychain so no additional encoding layer is needed.
+
+    If no key exists yet, one is generated and persisted.
+    """
+    stored: str | None = keyring.get_password(_SERVICE, _USERNAME)
+    if stored is None:
+        # generate_key() returns url-safe-b64 bytes (44 bytes, 32 decoded)
+        fernet_key: bytes = Fernet.generate_key()
+        stored = fernet_key.decode("utf-8")
+        keyring.set_password(_SERVICE, _USERNAME, stored)
+    # Return as bytes so callers can pass straight to Fernet()
+    return stored.encode("utf-8")
+
+
+def _get_fernet() -> Fernet:
+    global _fernet
+    if _fernet is None:
+        key = get_or_create_key()
+        _fernet = Fernet(key)
+    return _fernet
+
+
+def encrypt(plaintext: str) -> str:
+    """
+    Encrypt *plaintext* with Fernet.
+
+    Returns a url-safe-base64 ciphertext string safe for SQLite storage.
+    """
+    f = _get_fernet()
+    return f.encrypt(plaintext.encode("utf-8")).decode("utf-8")
+
+
+def decrypt(ciphertext: str) -> str:
+    """
+    Decrypt a Fernet ciphertext string produced by :func:`encrypt`.
+
+    Raises :class:`cryptography.fernet.InvalidToken` if the ciphertext
+    has been tampered with or was not produced by this key.
+    """
+    f = _get_fernet()
+    return f.decrypt(ciphertext.encode("utf-8")).decode("utf-8")
+
+
+def init_crypto() -> None:
+    """
+    Module-level guard — call at daemon startup.
+
+    Verifies that the Keychain backend is reachable *and* that a key can
+    be read/created.  Raises :class:`RuntimeError` if not; the daemon
+    should refuse to start rather than silently fall back to plaintext
+    storage (ARCHITECTURE.md Design Constraint #8).
+    """
+    if not keychain_available():
+        raise RuntimeError(
+            "Keychain backend is not available.  "
+            "Friday Budgeting Pro refuses to start without a working Keychain "
+            "because Plaid access tokens must be encrypted at rest "
+            "(ARCHITECTURE.md Design Constraint #8).  "
+            "Ensure the system keyring is configured before launching the daemon."
+        )
+    # Warm the Fernet instance so callers can use it immediately after init.
+    _get_fernet()

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -1,0 +1,174 @@
+"""
+Tests for server/crypto.py — token-at-rest encryption helpers.
+
+Uses keyring's in-memory test backend so that no actual macOS Keychain
+entries are created during CI or local test runs.
+"""
+
+import pytest
+import keyring
+import keyring.errors
+from keyring.backend import KeyringBackend
+
+
+# ---------------------------------------------------------------------------
+# In-memory keyring backend (avoids touching the real macOS Keychain)
+# ---------------------------------------------------------------------------
+
+class _InMemoryKeyring(KeyringBackend):
+    """Simple dict-backed keyring for testing."""
+
+    priority = 10  # must be > 0 to be considered
+
+    def __init__(self):
+        self._store: dict[tuple[str, str], str] = {}
+
+    def get_password(self, service: str, username: str) -> str | None:
+        return self._store.get((service, username))
+
+    def set_password(self, service: str, username: str, password: str) -> None:
+        self._store[(service, username)] = password
+
+    def delete_password(self, service: str, username: str) -> None:
+        self._store.pop((service, username), None)
+
+
+class _BrokenKeyring(KeyringBackend):
+    """Always raises — simulates an unusable Keychain backend."""
+
+    priority = 10
+
+    def get_password(self, service: str, username: str) -> str | None:
+        raise keyring.errors.KeyringError("backend unavailable")
+
+    def set_password(self, service: str, username: str, password: str) -> None:
+        raise keyring.errors.KeyringError("backend unavailable")
+
+    def delete_password(self, service: str, username: str) -> None:
+        raise keyring.errors.KeyringError("backend unavailable")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=False)
+def in_memory_keyring():
+    """
+    Replace the global keyring backend with an in-memory store for the
+    duration of each test, then restore the original.
+    Also resets the module-level _fernet cache so each test gets a fresh key.
+    """
+    original = keyring.get_keyring()
+    mem = _InMemoryKeyring()
+    keyring.set_keyring(mem)
+
+    # Reset cached Fernet instance inside the module under test
+    import server.crypto as crypto_mod
+    crypto_mod._fernet = None
+
+    yield mem
+
+    # Restore
+    keyring.set_keyring(original)
+    crypto_mod._fernet = None
+
+
+@pytest.fixture()
+def broken_keyring():
+    """Replace the global keyring backend with a permanently-broken one."""
+    original = keyring.get_keyring()
+    keyring.set_keyring(_BrokenKeyring())
+
+    import server.crypto as crypto_mod
+    crypto_mod._fernet = None
+
+    yield
+
+    keyring.set_keyring(original)
+    crypto_mod._fernet = None
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_round_trip(in_memory_keyring):
+    """encrypt then decrypt returns the original plaintext."""
+    from server.crypto import encrypt, decrypt
+
+    plaintext = "access-sandbox-abc123def456"
+    assert decrypt(encrypt(plaintext)) == plaintext
+
+
+def test_tampered_ciphertext_raises(in_memory_keyring):
+    """Decrypting a tampered ciphertext raises InvalidToken."""
+    from cryptography.fernet import InvalidToken
+    from server.crypto import encrypt, decrypt
+
+    ciphertext = encrypt("some-plaid-token")
+    # Flip a few bytes in the middle of the ciphertext
+    bad = ciphertext[:-4] + "XXXX"
+    with pytest.raises(InvalidToken):
+        decrypt(bad)
+
+
+def test_different_plaintexts_produce_different_ciphertexts(in_memory_keyring):
+    """Two distinct plaintexts must encrypt to different ciphertexts."""
+    from server.crypto import encrypt
+
+    ct1 = encrypt("token-aaa")
+    ct2 = encrypt("token-bbb")
+    assert ct1 != ct2
+
+
+def test_keychain_available_true_with_in_memory_backend(in_memory_keyring):
+    """keychain_available() returns True when the backend is working."""
+    from server.crypto import keychain_available
+
+    assert keychain_available() is True
+
+
+def test_init_crypto_raises_with_broken_backend(broken_keyring):
+    """init_crypto() raises RuntimeError when the Keychain backend is broken."""
+    from server.crypto import init_crypto
+
+    with pytest.raises(RuntimeError, match="Keychain backend is not available"):
+        init_crypto()
+
+
+def test_encrypt_returns_string(in_memory_keyring):
+    """encrypt() must return a plain string (safe for SQLite storage)."""
+    from server.crypto import encrypt
+
+    result = encrypt("hello")
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+def test_decrypt_returns_string(in_memory_keyring):
+    """decrypt() must return a plain string."""
+    from server.crypto import encrypt, decrypt
+
+    result = decrypt(encrypt("world"))
+    assert isinstance(result, str)
+
+
+def test_key_persisted_across_calls(in_memory_keyring):
+    """The same key is reused across multiple encrypt/decrypt calls."""
+    from server.crypto import encrypt, decrypt
+
+    ct = encrypt("persistent-token")
+    # Decrypting with the *same* module (same key) should succeed
+    assert decrypt(ct) == "persistent-token"
+
+
+def test_key_generated_and_stored_in_keychain(in_memory_keyring):
+    """get_or_create_key() stores the key in the keyring on first call."""
+    from server.crypto import get_or_create_key
+    import keyring as kr
+
+    get_or_create_key()
+    stored = kr.get_password("friday-budgeting-pro", "fernet-key")
+    assert stored is not None
+    assert len(stored) > 0


### PR DESCRIPTION
Closes #38

Fernet encrypt/decrypt helpers in server/crypto.py with the key stored via keyring (macOS Keychain on Darwin). Refuses to init if Keychain backend is unusable. Bank-connection wiring will land with #15.