### PR TITLE
[Reliability] Single-flight sync lock

### DIFF
--- a/server/sync_lock.py
+++ b/server/sync_lock.py
@@ -1,0 +1,151 @@
+"""
+server/sync_lock.py — Single-flight sync lock primitive.
+
+Uses a POSIX advisory exclusive lock (fcntl.flock) on SYNC_LOCK_PATH so that
+only one sync operation can run at a time.  The lock file is never deleted —
+deletion causes races with concurrent openers; the flock is the gate.
+
+Unix only (fcntl).  No Windows fallback.
+
+Public API
+----------
+acquire_sync_lock(timeout: float = 0.0) -> SyncLock | None
+    Non-blocking acquire.  Returns a SyncLock on success, None on contention.
+    When timeout > 0 the call retries with short sleeps until the lock is
+    acquired or the timeout elapses.
+
+sync_lock(timeout: float = 0.0) — @contextmanager
+    Yields a SyncLock or raises LockBusy on contention.
+
+class SyncLock
+    Context manager.  Holds the open file descriptor and releases the flock
+    on __exit__ / close().  Does NOT delete the lock file.
+
+class LockBusy(Exception)
+    Raised by sync_lock() when the lock cannot be acquired.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Generator
+
+import server.paths as _paths
+
+__all__ = [
+    "SyncLock",
+    "LockBusy",
+    "acquire_sync_lock",
+    "sync_lock",
+]
+
+_RETRY_INTERVAL = 0.05  # seconds between retries when timeout > 0
+
+
+class LockBusy(Exception):
+    """Raised when the sync lock cannot be acquired due to contention."""
+
+
+class SyncLock:
+    """Holds an exclusive flock on the sync lock file.
+
+    Acquire via :func:`acquire_sync_lock` or the :func:`sync_lock` context
+    manager rather than constructing directly.
+    """
+
+    def __init__(self, fd: int) -> None:
+        self._fd: int | None = fd
+
+    # ------------------------------------------------------------------
+    # Context-manager protocol
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> "SyncLock":
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.close()
+
+    # ------------------------------------------------------------------
+    # Explicit release
+    # ------------------------------------------------------------------
+
+    def close(self) -> None:
+        """Release the flock and close the file descriptor.
+
+        Idempotent — safe to call more than once.
+        """
+        if self._fd is not None:
+            try:
+                fcntl.flock(self._fd, fcntl.LOCK_UN)
+            finally:
+                os.close(self._fd)
+                self._fd = None
+
+
+def _open_lock_file() -> int:
+    """Return an open file descriptor for SYNC_LOCK_PATH (mode 0600).
+
+    Creates the file via server.paths.create_file if it does not exist,
+    then opens it read-only for locking (we only need the fd, not the data).
+    """
+    lock_path: Path = _paths.SYNC_LOCK_PATH
+    _paths.create_file(lock_path)
+    return os.open(lock_path, os.O_RDONLY)
+
+
+def acquire_sync_lock(timeout: float = 0.0) -> SyncLock | None:
+    """Try to acquire the exclusive sync lock.
+
+    Parameters
+    ----------
+    timeout:
+        * ``0.0`` (default) — single non-blocking attempt.
+        * ``> 0`` — keep retrying until *timeout* seconds have elapsed.
+
+    Returns
+    -------
+    SyncLock
+        On success.
+    None
+        On contention (lock is held by another process/descriptor).
+    """
+    deadline: float | None = (time.monotonic() + timeout) if timeout > 0 else None
+
+    while True:
+        fd = _open_lock_file()
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return SyncLock(fd)
+        except BlockingIOError:
+            os.close(fd)
+            if deadline is None or time.monotonic() >= deadline:
+                return None
+            time.sleep(_RETRY_INTERVAL)
+
+
+@contextmanager
+def sync_lock(timeout: float = 0.0) -> Generator[SyncLock, None, None]:
+    """Context manager that yields a :class:`SyncLock` or raises :class:`LockBusy`.
+
+    Parameters
+    ----------
+    timeout:
+        Passed through to :func:`acquire_sync_lock`.
+
+    Raises
+    ------
+    LockBusy
+        When the lock cannot be acquired within *timeout* seconds.
+    """
+    lock = acquire_sync_lock(timeout=timeout)
+    if lock is None:
+        raise LockBusy("sync lock is held by another process")
+    try:
+        yield lock
+    finally:
+        lock.close()

--- a/tests/test_sync_lock.py
+++ b/tests/test_sync_lock.py
@@ -1,0 +1,154 @@
+"""
+tests/test_sync_lock.py — Tests for server.sync_lock
+"""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+import server.paths as paths
+from server.sync_lock import (
+    LockBusy,
+    SyncLock,
+    acquire_sync_lock,
+    sync_lock,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def lock_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect SYNC_LOCK_PATH to a temp file for isolation."""
+    p = tmp_path / "sync.lock"
+    monkeypatch.setattr(paths, "SYNC_LOCK_PATH", p)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Basic acquire / release
+# ---------------------------------------------------------------------------
+
+
+def test_first_acquire_succeeds(lock_path: Path) -> None:
+    lock = acquire_sync_lock()
+    assert lock is not None
+    lock.close()
+
+
+def test_second_acquire_while_held_returns_none(lock_path: Path) -> None:
+    lock1 = acquire_sync_lock()
+    assert lock1 is not None
+    try:
+        lock2 = acquire_sync_lock()
+        assert lock2 is None
+    finally:
+        lock1.close()
+
+
+def test_acquire_after_release_succeeds(lock_path: Path) -> None:
+    lock1 = acquire_sync_lock()
+    assert lock1 is not None
+    lock1.close()
+
+    lock2 = acquire_sync_lock()
+    assert lock2 is not None
+    lock2.close()
+
+
+# ---------------------------------------------------------------------------
+# File permissions
+# ---------------------------------------------------------------------------
+
+
+def test_lock_file_mode_is_0600(lock_path: Path) -> None:
+    lock = acquire_sync_lock()
+    assert lock is not None
+    try:
+        mode = stat.S_IMODE(lock_path.stat().st_mode)
+        assert mode == 0o600
+    finally:
+        lock.close()
+
+
+# ---------------------------------------------------------------------------
+# Context manager
+# ---------------------------------------------------------------------------
+
+
+def test_context_manager_releases_on_normal_exit(lock_path: Path) -> None:
+    with sync_lock() as lk:
+        assert isinstance(lk, SyncLock)
+
+    # Should be releasable now
+    lock2 = acquire_sync_lock()
+    assert lock2 is not None
+    lock2.close()
+
+
+def test_context_manager_releases_on_exception(lock_path: Path) -> None:
+    try:
+        with sync_lock():
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
+
+    lock2 = acquire_sync_lock()
+    assert lock2 is not None
+    lock2.close()
+
+
+def test_sync_lock_raises_lock_busy_on_contention(lock_path: Path) -> None:
+    lock1 = acquire_sync_lock()
+    assert lock1 is not None
+    try:
+        with pytest.raises(LockBusy):
+            with sync_lock():
+                pass
+    finally:
+        lock1.close()
+
+
+# ---------------------------------------------------------------------------
+# Low-level contention: two raw fds on the same file
+# ---------------------------------------------------------------------------
+
+
+def test_raw_contention_raises_blocking_io_error(lock_path: Path) -> None:
+    """Open the same file with two fds; second flock should raise BlockingIOError."""
+    # Ensure file exists with correct mode
+    paths.create_file(lock_path)
+
+    fd1 = os.open(lock_path, os.O_RDONLY)
+    fd2 = os.open(lock_path, os.O_RDONLY)
+    try:
+        fcntl.flock(fd1, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        with pytest.raises(BlockingIOError):
+            fcntl.flock(fd2, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    finally:
+        try:
+            fcntl.flock(fd1, fcntl.LOCK_UN)
+        except Exception:
+            pass
+        os.close(fd1)
+        os.close(fd2)
+
+
+# ---------------------------------------------------------------------------
+# SyncLock.close() is idempotent
+# ---------------------------------------------------------------------------
+
+
+def test_close_is_idempotent(lock_path: Path) -> None:
+    lock = acquire_sync_lock()
+    assert lock is not None
+    lock.close()
+    lock.close()  # Should not raise


### PR DESCRIPTION
Closes #41

flock primitive only. sync() wiring with #16.