### PR TITLE
[P2] Plaid client wrapper

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@
 fastmcp
 cryptography>=41.0
 keyring>=24.0
+plaid-python>=14.0
 # Test deps:
 pytest>=7.0

--- a/server/plaid_client.py
+++ b/server/plaid_client.py
@@ -1,0 +1,150 @@
+"""
+Thin wrapper around the plaid-python SDK for Friday Budgeting Pro.
+
+Exposes three operations:
+    create_link_token   — generate a Link token for the frontend
+    exchange_public_token — exchange a public token for an access token + item_id
+    sync_transactions   — incremental transaction sync via the Transactions Sync API
+
+Environment variables
+---------------------
+PLAID_ENV        : sandbox | development | production  (default: sandbox)
+PLAID_CLIENT_ID  : Plaid client ID (required)
+PLAID_SECRET     : Plaid secret for the configured environment (required)
+
+Security note
+-------------
+Callers MUST encrypt tokens via server.crypto.encrypt before persisting.
+This module never touches encryption or the database; it only communicates
+with the Plaid API using plaintext tokens supplied by the caller.
+"""
+
+import os
+
+import plaid
+from plaid.api import plaid_api
+from plaid.model.link_token_create_request import LinkTokenCreateRequest
+from plaid.model.link_token_create_request_user import LinkTokenCreateRequestUser
+from plaid.model.country_code import CountryCode
+from plaid.model.products import Products
+from plaid.model.item_public_token_exchange_request import ItemPublicTokenExchangeRequest
+from plaid.model.transactions_sync_request import TransactionsSyncRequest
+
+# Use URL strings directly so we don't depend on which Environment constants
+# the installed plaid-python version exposes (>= 14 dropped Development).
+_ENV_MAP: dict[str, str] = {
+    "sandbox": "https://sandbox.plaid.com",
+    "development": "https://development.plaid.com",
+    "production": "https://production.plaid.com",
+}
+
+_APP_NAME = "Friday Budgeting Pro"
+
+
+def _build_client() -> plaid_api.PlaidApi:
+    """Instantiate a PlaidApi client from environment variables."""
+    raw_env = os.environ.get("PLAID_ENV", "sandbox").lower()
+    if raw_env not in _ENV_MAP:
+        raise ValueError(
+            f"Invalid PLAID_ENV '{raw_env}'. Must be one of: "
+            + ", ".join(_ENV_MAP)
+        )
+
+    client_id = os.environ.get("PLAID_CLIENT_ID")
+    if not client_id:
+        raise EnvironmentError(
+            "PLAID_CLIENT_ID environment variable is not set. "
+            "Set it to your Plaid client ID before starting the daemon."
+        )
+
+    secret = os.environ.get("PLAID_SECRET")
+    if not secret:
+        raise EnvironmentError(
+            "PLAID_SECRET environment variable is not set. "
+            "Set it to the Plaid secret for your environment before starting the daemon."
+        )
+
+    configuration = plaid.Configuration(
+        host=_ENV_MAP[raw_env],
+        api_key={
+            "clientId": client_id,
+            "secret": secret,
+        },
+    )
+    api_client = plaid.ApiClient(configuration)
+    return plaid_api.PlaidApi(api_client)
+
+
+def create_link_token(user_id: str = "friday-bp-user") -> str:
+    """
+    Create a Plaid Link token for the given *user_id*.
+
+    Returns the ``link_token`` string that the frontend passes to Plaid Link.
+
+    Callers MUST encrypt tokens via server.crypto.encrypt before persisting.
+    """
+    client = _build_client()
+    request = LinkTokenCreateRequest(
+        user=LinkTokenCreateRequestUser(client_user_id=user_id),
+        client_name=_APP_NAME,
+        products=[Products("transactions")],
+        country_codes=[CountryCode("US"), CountryCode("CA")],
+        language="en",
+    )
+    response = client.link_token_create(request)
+    return response["link_token"]
+
+
+def exchange_public_token(public_token: str) -> dict:
+    """
+    Exchange a public token from Plaid Link for a persistent access token.
+
+    Returns a dict with keys:
+        ``access_token`` — the Plaid access token (plaintext; encrypt before persisting)
+        ``item_id``       — the Plaid item ID
+
+    Callers MUST encrypt tokens via server.crypto.encrypt before persisting.
+    """
+    client = _build_client()
+    request = ItemPublicTokenExchangeRequest(public_token=public_token)
+    response = client.item_public_token_exchange(request)
+    return {
+        "access_token": response["access_token"],
+        "item_id": response["item_id"],
+    }
+
+
+def sync_transactions(access_token: str, cursor: str | None = None) -> dict:
+    """
+    Incrementally sync transactions for the item associated with *access_token*.
+
+    Parameters
+    ----------
+    access_token : str
+        Plaintext Plaid access token.  Caller is responsible for decrypting
+        before passing here; see server.crypto.decrypt.
+    cursor : str or None
+        Pagination cursor from a previous call.  Pass ``None`` for the initial
+        fetch (returns all historical transactions).
+
+    Returns a dict with keys:
+        ``added``       — list of added transaction objects
+        ``modified``    — list of modified transaction objects
+        ``removed``     — list of removed transaction objects
+        ``next_cursor`` — cursor string for the next incremental call
+
+    Callers MUST encrypt tokens via server.crypto.encrypt before persisting.
+    """
+    client = _build_client()
+    kwargs: dict = {"access_token": access_token}
+    if cursor is not None:
+        kwargs["cursor"] = cursor
+
+    request = TransactionsSyncRequest(**kwargs)
+    response = client.transactions_sync(request)
+    return {
+        "added": response["added"],
+        "modified": response["modified"],
+        "removed": response["removed"],
+        "next_cursor": response["next_cursor"],
+    }

--- a/tests/test_plaid_client.py
+++ b/tests/test_plaid_client.py
@@ -1,0 +1,188 @@
+"""
+Tests for server/plaid_client.py
+
+All Plaid API calls are mocked — no network access required.
+"""
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _env(extra: dict | None = None) -> dict:
+    """Return a minimal valid env dict, optionally overriding keys."""
+    base = {
+        "PLAID_ENV": "sandbox",
+        "PLAID_CLIENT_ID": "test-client-id",
+        "PLAID_SECRET": "test-secret",
+    }
+    if extra:
+        base.update(extra)
+    return base
+
+
+def _mock_plaid_api(mock_api_cls: MagicMock) -> MagicMock:
+    """Return the PlaidApi instance mock from the class mock."""
+    return mock_api_cls.return_value
+
+
+# ---------------------------------------------------------------------------
+# create_link_token
+# ---------------------------------------------------------------------------
+
+class TestCreateLinkToken(unittest.TestCase):
+
+    @patch("server.plaid_client.plaid_api.PlaidApi")
+    def test_returns_link_token(self, mock_api_cls):
+        api = _mock_plaid_api(mock_api_cls)
+        api.link_token_create.return_value = {"link_token": "link-sandbox-abc123"}
+
+        with patch.dict(os.environ, _env(), clear=False):
+            from server import plaid_client
+            result = plaid_client.create_link_token()
+
+        self.assertEqual(result, "link-sandbox-abc123")
+        api.link_token_create.assert_called_once()
+
+    @patch("server.plaid_client.plaid_api.PlaidApi")
+    def test_custom_user_id(self, mock_api_cls):
+        api = _mock_plaid_api(mock_api_cls)
+        api.link_token_create.return_value = {"link_token": "link-sandbox-xyz"}
+
+        with patch.dict(os.environ, _env(), clear=False):
+            from server import plaid_client
+            result = plaid_client.create_link_token(user_id="user-42")
+
+        self.assertEqual(result, "link-sandbox-xyz")
+        call_args = api.link_token_create.call_args
+        # The request should have been built with user_id="user-42"
+        request = call_args[0][0]
+        self.assertEqual(request.user.client_user_id, "user-42")
+
+
+# ---------------------------------------------------------------------------
+# exchange_public_token
+# ---------------------------------------------------------------------------
+
+class TestExchangePublicToken(unittest.TestCase):
+
+    @patch("server.plaid_client.plaid_api.PlaidApi")
+    def test_returns_access_token_and_item_id(self, mock_api_cls):
+        api = _mock_plaid_api(mock_api_cls)
+        api.item_public_token_exchange.return_value = {
+            "access_token": "access-sandbox-token-abc",
+            "item_id": "item-id-xyz",
+        }
+
+        with patch.dict(os.environ, _env(), clear=False):
+            from server import plaid_client
+            result = plaid_client.exchange_public_token("public-sandbox-abc")
+
+        self.assertEqual(result["access_token"], "access-sandbox-token-abc")
+        self.assertEqual(result["item_id"], "item-id-xyz")
+        api.item_public_token_exchange.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# sync_transactions
+# ---------------------------------------------------------------------------
+
+class TestSyncTransactions(unittest.TestCase):
+
+    @patch("server.plaid_client.plaid_api.PlaidApi")
+    def test_sync_without_cursor(self, mock_api_cls):
+        api = _mock_plaid_api(mock_api_cls)
+        api.transactions_sync.return_value = {
+            "added": [{"transaction_id": "tx1"}],
+            "modified": [],
+            "removed": [],
+            "next_cursor": "cursor-v2",
+        }
+
+        with patch.dict(os.environ, _env(), clear=False):
+            from server import plaid_client
+            result = plaid_client.sync_transactions("access-sandbox-token")
+
+        self.assertEqual(len(result["added"]), 1)
+        self.assertEqual(result["next_cursor"], "cursor-v2")
+        self.assertEqual(result["modified"], [])
+        self.assertEqual(result["removed"], [])
+
+    @patch("server.plaid_client.plaid_api.PlaidApi")
+    def test_sync_with_cursor(self, mock_api_cls):
+        api = _mock_plaid_api(mock_api_cls)
+        api.transactions_sync.return_value = {
+            "added": [],
+            "modified": [{"transaction_id": "tx2"}],
+            "removed": [],
+            "next_cursor": "cursor-v3",
+        }
+
+        with patch.dict(os.environ, _env(), clear=False):
+            from server import plaid_client
+            result = plaid_client.sync_transactions(
+                "access-sandbox-token", cursor="cursor-v2"
+            )
+
+        self.assertEqual(result["next_cursor"], "cursor-v3")
+        self.assertEqual(len(result["modified"]), 1)
+
+        # Verify the cursor was passed in the request
+        call_args = api.transactions_sync.call_args
+        request = call_args[0][0]
+        self.assertEqual(request.cursor, "cursor-v2")
+
+
+# ---------------------------------------------------------------------------
+# Environment-variable validation
+# ---------------------------------------------------------------------------
+
+class TestEnvValidation(unittest.TestCase):
+
+    def test_bad_plaid_env_raises_value_error(self):
+        bad_env = _env({"PLAID_ENV": "staging"})
+        with patch.dict(os.environ, bad_env, clear=False):
+            import importlib
+            from server import plaid_client
+            importlib.reload(plaid_client)
+            with self.assertRaises(ValueError):
+                plaid_client.create_link_token()
+
+    @patch("server.plaid_client.plaid_api.PlaidApi")
+    def test_missing_client_id_raises_environment_error(self, mock_api_cls):
+        env = {
+            "PLAID_ENV": "sandbox",
+            "PLAID_SECRET": "test-secret",
+        }
+        # Remove PLAID_CLIENT_ID if present
+        patched = {k: v for k, v in os.environ.items() if k != "PLAID_CLIENT_ID"}
+        patched.update(env)
+        with patch.dict(os.environ, patched, clear=True):
+            import importlib
+            from server import plaid_client
+            importlib.reload(plaid_client)
+            with self.assertRaises(EnvironmentError):
+                plaid_client.create_link_token()
+
+    @patch("server.plaid_client.plaid_api.PlaidApi")
+    def test_missing_secret_raises_environment_error(self, mock_api_cls):
+        env = {
+            "PLAID_ENV": "sandbox",
+            "PLAID_CLIENT_ID": "test-client-id",
+        }
+        patched = {k: v for k, v in os.environ.items() if k != "PLAID_SECRET"}
+        patched.update(env)
+        with patch.dict(os.environ, patched, clear=True):
+            import importlib
+            from server import plaid_client
+            importlib.reload(plaid_client)
+            with self.assertRaises(EnvironmentError):
+                plaid_client.create_link_token()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #13

Thin plaid-python wrapper: create_link_token, exchange_public_token, sync_transactions. Token encryption happens at the storage boundary in #15 via server.crypto.