### PR TITLE
[P3] Transaction sync with cursor persistence

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -7,12 +7,16 @@ Real implementations land in later tickets.
 
 from __future__ import annotations
 
+import json as _json
+import time as _time
 import uuid
 from typing import List, Optional
 
 import fastmcp
 
-from server.db import get_db
+from server.db import get_db, transaction as db_txn
+from server.sync_lock import sync_lock, LockBusy
+from server.classifier import apply_rules
 import server.paths
 import server.crypto
 import server.plaid_client
@@ -194,7 +198,209 @@ def remove_line_item(id: str) -> dict:
 @mcp.tool
 def sync() -> dict:
     """Pull new transactions from Plaid, classify them, and return a summary."""
-    return {"status": "not_implemented"}
+
+    def _get(obj, key, default=None):
+        """Get a field from a dict or an SDK object."""
+        if isinstance(obj, dict):
+            return obj.get(key, default)
+        return getattr(obj, key, default)
+
+    def _is_reauth_error(exc: Exception) -> bool:
+        """Return True when *exc* signals ITEM_LOGIN_REQUIRED."""
+        body = getattr(exc, "body", None)
+        if body:
+            try:
+                parsed = _json.loads(body)
+                return parsed.get("error_code") == "ITEM_LOGIN_REQUIRED"
+            except Exception:
+                pass
+        return False
+
+    connections_synced = 0
+    total_added = 0
+    total_modified = 0
+    total_removed = 0
+    total_classified = 0
+
+    try:
+        with sync_lock(timeout=0.0):
+            db_conn = get_db(server.paths.DB_PATH)
+            try:
+                active_conns = db_conn.execute(
+                    "SELECT id, plaid_access_token_encrypted "
+                    "FROM bank_connections WHERE status = 'active'"
+                ).fetchall()
+
+                for bc in active_conns:
+                    connection_id = bc["id"]
+                    encrypted_token = bc["plaid_access_token_encrypted"]
+                    access_token = server.crypto.decrypt(encrypted_token)
+
+                    cursor_row = db_conn.execute(
+                        "SELECT cursor FROM sync_cursors WHERE connection_id = ?",
+                        (connection_id,),
+                    ).fetchone()
+                    cursor = cursor_row["cursor"] if cursor_row else None
+
+                    try:
+                        result = server.plaid_client.sync_transactions(access_token, cursor)
+                    except Exception as e:
+                        if _is_reauth_error(e):
+                            with db_txn(db_conn):
+                                db_conn.execute(
+                                    "UPDATE bank_connections SET status='needs_reauth' WHERE id=?",
+                                    (connection_id,),
+                                )
+                            continue
+                        raise
+
+                    added_txns = result.get("added", []) if isinstance(result, dict) else []
+                    modified_txns = result.get("modified", []) if isinstance(result, dict) else []
+                    removed_txns = result.get("removed", []) if isinstance(result, dict) else []
+                    next_cursor = result.get("next_cursor") if isinstance(result, dict) else None
+
+                    now = int(_time.time())
+                    conn_added = 0
+                    conn_modified = 0
+                    conn_removed = 0
+                    conn_classified = 0
+
+                    with db_txn(db_conn):
+                        # --- Added transactions ---
+                        for txn in added_txns:
+                            plaid_account_id = _get(txn, "account_id")
+                            plaid_txn_id = _get(txn, "transaction_id")
+                            date = _get(txn, "date")
+                            name = _get(txn, "name") or ""
+                            merchant_name = _get(txn, "merchant_name") or ""
+                            merchant = merchant_name if merchant_name else name
+                            amount = _get(txn, "amount")
+                            pending = bool(_get(txn, "pending", False))
+
+                            # Upsert bank_account (INSERT OR IGNORE on plaid_account_id UNIQUE)
+                            db_conn.execute(
+                                "INSERT OR IGNORE INTO bank_accounts "
+                                "(id, connection_id, plaid_account_id) VALUES (?, ?, ?)",
+                                (str(uuid.uuid4()), connection_id, plaid_account_id),
+                            )
+                            ba_row = db_conn.execute(
+                                "SELECT id FROM bank_accounts WHERE plaid_account_id = ?",
+                                (plaid_account_id,),
+                            ).fetchone()
+                            bank_account_id = ba_row["id"]
+
+                            txn_id = str(uuid.uuid4())
+                            cur = db_conn.execute(
+                                "INSERT OR IGNORE INTO transactions "
+                                "(id, bank_account_id, plaid_transaction_id, date, merchant, amount, pending) "
+                                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                                (
+                                    txn_id,
+                                    bank_account_id,
+                                    plaid_txn_id,
+                                    str(date) if date is not None else None,
+                                    merchant,
+                                    amount,
+                                    1 if pending else 0,
+                                ),
+                            )
+
+                            if cur.rowcount > 0:
+                                # Newly inserted — count and attempt Tier-1 classification
+                                conn_added += 1
+                                txn_dict = {
+                                    "id": txn_id,
+                                    "merchant": merchant,
+                                    "amount": amount,
+                                    "bank_account_id": bank_account_id,
+                                }
+                                entry = apply_rules(db_conn, txn_dict)
+                                if entry is not None:
+                                    db_conn.execute(
+                                        "INSERT OR IGNORE INTO transaction_entries "
+                                        "(id, transaction_id, ledger_id, line_item_id, "
+                                        " amount, source, confidence, reviewed) "
+                                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                                        (
+                                            str(uuid.uuid4()),
+                                            entry["transaction_id"],
+                                            entry["ledger_id"],
+                                            entry["line_item_id"],
+                                            entry["amount"],
+                                            entry["source"],
+                                            entry["confidence"],
+                                            entry["reviewed"],
+                                        ),
+                                    )
+                                    conn_classified += 1
+
+                        # --- Modified transactions ---
+                        for txn in modified_txns:
+                            plaid_txn_id = _get(txn, "transaction_id")
+                            date = _get(txn, "date")
+                            name = _get(txn, "name") or ""
+                            merchant_name = _get(txn, "merchant_name") or ""
+                            merchant = merchant_name if merchant_name else name
+                            amount = _get(txn, "amount")
+                            pending = bool(_get(txn, "pending", False))
+                            db_conn.execute(
+                                "UPDATE transactions "
+                                "SET date=?, merchant=?, amount=?, pending=? "
+                                "WHERE plaid_transaction_id=?",
+                                (
+                                    str(date) if date is not None else None,
+                                    merchant,
+                                    amount,
+                                    1 if pending else 0,
+                                    plaid_txn_id,
+                                ),
+                            )
+                            conn_modified += 1
+
+                        # --- Removed transactions ---
+                        for txn in removed_txns:
+                            plaid_txn_id = _get(txn, "transaction_id")
+                            db_conn.execute(
+                                "DELETE FROM transactions WHERE plaid_transaction_id = ?",
+                                (plaid_txn_id,),
+                            )
+                            conn_removed += 1
+
+                        # Upsert cursor — advances ONLY on full success of this batch
+                        db_conn.execute(
+                            "INSERT INTO sync_cursors (connection_id, cursor, last_synced_at) "
+                            "VALUES (?, ?, ?) "
+                            "ON CONFLICT(connection_id) DO UPDATE SET "
+                            "    cursor = excluded.cursor, "
+                            "    last_synced_at = excluded.last_synced_at",
+                            (connection_id, next_cursor, now),
+                        )
+
+                        db_conn.execute(
+                            "UPDATE bank_connections SET last_synced_at=? WHERE id=?",
+                            (now, connection_id),
+                        )
+
+                    connections_synced += 1
+                    total_added += conn_added
+                    total_modified += conn_modified
+                    total_removed += conn_removed
+                    total_classified += conn_classified
+
+            finally:
+                db_conn.close()
+
+    except LockBusy:
+        return {"status": "already_running"}
+
+    return {
+        "status": "ok",
+        "connections_synced": connections_synced,
+        "added": total_added,
+        "modified": total_modified,
+        "removed": total_removed,
+        "classified_by_rule": total_classified,
+    }
 
 
 @mcp.tool

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,0 +1,223 @@
+"""
+tests/test_sync.py — Tests for server.main.sync() (issue #16).
+
+Covers:
+  - Normal sync: 3 added transactions, 1 matched by routing rule
+  - ITEM_LOGIN_REQUIRED: connection flagged as needs_reauth, no crash
+  - Idempotent re-sync: no duplicate transactions on second call
+  - sync_lock contention: returns {"status": "already_running"}
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+
+from server.db import get_db, init_db
+from server.main import sync
+
+
+# ---------------------------------------------------------------------------
+# Helpers / shared fixtures
+# ---------------------------------------------------------------------------
+
+class _FakePlaidError(Exception):
+    """Minimal stand-in for plaid.ApiException with a JSON body."""
+
+    def __init__(self, error_code: str) -> None:
+        super().__init__(error_code)
+        self.body = json.dumps({"error_code": error_code})
+
+
+_ADDED_TXNS = [
+    {
+        "transaction_id": "plaid-txn-1",
+        "account_id": "plaid-acct-1",
+        "date": "2024-01-01",
+        "name": "Starbucks Coffee",
+        "merchant_name": "Starbucks",
+        "amount": 5.50,
+        "pending": False,
+    },
+    {
+        "transaction_id": "plaid-txn-2",
+        "account_id": "plaid-acct-1",
+        "date": "2024-01-02",
+        "name": "Uber",
+        "merchant_name": "Uber",
+        "amount": 12.00,
+        "pending": False,
+    },
+    {
+        "transaction_id": "plaid-txn-3",
+        "account_id": "plaid-acct-1",
+        "date": "2024-01-03",
+        "name": "Amazon",
+        "merchant_name": None,
+        "amount": 35.00,
+        "pending": True,
+    },
+]
+
+
+def _mock_sync_ok(access_token, cursor=None):
+    return {
+        "added": _ADDED_TXNS,
+        "modified": [],
+        "removed": [],
+        "next_cursor": "cursor-2",
+    }
+
+
+@pytest.fixture()
+def env(tmp_path, monkeypatch):
+    """Patch paths, init a tmp DB, and seed the minimum required rows."""
+    db = tmp_path / "data.db"
+    lock = tmp_path / "sync.lock"
+    monkeypatch.setattr("server.paths.DB_PATH", db)
+    monkeypatch.setattr("server.paths.SYNC_LOCK_PATH", lock)
+
+    init_db(db)
+
+    ledger_id = str(uuid.uuid4())
+    line_item_id = str(uuid.uuid4())
+    connection_id = str(uuid.uuid4())
+    rule_id = str(uuid.uuid4())
+
+    conn = get_db(db)
+    conn.execute(
+        "INSERT INTO ledgers (id, name) VALUES (?, ?)",
+        (ledger_id, "Personal"),
+    )
+    conn.execute(
+        "INSERT INTO line_items (id, ledger_id, name, item_type) VALUES (?, ?, ?, 'expense')",
+        (line_item_id, ledger_id, "Dining"),
+    )
+    conn.execute(
+        "INSERT INTO bank_connections "
+        "(id, plaid_item_id, plaid_access_token_encrypted, status) "
+        "VALUES (?, 'item-1', 'test-token', 'active')",
+        (connection_id,),
+    )
+    conn.execute(
+        "INSERT INTO routing_rules (id, merchant_pattern, line_item_id) VALUES (?, ?, ?)",
+        (rule_id, "starbucks", line_item_id),
+    )
+    conn.commit()
+    conn.close()
+
+    return {
+        "db": db,
+        "lock": lock,
+        "connection_id": connection_id,
+        "ledger_id": ledger_id,
+        "line_item_id": line_item_id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test 1: normal sync
+# ---------------------------------------------------------------------------
+
+def test_sync_normal(env, monkeypatch):
+    monkeypatch.setattr("server.plaid_client.sync_transactions", _mock_sync_ok)
+    monkeypatch.setattr("server.crypto.decrypt", lambda x: x)
+
+    result = sync()
+
+    # Return-value assertions
+    assert result["status"] == "ok"
+    assert result["connections_synced"] == 1
+    assert result["added"] == 3
+    assert result["classified_by_rule"] == 1
+
+    conn = get_db(env["db"])
+
+    # 3 rows in transactions
+    txns = conn.execute("SELECT * FROM transactions").fetchall()
+    assert len(txns) == 3
+
+    # 1 transaction_entry with source='rule' (only Starbucks matched)
+    entries = conn.execute("SELECT * FROM transaction_entries").fetchall()
+    assert len(entries) == 1
+    assert entries[0]["source"] == "rule"
+
+    # sync_cursors persisted
+    cursor_row = conn.execute("SELECT cursor FROM sync_cursors").fetchone()
+    assert cursor_row is not None
+    assert cursor_row["cursor"] == "cursor-2"
+
+    # bank_connections.last_synced_at set
+    bc = conn.execute(
+        "SELECT last_synced_at FROM bank_connections WHERE id = ?",
+        (env["connection_id"],),
+    ).fetchone()
+    assert bc["last_synced_at"] is not None
+
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 2: ITEM_LOGIN_REQUIRED → connection status = needs_reauth
+# ---------------------------------------------------------------------------
+
+def test_sync_item_login_required(env, monkeypatch):
+    def _raise_reauth(access_token, cursor=None):
+        raise _FakePlaidError("ITEM_LOGIN_REQUIRED")
+
+    monkeypatch.setattr("server.plaid_client.sync_transactions", _raise_reauth)
+    monkeypatch.setattr("server.crypto.decrypt", lambda x: x)
+
+    result = sync()
+
+    # sync() should complete without crashing; 0 connections successfully synced
+    assert result["status"] == "ok"
+    assert result["connections_synced"] == 0
+
+    conn = get_db(env["db"])
+    bc = conn.execute(
+        "SELECT status FROM bank_connections WHERE id = ?",
+        (env["connection_id"],),
+    ).fetchone()
+    assert bc["status"] == "needs_reauth"
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 3: idempotent re-sync — no duplicate transactions
+# ---------------------------------------------------------------------------
+
+def test_sync_idempotent(env, monkeypatch):
+    monkeypatch.setattr("server.plaid_client.sync_transactions", _mock_sync_ok)
+    monkeypatch.setattr("server.crypto.decrypt", lambda x: x)
+
+    sync()
+    sync()  # second call with identical batch — INSERT OR IGNORE absorbs it
+
+    conn = get_db(env["db"])
+    txns = conn.execute("SELECT * FROM transactions").fetchall()
+    assert len(txns) == 3  # still exactly 3, not 6
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 4: sync_lock contention → {"status": "already_running"}
+# ---------------------------------------------------------------------------
+
+def test_sync_lock_contention(env, monkeypatch):
+    from server.sync_lock import acquire_sync_lock
+
+    monkeypatch.setattr("server.plaid_client.sync_transactions", _mock_sync_ok)
+    monkeypatch.setattr("server.crypto.decrypt", lambda x: x)
+
+    # Hold the lock ourselves so sync() cannot acquire it
+    held = acquire_sync_lock(timeout=0.0)
+    assert held is not None, "could not acquire lock in test setup"
+    try:
+        result = sync()
+    finally:
+        held.close()
+
+    assert result == {"status": "already_running"}


### PR DESCRIPTION
Closes #16

sync() pulls each active bank_connection via Plaid /transactions/sync, persists cursor, inserts new transactions, runs Tier 1 rules classification, handles ITEM_LOGIN_REQUIRED. Single-flight via sync_lock.