### PR TITLE
[P4] LLM wrapper: route through OpenClaw local API

### DIFF
--- a/server/llm.py
+++ b/server/llm.py
@@ -1,25 +1,86 @@
 """
 server/llm.py — Thin LLM wrapper for Friday Budgeting Pro.
 
-Provides a single function, chat(), that sends messages to the configured
-LLM and returns the response text.  The implementation is intentionally
-kept small and fully mockable in tests via:
+Design
+------
+Calls are routed **primarily** through OpenClaw's local completions API
+(an OpenAI-compatible HTTP endpoint running on localhost).  If that endpoint
+is unreachable (connection refused, timeout, HTTP error), the wrapper falls
+back to calling the Anthropic or OpenAI SDK directly — the same path that
+existed before this change.
 
-    unittest.mock.patch("server.llm.chat", ...)
+Primary path (OpenClaw local API)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+POST to OPENCLAW_API_URL (default "http://127.0.0.1:7531/v1/completions")
+with body::
 
-Configuration is environment-driven:
-    OPENCLAW_LLM_PROVIDER  — "anthropic" (default if anthropic SDK present)
-    OPENCLAW_LLM_MODEL     — e.g. "claude-3-5-haiku-20241022"
+    {
+        "messages": [...],
+        "temperature": 0.0,
+        "model": "<OPENCLAW_LLM_MODEL or claude-sonnet-4-6>"
+    }
+
+Uses stdlib ``urllib.request`` only (no extra dependencies, 3-second timeout).
+
+Response parsing (tried in order):
+    1. OpenAI-style:  {"choices": [{"message": {"content": "..."}}]}
+    2. OpenAI delta:  {"choices": [{"delta":   {"content": "..."}}]}
+    3. Flat text:     {"text": "..."}
+    4. Flat content:  {"content": "..."}
+
+If none of those match, or the response body is not valid JSON, the wrapper
+logs a warning and falls back to the SDK path.
+
+Fallback path (SDK)
+~~~~~~~~~~~~~~~~~~~
+When OpenClaw is unreachable *or* the response is unparse-able, the wrapper
+tries Anthropic then OpenAI (same auto-detection logic as before).  A warning
+is logged so operators know the fallback was used.
+
+Patchability
+~~~~~~~~~~~~
+The public ``chat()`` function is fully mockable in tests::
+
+    with unittest.mock.patch("server.llm.chat", return_value="..."):
+        ...
+
+Env vars
+~~~~~~~~
+``OPENCLAW_API_URL``   — full URL of the local completions endpoint.
+``OPENCLAW_LLM_MODEL`` — model name forwarded to OpenClaw (default:
+                          "claude-sonnet-4-6").
+``OPENCLAW_LLM_PROVIDER`` — "anthropic" or "openai" (SDK fallback provider).
 """
 
 from __future__ import annotations
 
 import json
+import logging
 import os
+import urllib.error
+import urllib.request
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     pass
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants / env helpers
+# ---------------------------------------------------------------------------
+
+_DEFAULT_OPENCLAW_URL = "http://127.0.0.1:7531/v1/completions"
+_OPENCLAW_TIMEOUT = 3  # seconds
+
+
+def _openclaw_url() -> str:
+    return os.environ.get("OPENCLAW_API_URL", _DEFAULT_OPENCLAW_URL)
+
+
+def _openclaw_model() -> str:
+    return os.environ.get("OPENCLAW_LLM_MODEL", "claude-sonnet-4-6")
+
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -27,29 +88,137 @@ if TYPE_CHECKING:
 
 
 def chat(messages: list[dict], temperature: float = 0.0) -> str:
-    """Send *messages* to the configured LLM and return the response text.
+    """Send *messages* to the LLM and return the response text.
+
+    Tries the OpenClaw local API first; falls back to the direct SDK path
+    when OpenClaw is unreachable or returns an unparseable response.
 
     Args:
         messages: A list of ``{"role": ..., "content": ...}`` dicts.
-            The first message whose role is "system" is treated as the
-            system prompt by providers that handle it separately.
         temperature: Sampling temperature (0.0 = deterministic).
 
     Returns:
         The assistant's reply as a plain string.
 
     Raises:
-        RuntimeError: If OPENCLAW_LLM_PROVIDER / OPENCLAW_LLM_MODEL are
-            absent and no provider can be auto-detected.
-        Exception: Any exception raised by the underlying SDK is propagated.
-
-    Note:
-        This function is designed to be patched in tests::
-
-            with unittest.mock.patch("server.llm.chat") as mock_chat:
-                mock_chat.return_value = '{"line_item_id": "..."}'
-                ...
+        RuntimeError: If OpenClaw is unreachable **and** no SDK provider is
+            available.
+        Exception: Any unhandled exception from the SDK is propagated.
     """
+    # --- Primary path: OpenClaw local API ---
+    try:
+        return _chat_openclaw(messages, temperature)
+    except (
+        urllib.error.URLError,
+        urllib.error.HTTPError,
+        TimeoutError,
+        ConnectionError,
+        OSError,
+    ) as exc:
+        logger.warning(
+            "OpenClaw local API unreachable (%s); falling back to direct SDK.", exc
+        )
+    except _UnparseableResponseError as exc:
+        logger.warning(
+            "OpenClaw response could not be parsed (%s); falling back to direct SDK.",
+            exc,
+        )
+
+    # --- Fallback path: direct SDK ---
+    return _chat_sdk_fallback(messages, temperature)
+
+
+# ---------------------------------------------------------------------------
+# OpenClaw primary path
+# ---------------------------------------------------------------------------
+
+
+class _UnparseableResponseError(Exception):
+    """Raised when the OpenClaw response body cannot be parsed."""
+
+
+def _chat_openclaw(messages: list[dict], temperature: float) -> str:
+    """POST to OpenClaw local completions endpoint and parse the reply."""
+    url = _openclaw_url()
+    payload = json.dumps(
+        {
+            "messages": messages,
+            "temperature": temperature,
+            "model": _openclaw_model(),
+        }
+    ).encode()
+
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    with urllib.request.urlopen(req, timeout=_OPENCLAW_TIMEOUT) as resp:
+        raw = resp.read()
+
+    # Parse JSON
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError) as exc:
+        raise _UnparseableResponseError(f"Non-JSON response: {exc}") from exc
+
+    # Try known response shapes in order of likelihood
+    text = _extract_content(data)
+    if text is None:
+        raise _UnparseableResponseError(
+            f"Unrecognised response shape: {list(data.keys())!r}"
+        )
+    return text
+
+
+def _extract_content(data: dict) -> str | None:
+    """Try multiple plausible response shapes and return the content string.
+
+    Shapes tried (in order):
+        1. OpenAI-style:  {"choices": [{"message": {"content": "..."}}]}
+        2. OpenAI delta:  {"choices": [{"delta":   {"content": "..."}}]}
+        3. Flat text:     {"text": "..."}
+        4. Flat content:  {"content": "..."}
+
+    Returns ``None`` if none of the shapes matched.
+    """
+    # Shape 1 & 2: choices list
+    choices = data.get("choices")
+    if isinstance(choices, list) and choices:
+        first = choices[0]
+        if isinstance(first, dict):
+            # message.content
+            msg = first.get("message")
+            if isinstance(msg, dict) and "content" in msg:
+                return str(msg["content"])
+            # delta.content (streaming residue)
+            delta = first.get("delta")
+            if isinstance(delta, dict) and "content" in delta:
+                return str(delta["content"])
+            # bare "text" inside choice
+            if "text" in first:
+                return str(first["text"])
+
+    # Shape 3: flat {"text": "..."}
+    if "text" in data:
+        return str(data["text"])
+
+    # Shape 4: flat {"content": "..."}
+    if "content" in data:
+        return str(data["content"])
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# SDK fallback path (lazy imports — no top-level SDK dependency)
+# ---------------------------------------------------------------------------
+
+
+def _chat_sdk_fallback(messages: list[dict], temperature: float) -> str:
+    """Call the Anthropic or OpenAI SDK directly."""
     provider = os.environ.get("OPENCLAW_LLM_PROVIDER", "").lower()
     model = os.environ.get("OPENCLAW_LLM_MODEL", "")
 
@@ -70,8 +239,8 @@ def chat(messages: list[dict], temperature: float = 0.0) -> str:
 
     if not provider:
         raise RuntimeError(
-            "No LLM provider configured. Set OPENCLAW_LLM_PROVIDER "
-            "(e.g. 'anthropic') and OPENCLAW_LLM_MODEL environment variables."
+            "OpenClaw is unreachable and no LLM SDK is available. "
+            "Set OPENCLAW_LLM_PROVIDER (e.g. 'anthropic') and OPENCLAW_LLM_MODEL."
         )
 
     if provider == "anthropic":
@@ -85,18 +254,12 @@ def chat(messages: list[dict], temperature: float = 0.0) -> str:
         )
 
 
-# ---------------------------------------------------------------------------
-# Provider implementations (lazy imports — no top-level SDK dependency)
-# ---------------------------------------------------------------------------
-
-
 def _chat_anthropic(messages: list[dict], temperature: float, model: str) -> str:
     import anthropic  # type: ignore[import]
 
     if not model:
         model = "claude-3-5-haiku-20241022"
 
-    # Anthropic API separates system from human/assistant turns
     system_parts = [m["content"] for m in messages if m["role"] == "system"]
     human_messages = [m for m in messages if m["role"] != "system"]
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,202 @@
+"""
+tests/test_llm.py — Unit tests for server.llm.
+
+All tests are fully isolated: no real network calls are made.
+urllib.request.urlopen and the SDK helpers are patched at the module level.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import unittest
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_urlopen_response(body: bytes) -> MagicMock:
+    """Return a context-manager mock whose .read() returns *body*."""
+    resp = MagicMock()
+    resp.read.return_value = body
+    # Support "with urlopen(...) as resp:"
+    cm = MagicMock()
+    cm.__enter__ = MagicMock(return_value=resp)
+    cm.__exit__ = MagicMock(return_value=False)
+    return cm
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestChatOpenClawPrimary(unittest.TestCase):
+    """Happy-path: OpenClaw returns an OpenAI-shaped response."""
+
+    def test_openai_shape_returns_content(self):
+        """chat() extracts content from an OpenAI-shape response."""
+        body = json.dumps(
+            {"choices": [{"message": {"content": "hello world"}}]}
+        ).encode()
+        cm = _make_urlopen_response(body)
+
+        with patch("urllib.request.urlopen", return_value=cm) as mock_urlopen:
+            from server.llm import chat
+            result = chat([{"role": "user", "content": "hi"}])
+
+        self.assertEqual(result, "hello world")
+        mock_urlopen.assert_called_once()
+
+
+class TestChatFallbackOnURLError(unittest.TestCase):
+    """When urlopen raises URLError, chat() falls back to the SDK path."""
+
+    def test_fallback_used_on_url_error(self):
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=urllib.error.URLError("connection refused"),
+        ):
+            with patch(
+                "server.llm._chat_sdk_fallback", return_value="sdk-response"
+            ) as mock_fallback:
+                from server.llm import chat
+                result = chat([{"role": "user", "content": "hi"}])
+
+        self.assertEqual(result, "sdk-response")
+        mock_fallback.assert_called_once()
+
+    def test_fallback_used_on_connection_error(self):
+        with patch(
+            "urllib.request.urlopen",
+            side_effect=ConnectionRefusedError("refused"),
+        ):
+            with patch(
+                "server.llm._chat_sdk_fallback", return_value="fallback-ok"
+            ) as mock_fallback:
+                from server.llm import chat
+                result = chat([{"role": "user", "content": "hi"}])
+
+        self.assertEqual(result, "fallback-ok")
+        mock_fallback.assert_called_once()
+
+
+class TestChatCustomURL(unittest.TestCase):
+    """When OPENCLAW_API_URL is set, urlopen receives that URL."""
+
+    def test_custom_url_used(self):
+        body = json.dumps(
+            {"choices": [{"message": {"content": "custom"}}]}
+        ).encode()
+        cm = _make_urlopen_response(body)
+
+        custom_url = "http://localhost:9999/v1/completions"
+        env_patch = {"OPENCLAW_API_URL": custom_url}
+
+        with patch.dict(os.environ, env_patch):
+            with patch("urllib.request.urlopen", return_value=cm) as mock_urlopen:
+                from server.llm import chat
+                result = chat([{"role": "user", "content": "hi"}])
+
+        self.assertEqual(result, "custom")
+        call_args = mock_urlopen.call_args
+        # The first positional arg is the Request object
+        req = call_args[0][0]
+        self.assertEqual(req.full_url, custom_url)
+
+
+class TestChatFlatResponseShape(unittest.TestCase):
+    """Flat {"text": "..."} response shape is parsed correctly."""
+
+    def test_flat_text_shape(self):
+        body = json.dumps({"text": "hi"}).encode()
+        cm = _make_urlopen_response(body)
+
+        with patch("urllib.request.urlopen", return_value=cm):
+            from server.llm import chat
+            result = chat([{"role": "user", "content": "hello"}])
+
+        self.assertEqual(result, "hi")
+
+    def test_flat_content_shape(self):
+        body = json.dumps({"content": "flat-content"}).encode()
+        cm = _make_urlopen_response(body)
+
+        with patch("urllib.request.urlopen", return_value=cm):
+            from server.llm import chat
+            result = chat([{"role": "user", "content": "hello"}])
+
+        self.assertEqual(result, "flat-content")
+
+
+class TestChatMalformedJSON(unittest.TestCase):
+    """Malformed JSON response falls back to the SDK path."""
+
+    def test_malformed_json_falls_back(self):
+        body = b"not valid json {"
+        cm = _make_urlopen_response(body)
+
+        with patch("urllib.request.urlopen", return_value=cm):
+            with patch(
+                "server.llm._chat_sdk_fallback", return_value="sdk-ok"
+            ) as mock_fallback:
+                from server.llm import chat
+                result = chat([{"role": "user", "content": "hi"}])
+
+        self.assertEqual(result, "sdk-ok")
+        mock_fallback.assert_called_once()
+
+
+class TestChatUnrecognisedShape(unittest.TestCase):
+    """An unrecognised JSON shape falls back to the SDK path."""
+
+    def test_unknown_shape_falls_back(self):
+        body = json.dumps({"unknown_key": "value"}).encode()
+        cm = _make_urlopen_response(body)
+
+        with patch("urllib.request.urlopen", return_value=cm):
+            with patch(
+                "server.llm._chat_sdk_fallback", return_value="sdk-shape-fallback"
+            ) as mock_fallback:
+                from server.llm import chat
+                result = chat([{"role": "user", "content": "hi"}])
+
+        self.assertEqual(result, "sdk-shape-fallback")
+        mock_fallback.assert_called_once()
+
+
+class TestChatOpenAIDeltaShape(unittest.TestCase):
+    """OpenAI delta (streaming residue) shape is also supported."""
+
+    def test_delta_shape(self):
+        body = json.dumps(
+            {"choices": [{"delta": {"content": "delta-reply"}}]}
+        ).encode()
+        cm = _make_urlopen_response(body)
+
+        with patch("urllib.request.urlopen", return_value=cm):
+            from server.llm import chat
+            result = chat([{"role": "user", "content": "hi"}])
+
+        self.assertEqual(result, "delta-reply")
+
+
+class TestChatInterface(unittest.TestCase):
+    """The chat() function is patchable at 'server.llm.chat'."""
+
+    def test_patchable(self):
+        with patch("server.llm.chat", return_value="mocked") as mock_chat:
+            from server import llm
+            result = llm.chat([{"role": "user", "content": "test"}])
+
+        self.assertEqual(result, "mocked")
+        mock_chat.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #79

server/llm.py now POSTs to OpenClaw's local completions endpoint (default http://127.0.0.1:7531/v1/completions, override via OPENCLAW_API_URL). Falls back to direct anthropic/openai SDK when OpenClaw is unreachable. Supports OpenAI-shape and flat response bodies. server/classifier.py is untouched — same chat() interface.