### PR TITLE
[P5] apply_initial_setup MCP tool

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -30,8 +30,29 @@ mcp = fastmcp.FastMCP("friday-budgeting-pro")
 
 @mcp.tool
 def setup_status() -> dict:
-    """Return whether initial setup is not_started, in_progress, or complete."""
-    return {"status": "not_implemented"}
+    """Return whether initial setup is not_started, in_progress, or complete.
+
+    Status rules:
+      - "not_started"  → 0 ledgers AND 0 bank_connections
+      - "in_progress"  → ≥1 ledger AND 0 bank_connections
+                         (user picked a ledger but hasn't linked a bank yet)
+      - "complete"     → ≥1 ledger AND ≥1 bank_connection
+    """
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        ledger_count = conn.execute("SELECT COUNT(*) FROM ledgers").fetchone()[0]
+        bank_count = conn.execute("SELECT COUNT(*) FROM bank_connections").fetchone()[0]
+    finally:
+        conn.close()
+
+    if ledger_count == 0 and bank_count == 0:
+        status = "not_started"
+    elif ledger_count >= 1 and bank_count == 0:
+        status = "in_progress"
+    else:
+        status = "complete"
+
+    return {"status": status}
 
 
 @mcp.tool
@@ -40,8 +61,121 @@ def apply_initial_setup(
     extra_ledgers: List,
     hints: List,
 ) -> dict:
-    """Perform the whole first-run setup in one call."""
-    return {"status": "not_implemented"}
+    """Perform the whole first-run setup in one call.
+
+    Parameters
+    ----------
+    banks_to_link : List[str]
+        Human-readable bank names the user wants to connect.  NOTE: This tool
+        does NOT run Plaid Link — that interactive flow lives in start_link /
+        complete_link.  We simply acknowledge the requested banks and return
+        them so the caller can chain start_link calls for each one.
+    extra_ledgers : List[dict]
+        Additional ledgers beyond "Personal".  Each entry is a dict like::
+
+            {"name": "Business", "line_items": [{"name": "Office", "type": "expense"}, ...]}
+
+        The built-in "Personal" ledger is always created (with the standard
+        10 line items below) regardless of this parameter.
+    hints : List[str]
+        Natural-language classification hints; each becomes a row in
+        ``classification_hints``.  De-duped on exact text.
+
+    Standard Personal line items (always created):
+      Salary (income), Groceries (expense), Dining (expense),
+      Transport (expense), Subscriptions (expense), Healthcare (expense),
+      Travel (expense), Shopping (expense), Misc (expense), Other (expense)
+
+    Idempotent: re-running will not duplicate ledgers, line items, or hints.
+
+    Returns
+    -------
+    dict
+        {"status": "ok", "ledgers_created": [...], "line_items_created": N,
+         "hints_created": N, "banks_to_link": [...]}
+    """
+    PERSONAL_LINE_ITEMS = [
+        ("Salary", "income"),
+        ("Groceries", "expense"),
+        ("Dining", "expense"),
+        ("Transport", "expense"),
+        ("Subscriptions", "expense"),
+        ("Healthcare", "expense"),
+        ("Travel", "expense"),
+        ("Shopping", "expense"),
+        ("Misc", "expense"),
+        ("Other", "expense"),
+    ]
+
+    # Build the full ledger spec: Personal first, then any extras.
+    ledger_specs = [{"name": "Personal", "line_items": PERSONAL_LINE_ITEMS}]
+    for el in (extra_ledgers or []):
+        items = [(li["name"], li["type"]) for li in el.get("line_items", [])]
+        ledger_specs.append({"name": el["name"], "line_items": items})
+
+    ledgers_created: list[str] = []
+    line_items_created = 0
+    hints_created = 0
+
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        with db_txn(conn):
+            for spec in ledger_specs:
+                ledger_name = spec["name"]
+
+                # Upsert ledger — skip if already present.
+                existing_ledger = conn.execute(
+                    "SELECT id FROM ledgers WHERE name = ?", (ledger_name,)
+                ).fetchone()
+                if existing_ledger:
+                    ledger_id = existing_ledger["id"]
+                else:
+                    ledger_id = str(uuid.uuid4())
+                    conn.execute(
+                        "INSERT INTO ledgers (id, name) VALUES (?, ?)",
+                        (ledger_id, ledger_name),
+                    )
+                    ledgers_created.append(ledger_name)
+
+                # Upsert line items — skip if name+type already present in this ledger.
+                for item_name, item_type in spec["line_items"]:
+                    existing_item = conn.execute(
+                        "SELECT id FROM line_items "
+                        "WHERE ledger_id = ? AND name = ? AND item_type = ?",
+                        (ledger_id, item_name, item_type),
+                    ).fetchone()
+                    if existing_item:
+                        continue
+                    conn.execute(
+                        "INSERT INTO line_items (id, ledger_id, name, item_type) "
+                        "VALUES (?, ?, ?, ?)",
+                        (str(uuid.uuid4()), ledger_id, item_name, item_type),
+                    )
+                    line_items_created += 1
+
+            # Upsert hints — de-dupe on exact text.
+            for hint_text in (hints or []):
+                existing_hint = conn.execute(
+                    "SELECT id FROM classification_hints WHERE text = ?",
+                    (hint_text,),
+                ).fetchone()
+                if existing_hint:
+                    continue
+                conn.execute(
+                    "INSERT INTO classification_hints (id, text) VALUES (?, ?)",
+                    (str(uuid.uuid4()), hint_text),
+                )
+                hints_created += 1
+    finally:
+        conn.close()
+
+    return {
+        "status": "ok",
+        "ledgers_created": ledgers_created,
+        "line_items_created": line_items_created,
+        "hints_created": hints_created,
+        "banks_to_link": [*banks_to_link] if banks_to_link else [],
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_setup_tool.py
+++ b/tests/test_setup_tool.py
@@ -1,0 +1,160 @@
+"""
+tests/test_setup_tool.py — Tests for setup_status and apply_initial_setup MCP tools.
+"""
+
+from __future__ import annotations
+
+import uuid
+import pytest
+
+from server.db import get_db, init_db
+from server.main import setup_status, apply_initial_setup
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    """Create a fresh DB at tmp_path and monkeypatch server.paths.DB_PATH."""
+    import server.paths
+
+    db_file = tmp_path / "test.db"
+    monkeypatch.setattr(server.paths, "DB_PATH", db_file)
+    init_db(db_file)
+    return db_file
+
+
+# ---------------------------------------------------------------------------
+# setup_status tests
+# ---------------------------------------------------------------------------
+
+
+def test_setup_status_empty_is_not_started(tmp_db):
+    result = setup_status()
+    assert result == {"status": "not_started"}
+
+
+def test_setup_status_ledger_only_is_in_progress(tmp_db):
+    conn = get_db(tmp_db)
+    conn.execute("INSERT INTO ledgers (id, name) VALUES (?, ?)", (str(uuid.uuid4()), "Personal"))
+    conn.commit()
+    conn.close()
+
+    result = setup_status()
+    assert result == {"status": "in_progress"}
+
+
+def test_setup_status_ledger_and_bank_is_complete(tmp_db):
+    conn = get_db(tmp_db)
+    conn.execute("INSERT INTO ledgers (id, name) VALUES (?, ?)", (str(uuid.uuid4()), "Personal"))
+    conn.execute(
+        "INSERT INTO bank_connections (id, plaid_item_id, plaid_access_token_encrypted) "
+        "VALUES (?, ?, ?)",
+        (str(uuid.uuid4()), "item_abc", "enc_token"),
+    )
+    conn.commit()
+    conn.close()
+
+    result = setup_status()
+    assert result == {"status": "complete"}
+
+
+# ---------------------------------------------------------------------------
+# apply_initial_setup tests
+# ---------------------------------------------------------------------------
+
+
+def test_apply_minimal_creates_personal_ledger_with_10_items(tmp_db):
+    result = apply_initial_setup(banks_to_link=[], extra_ledgers=[], hints=[])
+
+    assert result["status"] == "ok"
+    assert result["ledgers_created"] == ["Personal"]
+    assert result["line_items_created"] == 10
+    assert result["hints_created"] == 0
+    assert result["banks_to_link"] == []
+
+    # Verify in DB
+    conn = get_db(tmp_db)
+    ledgers = conn.execute("SELECT name FROM ledgers").fetchall()
+    assert len(ledgers) == 1
+    assert ledgers[0]["name"] == "Personal"
+
+    line_items = conn.execute("SELECT name, item_type FROM line_items").fetchall()
+    assert len(line_items) == 10
+
+    # Check standard items are present
+    item_pairs = {(r["name"], r["item_type"]) for r in line_items}
+    assert ("Salary", "income") in item_pairs
+    assert ("Groceries", "expense") in item_pairs
+    assert ("Dining", "expense") in item_pairs
+    conn.close()
+
+
+def test_apply_with_extra_ledger_creates_personal_and_business(tmp_db):
+    extra = [{"name": "Business", "line_items": [{"name": "Office", "type": "expense"}]}]
+    result = apply_initial_setup(banks_to_link=[], extra_ledgers=extra, hints=[])
+
+    assert result["status"] == "ok"
+    assert set(result["ledgers_created"]) == {"Personal", "Business"}
+    # 10 personal + 1 business
+    assert result["line_items_created"] == 11
+
+    conn = get_db(tmp_db)
+    ledger_names = {r["name"] for r in conn.execute("SELECT name FROM ledgers").fetchall()}
+    assert ledger_names == {"Personal", "Business"}
+    conn.close()
+
+
+def test_apply_with_hints_creates_classification_hints(tmp_db):
+    hints = ["Amazon is usually Shopping", "Starbucks is Dining"]
+    result = apply_initial_setup(banks_to_link=[], extra_ledgers=[], hints=hints)
+
+    assert result["hints_created"] == 2
+
+    conn = get_db(tmp_db)
+    rows = conn.execute("SELECT text FROM classification_hints ORDER BY text").fetchall()
+    texts = [r["text"] for r in rows]
+    assert "Amazon is usually Shopping" in texts
+    assert "Starbucks is Dining" in texts
+    conn.close()
+
+
+def test_apply_banks_to_link_returned_not_stored(tmp_db):
+    """banks_to_link are acknowledged but NOT stored — Plaid Link happens separately."""
+    result = apply_initial_setup(
+        banks_to_link=["TD Bank", "RBC"], extra_ledgers=[], hints=[]
+    )
+    assert set(result["banks_to_link"]) == {"TD Bank", "RBC"}
+
+    # Nothing should be written to bank_connections
+    conn = get_db(tmp_db)
+    count = conn.execute("SELECT COUNT(*) FROM bank_connections").fetchone()[0]
+    conn.close()
+    assert count == 0
+
+
+def test_apply_is_idempotent(tmp_db):
+    """Calling apply_initial_setup twice must not duplicate any rows."""
+    hints = ["Amazon is usually Shopping"]
+    extra = [{"name": "Business", "line_items": [{"name": "Office", "type": "expense"}]}]
+
+    result1 = apply_initial_setup(banks_to_link=[], extra_ledgers=extra, hints=hints)
+    result2 = apply_initial_setup(banks_to_link=[], extra_ledgers=extra, hints=hints)
+
+    # Second call creates nothing new
+    assert result2["ledgers_created"] == []
+    assert result2["line_items_created"] == 0
+    assert result2["hints_created"] == 0
+
+    conn = get_db(tmp_db)
+    ledger_count = conn.execute("SELECT COUNT(*) FROM ledgers").fetchone()[0]
+    line_item_count = conn.execute("SELECT COUNT(*) FROM line_items").fetchone()[0]
+    hint_count = conn.execute("SELECT COUNT(*) FROM classification_hints").fetchone()[0]
+    conn.close()
+
+    assert ledger_count == 2          # Personal + Business
+    assert line_item_count == 11      # 10 personal + 1 business
+    assert hint_count == 1


### PR DESCRIPTION
Closes #22

setup_status + apply_initial_setup with idempotent ledger/line-item/hint creation, atomic via server.db.transaction(). Plaid Link flow stays in start_link/complete_link — apply just acknowledges banks_to_link.