### PR TITLE
[Reliability] LLM output validation

### DIFF
--- a/server/classifier.py
+++ b/server/classifier.py
@@ -112,7 +112,9 @@ def classify_with_llm(
 
     Raises:
         ValueError: If the LLM response is not valid JSON, is missing required
-            fields, or references a line_item_id that does not exist in the DB.
+            fields, references a line_item_id that does not exist in the DB, or
+            returns a ledger_id that does not match the ledger_id looked up from
+            the line_item in the DB (ledger_id mismatch).
     """
     from server.llm import chat  # local import keeps chat patchable in tests
 
@@ -237,10 +239,21 @@ def classify_with_llm(
 
     if li_row is None:
         raise ValueError(
-            f"LLM returned line_item_id={line_item_id!r} which does not exist in the DB."
+            f"LLM returned unknown line_item_id={line_item_id!r} which does not exist in the DB."
         )
 
     ledger_id: str = li_row["ledger_id"]
+
+    # ------------------------------------------------------------------
+    # 7. Validate ledger_id consistency if the LLM also returned one
+    # ------------------------------------------------------------------
+    if "ledger_id" in parsed:
+        llm_ledger_id = parsed["ledger_id"]
+        if llm_ledger_id != ledger_id:
+            raise ValueError(
+                f"LLM returned ledger_id={llm_ledger_id!r} but line_item_id={line_item_id!r}"
+                f" belongs to ledger_id={ledger_id!r} — ledger_id mismatch."
+            )
 
     return {
         "transaction_id": transaction["id"],
@@ -251,6 +264,81 @@ def classify_with_llm(
         "confidence":     confidence,
         "reviewed":       0,
     }
+
+
+# ---------------------------------------------------------------------------
+# Tier 2b — safe wrapper with fallback-to-review
+# ---------------------------------------------------------------------------
+
+
+def safe_classify(
+    conn: sqlite3.Connection,
+    transaction: dict | sqlite3.Row,
+    fallback_to_review: bool = True,
+) -> dict:
+    """Classify *transaction* with graceful degradation on LLM validation failures.
+
+    Wraps :func:`classify_with_llm` and intercepts ``ValueError`` raised by
+    any validation step (bad JSON, missing ``line_item_id`` key, unknown
+    ``line_item_id``, or ``ledger_id`` mismatch).
+
+    Args:
+        conn: An open sqlite3 connection with ``row_factory = sqlite3.Row``.
+        transaction: A dict or sqlite3.Row with at minimum:
+            - id        (str)
+            - merchant  (str)
+            - amount    (real)
+            - date      (str, ISO format)
+        fallback_to_review: When ``True`` (default) a validation failure
+            returns a stub entry flagged for human review instead of raising.
+            When ``False`` the ``ValueError`` is re-raised.
+
+    Returns:
+        On success: the entry dict returned by :func:`classify_with_llm`
+        (possibly with ``source`` updated by a downstream
+        :func:`flag_for_review` call if you use that separately).
+
+        On validation failure with *fallback_to_review=True*::
+
+            {
+                "transaction_id":  <str>,
+                "ledger_id":       None,
+                "line_item_id":    None,
+                "amount":          <real>,
+                "source":          "llm-rejected",
+                "confidence":      0.0,
+                "reviewed":        0,
+                "rejection_reason": "<short description of what went wrong>",
+            }
+
+    Raises:
+        ValueError: Only when *fallback_to_review=False* and the LLM output
+            fails validation.
+    """
+    import logging
+    logger = logging.getLogger(__name__)
+
+    try:
+        return classify_with_llm(conn, transaction)
+    except ValueError as exc:
+        reason = str(exc)
+        logger.warning(
+            "safe_classify: LLM output rejected for transaction_id=%r — %s",
+            transaction["id"],
+            reason,
+        )
+        if not fallback_to_review:
+            raise
+        return {
+            "transaction_id":   transaction["id"],
+            "ledger_id":        None,
+            "line_item_id":     None,
+            "amount":           transaction["amount"],
+            "source":           "llm-rejected",
+            "confidence":       0.0,
+            "reviewed":         0,
+            "rejection_reason": reason,
+        }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_classifier_validation.py
+++ b/tests/test_classifier_validation.py
@@ -1,0 +1,197 @@
+"""
+tests/test_classifier_validation.py — Tests for issue #42.
+
+Validates:
+  - safe_classify happy-path passes entry through
+  - safe_classify with unknown line_item_id → fallback stub (source="llm-rejected")
+  - safe_classify with malformed JSON → fallback stub
+  - safe_classify with fallback_to_review=False + bad output → raises ValueError
+  - classify_with_llm with ledger_id mismatch → raises ValueError
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from server.db import get_db, init_db
+from server.classifier import classify_with_llm, safe_classify
+
+
+# ---------------------------------------------------------------------------
+# Constants / helpers
+# ---------------------------------------------------------------------------
+
+LEDGER_ID    = "ledger-val"
+LEDGER_ID_2  = "ledger-other"
+LINE_ITEM_ID = "li-food"
+TXN_ID       = "txn-val-1"
+
+
+def seed(conn) -> None:
+    """Minimal seed: two ledgers + one line_item each."""
+    conn.execute("INSERT INTO ledgers (id, name) VALUES (?, ?)", (LEDGER_ID, "Food"))
+    conn.execute("INSERT INTO ledgers (id, name) VALUES (?, ?)", (LEDGER_ID_2, "Transport"))
+    conn.execute(
+        "INSERT INTO line_items (id, ledger_id, name) VALUES (?, ?, ?)",
+        (LINE_ITEM_ID, LEDGER_ID, "Groceries"),
+    )
+    conn.execute(
+        "INSERT INTO line_items (id, ledger_id, name) VALUES (?, ?, ?)",
+        ("li-transit", LEDGER_ID_2, "Transit"),
+    )
+    # FK chain for transactions
+    conn.execute(
+        "INSERT INTO bank_connections (id, plaid_access_token_encrypted) VALUES (?, ?)",
+        ("conn-val", "placeholder"),
+    )
+    conn.execute(
+        "INSERT INTO bank_accounts (id, connection_id) VALUES (?, ?)",
+        ("acct-val", "conn-val"),
+    )
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.commit()
+
+
+def make_txn(amount: float = 30.00) -> dict:
+    return {
+        "id":             TXN_ID,
+        "merchant":       "Loblaws",
+        "amount":         amount,
+        "date":           "2025-06-01",
+        "bank_account_id": "acct-val",
+    }
+
+
+def llm_json(**kwargs) -> str:
+    payload = {
+        "line_item_id": LINE_ITEM_ID,
+        "confidence":   0.85,
+        "reasoning":    "Loblaws is a grocery store.",
+    }
+    payload.update(kwargs)
+    return json.dumps(payload)
+
+
+# ---------------------------------------------------------------------------
+# Fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db(tmp_path):
+    db_path = tmp_path / "val_test.db"
+    init_db(db_path)
+    conn = get_db(db_path)
+    seed(conn)
+    yield conn
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests — safe_classify happy path
+# ---------------------------------------------------------------------------
+
+
+def test_safe_classify_valid_output_passes_through(db):
+    """safe_classify with valid LLM output returns the entry unchanged."""
+    mock_chat = MagicMock(return_value=llm_json())
+
+    with patch("server.llm.chat", mock_chat):
+        result = safe_classify(db, make_txn())
+
+    # Source is set by classify_with_llm; no rejection should occur
+    assert result["transaction_id"] == TXN_ID
+    assert result["line_item_id"]   == LINE_ITEM_ID
+    assert result["ledger_id"]      == LEDGER_ID
+    assert result["source"] in ("llm", "llm-needs-review"), (
+        f"Expected 'llm' or 'llm-needs-review', got {result['source']!r}"
+    )
+    assert "rejection_reason" not in result
+
+
+# ---------------------------------------------------------------------------
+# Tests — safe_classify fallback paths
+# ---------------------------------------------------------------------------
+
+
+def test_safe_classify_unknown_line_item_id_returns_rejected(db):
+    """Unknown line_item_id → fallback stub with source='llm-rejected'."""
+    bad_response = llm_json(line_item_id="li-does-not-exist")
+    mock_chat = MagicMock(return_value=bad_response)
+
+    with patch("server.llm.chat", mock_chat):
+        result = safe_classify(db, make_txn(), fallback_to_review=True)
+
+    assert result["source"]         == "llm-rejected"
+    assert result["line_item_id"]   is None
+    assert result["ledger_id"]      is None
+    assert result["confidence"]     == 0.0
+    assert result["reviewed"]       == 0
+    assert result["transaction_id"] == TXN_ID
+    assert result["amount"]         == 30.00
+    assert "unknown line_item_id" in result["rejection_reason"].lower() or \
+           "does not exist" in result["rejection_reason"].lower(), (
+        f"rejection_reason should mention unknown id, got: {result['rejection_reason']!r}"
+    )
+
+
+def test_safe_classify_malformed_json_returns_rejected(db):
+    """Malformed LLM JSON → fallback stub with source='llm-rejected'."""
+    mock_chat = MagicMock(return_value="this is not json {{{{")
+
+    with patch("server.llm.chat", mock_chat):
+        result = safe_classify(db, make_txn(), fallback_to_review=True)
+
+    assert result["source"]       == "llm-rejected"
+    assert result["line_item_id"] is None
+    assert result["ledger_id"]    is None
+    assert isinstance(result["rejection_reason"], str)
+    assert len(result["rejection_reason"]) > 0
+
+
+def test_safe_classify_fallback_false_reraises(db):
+    """With fallback_to_review=False, ValueError should propagate."""
+    bad_response = llm_json(line_item_id="li-ghost")
+    mock_chat = MagicMock(return_value=bad_response)
+
+    with patch("server.llm.chat", mock_chat):
+        with pytest.raises(ValueError):
+            safe_classify(db, make_txn(), fallback_to_review=False)
+
+
+# ---------------------------------------------------------------------------
+# Tests — classify_with_llm ledger_id mismatch
+# ---------------------------------------------------------------------------
+
+
+def test_classify_with_llm_ledger_id_mismatch_raises(db):
+    """LLM returning a ledger_id that doesn't match the DB lookup → ValueError."""
+    # LINE_ITEM_ID belongs to LEDGER_ID ("ledger-val"), but we tell the LLM
+    # to return LEDGER_ID_2 ("ledger-other") — that should be rejected.
+    bad_response = llm_json(
+        line_item_id=LINE_ITEM_ID,
+        ledger_id=LEDGER_ID_2,
+    )
+    mock_chat = MagicMock(return_value=bad_response)
+
+    with patch("server.llm.chat", mock_chat):
+        with pytest.raises(ValueError, match="ledger_id mismatch"):
+            classify_with_llm(db, make_txn())
+
+
+def test_classify_with_llm_correct_ledger_id_passes(db):
+    """LLM returning the correct ledger_id alongside line_item_id → no error."""
+    good_response = llm_json(
+        line_item_id=LINE_ITEM_ID,
+        ledger_id=LEDGER_ID,      # matches what's in the DB
+    )
+    mock_chat = MagicMock(return_value=good_response)
+
+    with patch("server.llm.chat", mock_chat):
+        result = classify_with_llm(db, make_txn())
+
+    assert result["ledger_id"]    == LEDGER_ID
+    assert result["line_item_id"] == LINE_ITEM_ID


### PR DESCRIPTION
Closes #42

safe_classify wraps classify_with_llm and falls back to a 'llm-rejected' review-flag entry on validation failure (bad JSON / unknown line_item_id / ledger mismatch). Hardens against LLM hallucination per Tier 3 (#20) fallback path.