### PR TITLE
[Sec] UI auth: argon2 + cookie session + rate limit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ uvicorn>=0.29
 openpyxl>=3.1
 jinja2>=3.0
 python-multipart>=0.0.7
+argon2-cffi>=23.1
 # Test deps:
 pytest>=7.0
 httpx>=0.27

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,288 @@
+"""
+tests/test_auth.py — Dedicated tests for ui.auth (issue #37).
+
+Covers:
+  - argon2id hash/verify round trip
+  - Wrong password → verify_password returns False, no exception
+  - Rate limiting: 5 failures → 6th attempt returns 429
+  - Rate limit resets after 5-minute window (monkeypatched _now)
+  - Successful login clears failed attempt counter
+  - Session lifetime: expired session rejected (monkeypatched _now)
+  - Restart-survival: session persisted in SQLite, no in-memory state needed
+  - prune_old_login_attempts removes rows older than 30 days
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def db_path(tmp_path: Path, monkeypatch) -> Path:
+    """Initialise a fresh SQLite DB and monkeypatch server.paths.DB_PATH."""
+    from server.db import init_db
+    import server.paths as paths
+
+    db = tmp_path / "test_auth.db"
+    init_db(db)
+
+    monkeypatch.setattr(paths, "DB_PATH", db)
+    monkeypatch.setattr(paths, "APP_DIR", tmp_path)
+    return db
+
+
+@pytest.fixture()
+def client(db_path: Path) -> TestClient:
+    from ui.server import app
+    return TestClient(app, follow_redirects=False)
+
+
+@pytest.fixture()
+def setup_client(client: TestClient) -> TestClient:
+    """Drive through setup wizard so a password is set."""
+    _complete_setup(client)
+    return client
+
+
+def _complete_setup(client: TestClient, password: str = "correcthorsebattery") -> None:
+    r = client.post("/setup/1", data={"password": password, "password_confirm": password})
+    assert r.status_code == 200
+    r = client.post("/setup/2", data={"notification_pref": "openclaw"})
+    assert r.status_code == 200
+    r = client.post("/setup/3", data={"ledger_name": "Personal"})
+    assert r.status_code == 200
+    r = client.post("/setup/4", data={})
+    assert r.status_code == 302
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — password hashing
+# ---------------------------------------------------------------------------
+
+class TestPasswordHashing:
+    def test_hash_verify_roundtrip(self):
+        from ui.auth import hash_password, verify_password
+        h = hash_password("mysecretpassword")
+        assert verify_password("mysecretpassword", h) is True
+
+    def test_wrong_password_returns_false(self):
+        from ui.auth import hash_password, verify_password
+        h = hash_password("correct")
+        result = verify_password("wrong", h)
+        assert result is False
+
+    def test_wrong_password_no_exception(self):
+        from ui.auth import hash_password, verify_password
+        h = hash_password("correct")
+        # Must not raise — just return False.
+        try:
+            result = verify_password("definitely wrong", h)
+            assert result is False
+        except Exception as exc:
+            pytest.fail(f"verify_password raised unexpectedly: {exc}")
+
+    def test_empty_password_returns_false(self):
+        from ui.auth import hash_password, verify_password
+        h = hash_password("nonempty")
+        assert verify_password("", h) is False
+
+    def test_hash_uses_argon2id_format(self):
+        from ui.auth import hash_password
+        h = hash_password("test")
+        # argon2-cffi produces $argon2id$ prefix
+        assert h.startswith("$argon2id$"), f"Unexpected hash prefix: {h[:20]}"
+
+    def test_two_hashes_differ(self):
+        """argon2 uses a random salt — two hashes of the same password differ."""
+        from ui.auth import hash_password
+        h1 = hash_password("same")
+        h2 = hash_password("same")
+        assert h1 != h2
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — rate limiting
+# ---------------------------------------------------------------------------
+
+class TestRateLimiting:
+    """Tests for check_rate_limit / record_login_attempt / clear_failed_attempts."""
+
+    def test_five_failures_block_sixth(self, setup_client, db_path):
+        """5 bad POST /login → 6th returns 429."""
+        for _ in range(5):
+            r = setup_client.post("/login", data={"password": "wrong"})
+            assert r.status_code == 200  # still getting login form back
+
+        r = setup_client.post("/login", data={"password": "wrong"})
+        assert r.status_code == 429
+        body = r.json()
+        assert body["error"] == "too_many_attempts"
+        assert isinstance(body["retry_after_seconds"], int)
+        assert body["retry_after_seconds"] > 0
+
+    def test_rate_limit_respects_window(self, setup_client, db_path, monkeypatch):
+        """After the 5-min window elapses, login is allowed again."""
+        import ui.auth as auth_module
+
+        base_time = 1_700_000_000
+
+        # Simulate 5 failures at base_time.
+        monkeypatch.setattr(auth_module, "_now", lambda: base_time)
+        for _ in range(5):
+            r = setup_client.post("/login", data={"password": "wrong"})
+            assert r.status_code == 200
+
+        # 6th attempt at base_time → blocked.
+        r = setup_client.post("/login", data={"password": "wrong"})
+        assert r.status_code == 429
+
+        # Advance time by 6 minutes (past the 5-min window).
+        monkeypatch.setattr(auth_module, "_now", lambda: base_time + 6 * 60)
+
+        # Now login should be allowed again (correct password).
+        r = setup_client.post("/login", data={"password": "correcthorsebattery"})
+        assert r.status_code == 302, f"Expected 302, got {r.status_code}: {r.text}"
+
+    def test_successful_login_clears_failed_counter(self, setup_client, db_path):
+        """4 failures + 1 success → counter resets → next attempt is not blocked."""
+        for _ in range(4):
+            r = setup_client.post("/login", data={"password": "wrong"})
+            assert r.status_code == 200
+
+        # Successful login — clears the failed counter.
+        r = setup_client.post("/login", data={"password": "correcthorsebattery"})
+        assert r.status_code == 302
+
+        # 5 more failures should be fine (counter was cleared).
+        for _ in range(5):
+            r = setup_client.post("/login", data={"password": "wrong"})
+            assert r.status_code == 200  # not yet blocked
+
+    def test_429_retry_after_is_sensible(self, setup_client, db_path):
+        """retry_after_seconds should be <= 300 (the window size)."""
+        for _ in range(5):
+            setup_client.post("/login", data={"password": "wrong"})
+
+        r = setup_client.post("/login", data={"password": "wrong"})
+        assert r.status_code == 429
+        assert r.json()["retry_after_seconds"] <= 300
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — session lifetime
+# ---------------------------------------------------------------------------
+
+class TestSessionLifetime:
+    def test_expired_session_rejected(self, setup_client, db_path, monkeypatch):
+        """Session 8 days old (no activity) must be rejected."""
+        import ui.auth as auth_module
+
+        base_time = 1_700_000_000
+        monkeypatch.setattr(auth_module, "_now", lambda: base_time)
+
+        # Log in at base_time — creates session with expires_at = base + 7d.
+        r = setup_client.post("/login", data={"password": "correcthorsebattery"})
+        assert r.status_code == 302
+
+        # Jump 8 days into the future — session should be expired.
+        monkeypatch.setattr(auth_module, "_now", lambda: base_time + 8 * 24 * 3600)
+
+        # Profile should redirect to /login (session rejected).
+        r = setup_client.get("/profile")
+        assert r.status_code == 302
+        assert r.headers["location"] == "/login"
+
+    def test_active_session_refreshes(self, setup_client, db_path, monkeypatch):
+        """Session touched at day 6 should still be valid at day 12."""
+        import ui.auth as auth_module
+
+        base_time = 1_700_000_000
+        monkeypatch.setattr(auth_module, "_now", lambda: base_time)
+
+        r = setup_client.post("/login", data={"password": "correcthorsebattery"})
+        assert r.status_code == 302
+
+        # At day 6, access profile → session refreshed (expires_at = day 6 + 7d = day 13).
+        monkeypatch.setattr(auth_module, "_now", lambda: base_time + 6 * 24 * 3600)
+        r = setup_client.get("/profile")
+        assert r.status_code == 200
+
+        # At day 12 (< day 13 new expiry), session should still be valid.
+        monkeypatch.setattr(auth_module, "_now", lambda: base_time + 12 * 24 * 3600)
+        r = setup_client.get("/profile")
+        assert r.status_code == 200
+
+    def test_session_restart_survival(self, db_path):
+        """Sessions are persisted in SQLite — reloading the DB makes them survive."""
+        import ui.auth as auth_module
+
+        # Create a session with a direct call (not via HTTP).
+        token = auth_module.create_session(db_path, user_agent="test-agent")
+        assert len(token) == 64  # 32 bytes → 64 hex chars
+
+        # Simulate "restart" by opening a fresh connection and querying.
+        from server.db import get_db
+        conn = get_db(db_path)
+        try:
+            row = conn.execute(
+                "SELECT id, expires_at FROM sessions WHERE id = ?", (token,)
+            ).fetchone()
+            assert row is not None, "Session not found after DB close/reopen"
+            assert row["id"] == token
+            assert row["expires_at"] > auth_module._now()
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — prune_old_login_attempts
+# ---------------------------------------------------------------------------
+
+class TestPruneOldLoginAttempts:
+    def test_prune_removes_old_rows(self, db_path):
+        """Rows older than 30 days are deleted; recent rows are kept."""
+        from server.db import get_db
+        import ui.auth as auth_module
+
+        now = auth_module._now()
+        old_ts = now - 31 * 24 * 3600   # 31 days ago → should be pruned
+        recent_ts = now - 1 * 24 * 3600  # 1 day ago → should survive
+
+        conn = get_db(db_path)
+        try:
+            conn.execute(
+                "INSERT INTO login_attempts (attempted_at, success) VALUES (?, 0)",
+                (old_ts,),
+            )
+            conn.execute(
+                "INSERT INTO login_attempts (attempted_at, success) VALUES (?, 0)",
+                (recent_ts,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        auth_module.prune_old_login_attempts(db_path)
+
+        conn = get_db(db_path)
+        try:
+            rows = conn.execute("SELECT attempted_at FROM login_attempts").fetchall()
+            timestamps = [r["attempted_at"] for r in rows]
+        finally:
+            conn.close()
+
+        assert old_ts not in timestamps, "Old row should have been pruned"
+        assert recent_ts in timestamps, "Recent row should be kept"
+
+    def test_prune_empty_table_is_safe(self, db_path):
+        """prune_old_login_attempts on an empty table must not raise."""
+        from ui.auth import prune_old_login_attempts
+        prune_old_login_attempts(db_path)  # should not raise

--- a/ui/auth.py
+++ b/ui/auth.py
@@ -1,26 +1,21 @@
 """
 ui/auth.py — Auth helpers for Friday Budgeting Pro UI.
 
-PLACEHOLDER IMPLEMENTATION — Issue #37 will replace this with:
-  - argon2id password hashing (instead of PBKDF2-HMAC-SHA256 used here)
-  - 7-day idle session expiry
-  - Login rate limiting (login_attempts table)
-
-Current scope (issue #14):
-  - PBKDF2-HMAC-SHA256 for password hashing (stdlib only, intentionally)
-  - Server-side session cookies ("friday_bp_session")
-  - check_session(request) — simple lookup, no expiry in this PR
-  - hash_password / verify_password — clearly marked for #37 replacement
+Implements issue #37:
+  - argon2id password hashing via argon2-cffi
+  - 7-day idle session expiry (sliding window)
+  - Login rate limiting (5 failed attempts per 5 minutes → 429)
+  - Opportunistic 30-day cleanup of login_attempts
 """
 
 from __future__ import annotations
 
-import hashlib
-import os
 import secrets
 import time
-from typing import Optional
+from typing import Optional, Tuple
 
+from argon2 import PasswordHasher
+from argon2.exceptions import VerifyMismatchError, VerificationError, InvalidHashError
 from fastapi import Request
 
 from server.db import get_db
@@ -28,57 +23,49 @@ from server.db import get_db
 # ── Session cookie name ────────────────────────────────────────────────────
 SESSION_COOKIE = "friday_bp_session"
 
-# ── PBKDF2 parameters ─────────────────────────────────────────────────────
-# TODO (#37): Replace with argon2id via argon2-cffi.  PBKDF2 is used here
-# only to avoid adding a non-stdlib dependency before #37 lands.
-_PBKDF2_HASH = "sha256"
-_PBKDF2_ITERATIONS = 260_000  # OWASP 2023 minimum for SHA-256
+# ── Session expiry ─────────────────────────────────────────────────────────
+_SESSION_TTL = 7 * 24 * 3600  # 7 days in seconds
+
+# ── Rate limit parameters ──────────────────────────────────────────────────
+_RATE_LIMIT_WINDOW = 5 * 60       # 5-minute window
+_RATE_LIMIT_MAX_FAILURES = 5      # max failed attempts before lockout
+_CLEANUP_HORIZON = 30 * 24 * 3600  # prune rows older than 30 days
+
+# ── argon2id hasher (sensible defaults from argon2-cffi) ──────────────────
+_ph = PasswordHasher()
+
+
+# ── Time helper (monkeypatchable for tests) ───────────────────────────────
+
+def _now() -> int:
+    """Return the current Unix timestamp as an integer.
+
+    Extracted as a module-level function so tests can monkeypatch it.
+    """
+    return int(time.time())
 
 
 # ── Password helpers ──────────────────────────────────────────────────────
 
 def hash_password(plaintext: str) -> str:
-    """Hash *plaintext* with PBKDF2-HMAC-SHA256 and a random salt.
+    """Hash *plaintext* with argon2id and return the encoded hash string.
 
-    Returns a ``"pbkdf2$<hex-salt>$<hex-digest>"`` string.
-
-    NOTE: This is a PLACEHOLDER.  Issue #37 will replace this function body
-    with argon2id (argon2-cffi).  The stored format will change at that point
-    and existing hashes will be invalidated — acceptable for a fresh install.
+    Uses argon2-cffi's PasswordHasher with default parameters (argon2id,
+    time_cost=3, memory_cost=65536, parallelism=4 as of argon2-cffi 21+).
     """
-    salt = os.urandom(16)
-    dk = hashlib.pbkdf2_hmac(
-        _PBKDF2_HASH,
-        plaintext.encode(),
-        salt,
-        _PBKDF2_ITERATIONS,
-    )
-    return f"pbkdf2${salt.hex()}${dk.hex()}"
+    return _ph.hash(plaintext)
 
 
 def verify_password(plaintext: str, stored_hash: str) -> bool:
     """Return True if *plaintext* matches *stored_hash*.
 
-    Accepts hashes produced by hash_password().
-
-    NOTE: This is a PLACEHOLDER — see hash_password() docstring.
+    Returns False on any mismatch without raising exceptions in normal flow.
+    Works with argon2id hashes produced by hash_password().
     """
     try:
-        scheme, salt_hex, dk_hex = stored_hash.split("$")
-    except ValueError:
+        return _ph.verify(stored_hash, plaintext)
+    except (VerifyMismatchError, VerificationError, InvalidHashError):
         return False
-    if scheme != "pbkdf2":
-        return False
-    salt = bytes.fromhex(salt_hex)
-    expected_dk = bytes.fromhex(dk_hex)
-    dk = hashlib.pbkdf2_hmac(
-        _PBKDF2_HASH,
-        plaintext.encode(),
-        salt,
-        _PBKDF2_ITERATIONS,
-    )
-    # Constant-time comparison to prevent timing attacks.
-    return secrets.compare_digest(dk, expected_dk)
 
 
 # ── Session helpers ───────────────────────────────────────────────────────
@@ -86,13 +73,12 @@ def verify_password(plaintext: str, stored_hash: str) -> bool:
 def create_session(db_path, user_agent: Optional[str] = None) -> str:
     """Insert a new session row and return the session token.
 
-    TODO (#37): Add 7-day idle expiry enforcement here.
+    Session has a 7-day sliding idle expiry (expires_at is refreshed on
+    every authenticated request via check_session).
     """
     token = secrets.token_hex(32)
-    now = int(time.time())
-    # expires_at: 7 days from now — #37 will enforce this; for now we store
-    # it correctly so the schema constraint is satisfied.
-    expires_at = now + 7 * 24 * 3600
+    now = _now()
+    expires_at = now + _SESSION_TTL
     conn = get_db(db_path)
     try:
         conn.execute(
@@ -117,14 +103,15 @@ def delete_session(db_path, token: str) -> None:
 
 
 def check_session(request: Request, db_path) -> bool:
-    """Return True if the request carries a valid session cookie.
+    """Return True if the request carries a valid, non-expired session cookie.
 
-    Reads the ``friday_bp_session`` cookie, looks it up in the sessions table.
-    Returns False if the cookie is absent, the session doesn't exist, or DB
-    lookup fails for any reason.
+    On a valid session:
+      - Checks that now <= expires_at (rejects expired sessions).
+      - Updates last_seen_at = now and extends expires_at by another 7 days
+        (sliding idle expiry window).
 
-    TODO (#37): Enforce 7-day idle expiry (expires_at / last_seen_at check).
-    TODO (#37): Refresh last_seen_at on valid requests.
+    Returns False if the cookie is absent, the session is expired, the row
+    doesn't exist, or the DB lookup fails for any reason.
     """
     token = request.cookies.get(SESSION_COOKIE)
     if not token:
@@ -132,11 +119,115 @@ def check_session(request: Request, db_path) -> bool:
     conn = get_db(db_path)
     try:
         row = conn.execute(
-            "SELECT id FROM sessions WHERE id = ?", (token,)
+            "SELECT expires_at FROM sessions WHERE id = ?", (token,)
         ).fetchone()
-        return row is not None
+        if row is None:
+            return False
+        now = _now()
+        if now > row["expires_at"]:
+            # Session has expired — delete it to keep the table tidy.
+            conn.execute("DELETE FROM sessions WHERE id = ?", (token,))
+            conn.commit()
+            return False
+        # Refresh sliding window.
+        new_expires = now + _SESSION_TTL
+        conn.execute(
+            "UPDATE sessions SET last_seen_at = ?, expires_at = ? WHERE id = ?",
+            (now, new_expires, token),
+        )
+        conn.commit()
+        return True
     except Exception:
         return False
+    finally:
+        conn.close()
+
+
+# ── Rate limiting helpers ─────────────────────────────────────────────────
+
+def check_rate_limit(db_path) -> Tuple[bool, int]:
+    """Check whether the login endpoint should be rate-limited.
+
+    Counts failed login_attempts rows within the last 5 minutes.
+    Returns (blocked, retry_after_seconds):
+      - blocked=True  → caller should return 429
+      - retry_after_seconds = seconds until the oldest failure leaves the window
+    """
+    now = _now()
+    window_start = now - _RATE_LIMIT_WINDOW
+    conn = get_db(db_path)
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) as cnt FROM login_attempts "
+            "WHERE attempted_at >= ? AND success = 0",
+            (window_start,),
+        ).fetchone()
+        count = row["cnt"]
+        if count >= _RATE_LIMIT_MAX_FAILURES:
+            oldest_row = conn.execute(
+                "SELECT MIN(attempted_at) as oldest FROM login_attempts "
+                "WHERE attempted_at >= ? AND success = 0",
+                (window_start,),
+            ).fetchone()
+            oldest = oldest_row["oldest"] or now
+            retry_after = max(int(oldest + _RATE_LIMIT_WINDOW - now), 1)
+            return True, retry_after
+        return False, 0
+    finally:
+        conn.close()
+
+
+def record_login_attempt(db_path, success: bool) -> None:
+    """Insert a row into login_attempts for the current attempt."""
+    conn = get_db(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO login_attempts (attempted_at, success) VALUES (?, ?)",
+            (_now(), 1 if success else 0),
+        )
+        conn.commit()
+    except Exception:
+        pass
+    finally:
+        conn.close()
+
+
+def clear_failed_attempts(db_path) -> None:
+    """Delete recent failed login attempts (called on successful login).
+
+    Clears all failed rows within the current rate-limit window so the
+    counter resets after a correct password is entered.
+    """
+    now = _now()
+    window_start = now - _RATE_LIMIT_WINDOW
+    conn = get_db(db_path)
+    try:
+        conn.execute(
+            "DELETE FROM login_attempts WHERE attempted_at >= ? AND success = 0",
+            (window_start,),
+        )
+        conn.commit()
+    except Exception:
+        pass
+    finally:
+        conn.close()
+
+
+def prune_old_login_attempts(db_path) -> None:
+    """Delete login_attempts rows older than 30 days.
+
+    Called opportunistically on every login to keep the table from growing
+    unboundedly without requiring a scheduled job.
+    """
+    cutoff = _now() - _CLEANUP_HORIZON
+    conn = get_db(db_path)
+    try:
+        conn.execute(
+            "DELETE FROM login_attempts WHERE attempted_at < ?", (cutoff,)
+        )
+        conn.commit()
+    except Exception:
+        pass
     finally:
         conn.close()
 
@@ -159,7 +250,7 @@ def get_password_hash(db_path) -> Optional[str]:
 
 def set_password_hash(db_path, hashed: str) -> None:
     """Upsert the UI password hash into app_config (single-row, id=1)."""
-    now = int(time.time())
+    now = _now()
     conn = get_db(db_path)
     try:
         conn.execute(

--- a/ui/server.py
+++ b/ui/server.py
@@ -46,11 +46,15 @@ import server.paths as _paths
 from server.db import get_db, init_db
 from ui.auth import (
     SESSION_COOKIE,
+    check_rate_limit,
     check_session,
+    clear_failed_attempts,
     create_session,
     delete_session,
     get_password_hash,
     hash_password,
+    prune_old_login_attempts,
+    record_login_attempt,
     set_password_hash,
     verify_password,
 )
@@ -386,11 +390,22 @@ async def login_post(request: Request):
 
     On failure: re-render login.html with an error.
 
-    Rate limiting: TODO (#37) — login_attempts table is populated below so
-    #37 can add enforcement without a schema change.
+    Rate limiting (#37): rejects with 429 after 5 failed attempts in 5 min.
+    Opportunistically prunes login_attempts rows older than 30 days.
     """
     if not _password_is_set():
         return _redirect("/setup")
+
+    # Opportunistic cleanup of old attempts (30-day horizon).
+    prune_old_login_attempts(_db_path())
+
+    # Enforce rate limit before touching the password.
+    blocked, retry_after = check_rate_limit(_db_path())
+    if blocked:
+        return JSONResponse(
+            status_code=429,
+            content={"error": "too_many_attempts", "retry_after_seconds": retry_after},
+        )
 
     form = await request.form()
     password = (form.get("password") or "")
@@ -398,8 +413,8 @@ async def login_post(request: Request):
     stored_hash = get_password_hash(_db_path())
     success = stored_hash is not None and verify_password(password, stored_hash)
 
-    # Record attempt (rate-limiting hook for #37).
-    _record_login_attempt(success)
+    # Record this attempt.
+    record_login_attempt(_db_path(), success)
 
     if not success:
         return templates.TemplateResponse(
@@ -408,6 +423,9 @@ async def login_post(request: Request):
             {"error": "Incorrect password."},
             status_code=200,
         )
+
+    # Successful login — clear the recent failure counter.
+    clear_failed_attempts(_db_path())
 
     # Create session.
     ua = request.headers.get("user-agent")
@@ -421,21 +439,6 @@ async def login_post(request: Request):
         samesite="strict",
     )
     return response
-
-
-def _record_login_attempt(success: bool) -> None:
-    """Insert a row into login_attempts so #37 can add rate limiting."""
-    conn = get_db(_db_path())
-    try:
-        conn.execute(
-            "INSERT INTO login_attempts (attempted_at, success) VALUES (?, ?)",
-            (int(time.time()), 1 if success else 0),
-        )
-        conn.commit()
-    except Exception:
-        pass
-    finally:
-        conn.close()
 
 
 # ── /logout ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #37

## Summary

argon2id via argon2-cffi, 7-day idle session expiry, 5-attempts-per-5-min rate limit with 429 response, opportunistic 30-day cleanup of login_attempts.

## Changes

### ui/auth.py
- Replaced PBKDF2 `hash_password` / `verify_password` with argon2id via `argon2-cffi` `PasswordHasher` (sensible defaults: argon2id, time_cost=3, memory_cost=65536, parallelism=4)
- Added `_now()` helper (monkeypatchable for tests)
- `check_session`: now rejects sessions where `now > expires_at`, and refreshes the sliding 7-day window (`last_seen_at` + `expires_at`) on every valid request
- Added `check_rate_limit(db_path)`: counts failed attempts in last 5 min; returns `(blocked, retry_after_seconds)`
- Added `record_login_attempt(db_path, success)`
- Added `clear_failed_attempts(db_path)`: clears recent failures on successful login
- Added `prune_old_login_attempts(db_path)`: deletes rows older than 30 days

### ui/server.py
- `POST /login`: calls `prune_old_login_attempts` (opportunistic), `check_rate_limit` (→ 429 if blocked), `record_login_attempt`, `clear_failed_attempts` on success
- Removed old `_record_login_attempt` stub (replaced by `ui.auth.record_login_attempt`)

### requirements.txt
- Added `argon2-cffi>=23.1`

### tests/test_auth.py (new)
- argon2id hash/verify round trip
- Wrong password → False, no exception
- 5 failures → 6th returns 429 with `{error: "too_many_attempts", retry_after_seconds: N}`
- Rate limit resets after 5-min window (monkeypatched `_now`)
- Successful login clears failed counter
- Session expires after 8 days of inactivity (monkeypatched `_now`)
- Sliding window: session touched at day 6 still valid at day 12
- Restart-survival: session in SQLite needs no in-memory state
- `prune_old_login_attempts` removes rows >30 days old; safe on empty table