### PR TITLE
[P2] Connection health monitor (polling-only)

### DIFF
--- a/server/health_monitor.py
+++ b/server/health_monitor.py
@@ -1,0 +1,123 @@
+"""
+server/health_monitor.py — Connection health monitor for Friday Budgeting Pro.
+
+Polls Plaid /item/get for each active bank_connection and updates
+bank_connections.status accordingly.  No webhooks — polling only per
+ARCHITECTURE.md § Security.
+
+Designed to be called from sync() before iterating connections.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING
+
+import server.crypto
+
+if TYPE_CHECKING:
+    import sqlite3
+
+logger = logging.getLogger(__name__)
+
+# Plaid error codes that map to specific statuses
+_REAUTH_CODES = {"ITEM_LOGIN_REQUIRED", "ITEM_LOCKED"}
+_PENDING_EXP_CODES = {"PENDING_EXPIRATION"}
+
+
+def check_all_connections(db_conn: "sqlite3.Connection", plaid_provider=None) -> dict:
+    """Poll Plaid for each active bank_connection and update statuses.
+
+    Parameters
+    ----------
+    db_conn:
+        An open SQLite connection (caller owns open/close).
+    plaid_provider:
+        A PlaidProvider instance.  Pass the singleton ``_plaid`` from
+        server/main.py.  If None, imports and instantiates one (test fallback).
+
+    Returns
+    -------
+    dict
+        {"checked": N, "active": A, "needs_reauth": R, "pending_expiration": P}
+    """
+    if plaid_provider is None:
+        from server.providers.plaid import PlaidProvider
+        plaid_provider = PlaidProvider()
+
+    rows = db_conn.execute(
+        "SELECT id, plaid_access_token_encrypted "
+        "FROM bank_connections WHERE status = 'active'"
+    ).fetchall()
+
+    checked = 0
+    active_count = 0
+    reauth_count = 0
+    pending_exp_count = 0
+    now = int(time.time())
+
+    for row in rows:
+        connection_id = row["id"]
+        encrypted_token = row["plaid_access_token_encrypted"]
+
+        try:
+            access_token = server.crypto.decrypt(encrypted_token)
+        except Exception as exc:
+            logger.warning(
+                "health_monitor: could not decrypt token for connection %s: %s",
+                connection_id,
+                exc,
+            )
+            continue
+
+        try:
+            status_info = plaid_provider.get_item_status(access_token)
+        except Exception as exc:
+            logger.warning(
+                "health_monitor: Plaid error for connection %s: %s",
+                connection_id,
+                exc,
+            )
+            checked += 1
+            continue
+
+        error_code = status_info.get("error_code") if isinstance(status_info, dict) else None
+
+        if error_code in _REAUTH_CODES:
+            db_conn.execute(
+                "UPDATE bank_connections SET status='needs_reauth' WHERE id=?",
+                (connection_id,),
+            )
+            reauth_count += 1
+        elif error_code in _PENDING_EXP_CODES:
+            db_conn.execute(
+                "UPDATE bank_connections SET status='pending_expiration' WHERE id=?",
+                (connection_id,),
+            )
+            pending_exp_count += 1
+        elif error_code is None:
+            # No error — connection is healthy
+            db_conn.execute(
+                "UPDATE bank_connections SET status='active', last_synced_at=? WHERE id=?",
+                (now, connection_id),
+            )
+            active_count += 1
+        else:
+            # Unknown/unexpected error code — log and leave status unchanged
+            logger.warning(
+                "health_monitor: unhandled Plaid error_code '%s' for connection %s",
+                error_code,
+                connection_id,
+            )
+
+        checked += 1
+
+    db_conn.commit()
+
+    return {
+        "checked": checked,
+        "active": active_count,
+        "needs_reauth": reauth_count,
+        "pending_expiration": pending_exp_count,
+    }

--- a/server/main.py
+++ b/server/main.py
@@ -22,6 +22,7 @@ from server.classifier import apply_rules
 import server.paths
 import server.crypto
 from server.providers.plaid import PlaidProvider
+import server.health_monitor
 
 _plaid = PlaidProvider()
 
@@ -360,10 +361,18 @@ def sync() -> dict:
     total_removed = 0
     total_classified = 0
 
+    health_check_result: dict = {}
+
     try:
         with sync_lock(timeout=0.0):
             db_conn = get_db(server.paths.DB_PATH)
             try:
+                # Run health check first so stale/expired connections are
+                # updated before we attempt to sync them.
+                health_check_result = server.health_monitor.check_all_connections(
+                    db_conn, plaid_provider=_plaid
+                )
+
                 active_conns = db_conn.execute(
                     "SELECT id, plaid_access_token_encrypted "
                     "FROM bank_connections WHERE status = 'active'"
@@ -538,6 +547,7 @@ def sync() -> dict:
         "modified": total_modified,
         "removed": total_removed,
         "classified_by_rule": total_classified,
+        "health_check": health_check_result,
     }
 
 

--- a/tests/test_health_monitor.py
+++ b/tests/test_health_monitor.py
@@ -1,0 +1,315 @@
+"""
+tests/test_health_monitor.py — Tests for server.health_monitor.check_all_connections().
+
+Covers:
+  - No error → status stays/becomes 'active', last_synced_at updated
+  - ITEM_LOGIN_REQUIRED → status becomes 'needs_reauth'
+  - PENDING_EXPIRATION → status becomes 'pending_expiration'
+  - Return shape includes correct counts
+  - ITEM_LOCKED → status becomes 'needs_reauth' (same re-auth bucket)
+  - Unknown error code → status unchanged (warning logged)
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from server.db import get_db, init_db
+from server.health_monitor import check_all_connections
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _insert_connection(conn, connection_id: str, status: str = "active") -> None:
+    conn.execute(
+        "INSERT INTO bank_connections "
+        "(id, plaid_item_id, plaid_access_token_encrypted, status) "
+        "VALUES (?, ?, ?, ?)",
+        (connection_id, f"item-{connection_id[:8]}", f"tok-{connection_id[:8]}", status),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def db_env(tmp_path, monkeypatch):
+    """Patch paths and init a tmp DB with three bank_connections."""
+    db = tmp_path / "data.db"
+    monkeypatch.setattr("server.paths.DB_PATH", db)
+    init_db(db)
+
+    conn_active_id = str(uuid.uuid4())       # should stay active (no error)
+    conn_reauth_id = str(uuid.uuid4())       # ITEM_LOGIN_REQUIRED → needs_reauth
+    conn_pending_id = str(uuid.uuid4())      # PENDING_EXPIRATION → pending_expiration
+
+    conn = get_db(db)
+    _insert_connection(conn, conn_active_id, "active")
+    _insert_connection(conn, conn_reauth_id, "active")
+    _insert_connection(conn, conn_pending_id, "active")
+    conn.commit()
+    conn.close()
+
+    return {
+        "db": db,
+        "conn_active_id": conn_active_id,
+        "conn_reauth_id": conn_reauth_id,
+        "conn_pending_id": conn_pending_id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Mock PlaidProvider
+# ---------------------------------------------------------------------------
+
+class _MockPlaid:
+    """Returns different item statuses keyed by access_token prefix."""
+
+    def __init__(self, token_responses: dict):
+        # token_responses: {token_prefix: return_dict}
+        self._responses = token_responses
+
+    def get_item_status(self, access_token: str) -> dict:
+        for prefix, resp in self._responses.items():
+            if access_token.startswith(prefix):
+                return resp
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_no_error_sets_active(db_env, monkeypatch):
+    """Connection with no Plaid error → status='active', last_synced_at updated."""
+    monkeypatch.setattr("server.crypto.decrypt", lambda x: x)
+
+    env = db_env
+    token = f"tok-{env['conn_active_id'][:8]}"
+
+    plaid = _MockPlaid({token: {"error_code": None, "item_id": "item-abc"}})
+
+    db = get_db(env["db"])
+    try:
+        # Only test the single active connection
+        db.execute(
+            "DELETE FROM bank_connections WHERE id != ?",
+            (env["conn_active_id"],),
+        )
+        db.commit()
+
+        result = check_all_connections(db, plaid_provider=plaid)
+    finally:
+        db.close()
+
+    assert result["checked"] == 1
+    assert result["active"] == 1
+    assert result["needs_reauth"] == 0
+    assert result["pending_expiration"] == 0
+
+    # Verify DB update
+    db2 = get_db(env["db"])
+    row = db2.execute(
+        "SELECT status, last_synced_at FROM bank_connections WHERE id=?",
+        (env["conn_active_id"],),
+    ).fetchone()
+    db2.close()
+
+    assert row["status"] == "active"
+    assert row["last_synced_at"] is not None
+
+
+def test_item_login_required_sets_needs_reauth(db_env, monkeypatch):
+    """ITEM_LOGIN_REQUIRED → status='needs_reauth'."""
+    monkeypatch.setattr("server.crypto.decrypt", lambda x: x)
+
+    env = db_env
+    token = f"tok-{env['conn_reauth_id'][:8]}"
+
+    plaid = _MockPlaid({token: {"error_code": "ITEM_LOGIN_REQUIRED"}})
+
+    db = get_db(env["db"])
+    try:
+        db.execute(
+            "DELETE FROM bank_connections WHERE id != ?",
+            (env["conn_reauth_id"],),
+        )
+        db.commit()
+
+        result = check_all_connections(db, plaid_provider=plaid)
+    finally:
+        db.close()
+
+    assert result["checked"] == 1
+    assert result["needs_reauth"] == 1
+    assert result["active"] == 0
+
+    db2 = get_db(env["db"])
+    row = db2.execute(
+        "SELECT status FROM bank_connections WHERE id=?",
+        (env["conn_reauth_id"],),
+    ).fetchone()
+    db2.close()
+
+    assert row["status"] == "needs_reauth"
+
+
+def test_pending_expiration_sets_status(db_env, monkeypatch):
+    """PENDING_EXPIRATION → status='pending_expiration'."""
+    monkeypatch.setattr("server.crypto.decrypt", lambda x: x)
+
+    env = db_env
+    token = f"tok-{env['conn_pending_id'][:8]}"
+
+    plaid = _MockPlaid({token: {"error_code": "PENDING_EXPIRATION"}})
+
+    db = get_db(env["db"])
+    try:
+        db.execute(
+            "DELETE FROM bank_connections WHERE id != ?",
+            (env["conn_pending_id"],),
+        )
+        db.commit()
+
+        result = check_all_connections(db, plaid_provider=plaid)
+    finally:
+        db.close()
+
+    assert result["checked"] == 1
+    assert result["pending_expiration"] == 1
+    assert result["needs_reauth"] == 0
+
+    db2 = get_db(env["db"])
+    row = db2.execute(
+        "SELECT status FROM bank_connections WHERE id=?",
+        (env["conn_pending_id"],),
+    ).fetchone()
+    db2.close()
+
+    assert row["status"] == "pending_expiration"
+
+
+def test_all_three_connections_counts(db_env, monkeypatch):
+    """Three connections with three different outcomes — verify full result shape."""
+    monkeypatch.setattr("server.crypto.decrypt", lambda x: x)
+
+    env = db_env
+    tok_active = f"tok-{env['conn_active_id'][:8]}"
+    tok_reauth = f"tok-{env['conn_reauth_id'][:8]}"
+    tok_pending = f"tok-{env['conn_pending_id'][:8]}"
+
+    plaid = _MockPlaid({
+        tok_active: {"error_code": None},
+        tok_reauth: {"error_code": "ITEM_LOGIN_REQUIRED"},
+        tok_pending: {"error_code": "PENDING_EXPIRATION"},
+    })
+
+    db = get_db(env["db"])
+    try:
+        result = check_all_connections(db, plaid_provider=plaid)
+    finally:
+        db.close()
+
+    assert result["checked"] == 3
+    assert result["active"] == 1
+    assert result["needs_reauth"] == 1
+    assert result["pending_expiration"] == 1
+
+
+def test_item_locked_sets_needs_reauth(db_env, monkeypatch):
+    """ITEM_LOCKED is also a re-auth scenario → status='needs_reauth'."""
+    monkeypatch.setattr("server.crypto.decrypt", lambda x: x)
+
+    env = db_env
+    token = f"tok-{env['conn_active_id'][:8]}"
+
+    plaid = _MockPlaid({token: {"error_code": "ITEM_LOCKED"}})
+
+    db = get_db(env["db"])
+    try:
+        db.execute(
+            "DELETE FROM bank_connections WHERE id != ?",
+            (env["conn_active_id"],),
+        )
+        db.commit()
+
+        result = check_all_connections(db, plaid_provider=plaid)
+    finally:
+        db.close()
+
+    assert result["needs_reauth"] == 1
+
+    db2 = get_db(env["db"])
+    row = db2.execute(
+        "SELECT status FROM bank_connections WHERE id=?",
+        (env["conn_active_id"],),
+    ).fetchone()
+    db2.close()
+
+    assert row["status"] == "needs_reauth"
+
+
+def test_unknown_error_code_leaves_status_unchanged(db_env, monkeypatch):
+    """Unknown Plaid error code → status unchanged, warning logged."""
+    monkeypatch.setattr("server.crypto.decrypt", lambda x: x)
+
+    env = db_env
+    token = f"tok-{env['conn_active_id'][:8]}"
+
+    plaid = _MockPlaid({token: {"error_code": "SOME_WEIRD_ERROR"}})
+
+    db = get_db(env["db"])
+    try:
+        db.execute(
+            "DELETE FROM bank_connections WHERE id != ?",
+            (env["conn_active_id"],),
+        )
+        db.commit()
+
+        result = check_all_connections(db, plaid_provider=plaid)
+    finally:
+        db.close()
+
+    # Counted as checked but not as active/reauth/pending
+    assert result["checked"] == 1
+    assert result["active"] == 0
+    assert result["needs_reauth"] == 0
+    assert result["pending_expiration"] == 0
+
+    # Status must not change
+    db2 = get_db(env["db"])
+    row = db2.execute(
+        "SELECT status FROM bank_connections WHERE id=?",
+        (env["conn_active_id"],),
+    ).fetchone()
+    db2.close()
+
+    assert row["status"] == "active"
+
+
+def test_no_active_connections_returns_zero_counts(db_env, monkeypatch):
+    """No active connections → all zero counts, plaid never called."""
+    monkeypatch.setattr("server.crypto.decrypt", lambda x: x)
+
+    env = db_env
+
+    class _NeverCalledPlaid:
+        def get_item_status(self, access_token):
+            raise AssertionError("should not be called")
+
+    db = get_db(env["db"])
+    try:
+        # Set all connections to non-active
+        db.execute("UPDATE bank_connections SET status='needs_reauth'")
+        db.commit()
+
+        result = check_all_connections(db, plaid_provider=_NeverCalledPlaid())
+    finally:
+        db.close()
+
+    assert result == {"checked": 0, "active": 0, "needs_reauth": 0, "pending_expiration": 0}

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -121,9 +121,13 @@ def env(tmp_path, monkeypatch):
 # Test 1: normal sync
 # ---------------------------------------------------------------------------
 
+_HEALTH_NOOP = {"checked": 0, "active": 0, "needs_reauth": 0, "pending_expiration": 0}
+
+
 def test_sync_normal(env, monkeypatch):
     monkeypatch.setattr("server.main._plaid.sync_transactions", _mock_sync_ok)
     monkeypatch.setattr("server.crypto.decrypt", lambda x: x)
+    monkeypatch.setattr("server.health_monitor.check_all_connections", lambda db, plaid_provider=None: _HEALTH_NOOP)
 
     result = sync()
 
@@ -169,6 +173,7 @@ def test_sync_item_login_required(env, monkeypatch):
 
     monkeypatch.setattr("server.main._plaid.sync_transactions", _raise_reauth)
     monkeypatch.setattr("server.crypto.decrypt", lambda x: x)
+    monkeypatch.setattr("server.health_monitor.check_all_connections", lambda db, plaid_provider=None: _HEALTH_NOOP)
 
     result = sync()
 
@@ -192,6 +197,7 @@ def test_sync_item_login_required(env, monkeypatch):
 def test_sync_idempotent(env, monkeypatch):
     monkeypatch.setattr("server.main._plaid.sync_transactions", _mock_sync_ok)
     monkeypatch.setattr("server.crypto.decrypt", lambda x: x)
+    monkeypatch.setattr("server.health_monitor.check_all_connections", lambda db, plaid_provider=None: _HEALTH_NOOP)
 
     sync()
     sync()  # second call with identical batch — INSERT OR IGNORE absorbs it
@@ -211,6 +217,7 @@ def test_sync_lock_contention(env, monkeypatch):
 
     monkeypatch.setattr("server.main._plaid.sync_transactions", _mock_sync_ok)
     monkeypatch.setattr("server.crypto.decrypt", lambda x: x)
+    monkeypatch.setattr("server.health_monitor.check_all_connections", lambda db, plaid_provider=None: _HEALTH_NOOP)
 
     # Hold the lock ourselves so sync() cannot acquire it
     held = acquire_sync_lock(timeout=0.0)


### PR DESCRIPTION
Closes #34

server/health_monitor.py polls Plaid /item/get for each active connection, updates bank_connections.status (needs_reauth / pending_expiration / active). Hooked into sync() so it runs every poll.