### PR TITLE
[P7] ClawHub installer scripts + launchd plist

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -36,8 +36,8 @@ metadata:
             {
               "id": "launchd",
               "kind": "shell",
-              "command": "python3 -m server.installer",
-              "label": "Install daemon (launchd)",
+              "command": "sh scripts/install.sh",
+              "label": "Install daemon (launchd plist + registration)",
             },
           ],
         "uninstall":
@@ -45,7 +45,7 @@ metadata:
             {
               "id": "launchd-remove",
               "kind": "shell",
-              "command": "launchctl bootout gui/$UID/ai.openclaw.friday-budgeting-pro 2>/dev/null; rm -f ~/Library/LaunchAgents/ai.openclaw.friday-budgeting-pro.plist",
+              "command": "sh scripts/uninstall.sh",
               "label": "Remove daemon",
             },
           ],

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# install.sh — Friday Budgeting Pro installer
+# Called by ClawHub as the post-install hook (SKILL.md metadata.openclaw.install).
+# Safe to run multiple times — all steps are idempotent.
+set -e
+
+LABEL="ai.openclaw.friday-budgeting-pro"
+PLIST_DEST="$HOME/Library/LaunchAgents/${LABEL}.plist"
+TEMPLATE_DIR="$(cd "$(dirname "$0")" && pwd)"
+TEMPLATE="${TEMPLATE_DIR}/launchd-template.plist"
+
+# 1. Ensure the app data directory exists.
+mkdir -p "$HOME/.friday-bp"
+
+# 2. Initialise the SQLite database (IF NOT EXISTS — fully idempotent).
+python3 -c "from server.db import init_db; from server.paths import DB_PATH; init_db(DB_PATH)"
+
+# 3. Render the launchd plist from the template (substitute @HOME@ and @PYTHON@).
+PYTHON_BIN="$(command -v python3)"
+sed \
+    -e "s|@HOME@|${HOME}|g" \
+    -e "s|@PYTHON@|${PYTHON_BIN}|g" \
+    "$TEMPLATE" > "$PLIST_DEST"
+chmod 0644 "$PLIST_DEST"
+
+# 4. Register (or re-register) the service with launchd.
+# "already loaded" errors are harmless — ignore them.
+launchctl bootstrap "gui/$(id -u)" "$PLIST_DEST" || true
+
+# 5. Done.
+echo "✓ Friday Budgeting Pro installed. Open http://127.0.0.1:6789 to finish setup."

--- a/scripts/launchd-template.plist
+++ b/scripts/launchd-template.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>ai.openclaw.friday-budgeting-pro</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>@PYTHON@</string>
+        <string>-m</string>
+        <string>server.daemon</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>@HOME@/.openclaw/skills/friday-budgeting-pro</string>
+
+    <key>StandardOutPath</key>
+    <string>@HOME@/.friday-bp/daemon.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>@HOME@/.friday-bp/daemon.log</string>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# uninstall.sh — Friday Budgeting Pro uninstaller
+# Called by ClawHub as the uninstall hook (SKILL.md metadata.openclaw.uninstall).
+# Data in ~/.friday-bp/ is intentionally preserved.
+set -e
+
+LABEL="ai.openclaw.friday-budgeting-pro"
+PLIST_DEST="$HOME/Library/LaunchAgents/${LABEL}.plist"
+
+# 1. Unload the daemon from launchd (ignore errors if not loaded).
+launchctl bootout "gui/$(id -u)/${LABEL}" || true
+
+# 2. Remove the plist file.
+rm -f "$PLIST_DEST"
+
+# 3. Done. Data directory is intentionally preserved.
+echo "✓ Friday Budgeting Pro daemon removed. Your data in ~/.friday-bp/ is preserved (delete manually to wipe)."

--- a/tests/test_installer_scripts.py
+++ b/tests/test_installer_scripts.py
@@ -1,0 +1,109 @@
+"""tests/test_installer_scripts.py — Static checks for ClawHub installer scripts.
+
+These tests perform file-system and content checks only.  They do NOT invoke
+launchctl, run install.sh, or modify the real system.  Manual E2E testing is
+required to verify the actual install/uninstall flow.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
+INSTALL_SH = SCRIPTS_DIR / "install.sh"
+UNINSTALL_SH = SCRIPTS_DIR / "uninstall.sh"
+PLIST_TEMPLATE = SCRIPTS_DIR / "launchd-template.plist"
+
+
+def _is_executable(path: Path) -> bool:
+    """Return True if the owner-execute bit is set on *path*."""
+    return bool(os.stat(path).st_mode & stat.S_IXUSR)
+
+
+# ---------------------------------------------------------------------------
+# install.sh
+# ---------------------------------------------------------------------------
+
+
+def test_install_sh_exists() -> None:
+    assert INSTALL_SH.exists(), f"{INSTALL_SH} not found"
+
+
+def test_install_sh_is_executable() -> None:
+    assert _is_executable(INSTALL_SH), f"{INSTALL_SH} is not executable"
+
+
+# ---------------------------------------------------------------------------
+# uninstall.sh
+# ---------------------------------------------------------------------------
+
+
+def test_uninstall_sh_exists() -> None:
+    assert UNINSTALL_SH.exists(), f"{UNINSTALL_SH} not found"
+
+
+def test_uninstall_sh_is_executable() -> None:
+    assert _is_executable(UNINSTALL_SH), f"{UNINSTALL_SH} is not executable"
+
+
+# ---------------------------------------------------------------------------
+# launchd-template.plist
+# ---------------------------------------------------------------------------
+
+
+def test_plist_template_is_valid_xml() -> None:
+    """xml.etree.ElementTree.parse must succeed without raising."""
+    ET.parse(str(PLIST_TEMPLATE))  # raises ParseError on malformed XML
+
+
+def test_plist_template_contains_home_placeholder() -> None:
+    content = PLIST_TEMPLATE.read_text()
+    assert "@HOME@" in content, "Template missing @HOME@ placeholder"
+
+
+def test_plist_template_contains_python_placeholder() -> None:
+    content = PLIST_TEMPLATE.read_text()
+    assert "@PYTHON@" in content, "Template missing @PYTHON@ placeholder"
+
+
+def test_plist_template_label() -> None:
+    """The plist <dict> must contain the correct Label string."""
+    tree = ET.parse(str(PLIST_TEMPLATE))
+    root = tree.getroot()
+    # plist > dict > key/string pairs
+    d = root.find("dict")
+    assert d is not None, "Root <plist> must contain a <dict>"
+    keys = [el.text for el in d.findall("key")]
+    assert "Label" in keys, "Template missing <key>Label</key>"
+    label_idx = list(d).index(d.findall("key")[keys.index("Label")])
+    label_value = list(d)[label_idx + 1]
+    assert label_value.text == "ai.openclaw.friday-budgeting-pro", (
+        f"Unexpected label value: {label_value.text!r}"
+    )
+
+
+def test_plist_template_keep_alive_true() -> None:
+    tree = ET.parse(str(PLIST_TEMPLATE))
+    root = tree.getroot()
+    d = root.find("dict")
+    assert d is not None
+    keys = [el.text for el in d.findall("key")]
+    assert "KeepAlive" in keys, "Template missing <key>KeepAlive</key>"
+    ka_idx = list(d).index(d.findall("key")[keys.index("KeepAlive")])
+    ka_value = list(d)[ka_idx + 1]
+    assert ka_value.tag == "true", f"KeepAlive should be <true/>, got <{ka_value.tag}/>"
+
+
+def test_plist_template_run_at_load_true() -> None:
+    tree = ET.parse(str(PLIST_TEMPLATE))
+    root = tree.getroot()
+    d = root.find("dict")
+    assert d is not None
+    keys = [el.text for el in d.findall("key")]
+    assert "RunAtLoad" in keys, "Template missing <key>RunAtLoad</key>"
+    ral_idx = list(d).index(d.findall("key")[keys.index("RunAtLoad")])
+    ral_value = list(d)[ral_idx + 1]
+    assert ral_value.tag == "true", f"RunAtLoad should be <true/>, got <{ral_value.tag}/>"


### PR DESCRIPTION
Closes #59

## What's in this PR

- `scripts/install.sh` — POSIX shell installer: creates `~/.friday-bp/`, initialises the DB, renders the launchd plist from template, registers the service with `launchctl bootstrap`. Fully idempotent.
- `scripts/uninstall.sh` — removes the plist and unloads the service via `launchctl bootout`. Preserves user data in `~/.friday-bp/`.
- `scripts/launchd-template.plist` — XML plist template with `@HOME@` and `@PYTHON@` placeholders substituted by `sed` at install time. KeepAlive + RunAtLoad enabled, label `ai.openclaw.friday-budgeting-pro`.
- `SKILL.md` install hooks updated to call `scripts/install.sh` (post) and `scripts/uninstall.sh` (uninstall) instead of the old inline commands.
- `tests/test_installer_scripts.py` — 10 static tests: file existence, executable bits, valid XML, placeholder presence, Label, KeepAlive, RunAtLoad. No launchctl invocations in tests.

## Manual E2E Test Required

1. Install via ClawHub or run `sh scripts/install.sh` from the skill directory.
2. Confirm `~/Library/LaunchAgents/ai.openclaw.friday-budgeting-pro.plist` exists with correct Home/Python paths.
3. Confirm daemon is running: `launchctl list | grep friday`.
4. Open http://127.0.0.1:6789 — setup wizard should appear.
5. Run `sh scripts/uninstall.sh` — daemon stops, plist removed, `~/.friday-bp/` untouched.
6. Re-run `sh scripts/install.sh` — should succeed without errors (idempotency check).