### PR TITLE
[P7] server/installer.py — launchd plist + MCP server registration

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -36,7 +36,7 @@ metadata:
             {
               "id": "launchd",
               "kind": "shell",
-              "command": "sh scripts/install.sh",
+              "command": "python3 -m server.installer install",
               "label": "Install daemon (launchd plist + registration)",
             },
           ],
@@ -45,7 +45,7 @@ metadata:
             {
               "id": "launchd-remove",
               "kind": "shell",
-              "command": "sh scripts/uninstall.sh",
+              "command": "python3 -m server.installer uninstall",
               "label": "Remove daemon",
             },
           ],

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+# DEPRECATED: This script has been superseded by server/installer.py (see issue #94).
+# It is kept as a reference only. SKILL.md now calls:
+#   python3 -m server.installer install
+# Do NOT add new logic here.
+#
 # install.sh — Friday Budgeting Pro installer
 # Called by ClawHub as the post-install hook (SKILL.md metadata.openclaw.install).
 # Safe to run multiple times — all steps are idempotent.

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+# DEPRECATED: This script has been superseded by server/installer.py (see issue #94).
+# It is kept as a reference only. SKILL.md now calls:
+#   python3 -m server.installer uninstall
+# Do NOT add new logic here.
+#
 # uninstall.sh — Friday Budgeting Pro uninstaller
 # Called by ClawHub as the uninstall hook (SKILL.md metadata.openclaw.uninstall).
 # Data in ~/.friday-bp/ is intentionally preserved.

--- a/server/installer.py
+++ b/server/installer.py
@@ -1,0 +1,152 @@
+"""server/installer.py — Friday Budgeting Pro Python installer.
+
+Replaces the bash scripts/install.sh approach (superseded by issue #94).
+
+Usage:
+    python3 -m server.installer          # install (default)
+    python3 -m server.installer install
+    python3 -m server.installer uninstall
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+LABEL = "ai.openclaw.friday-budgeting-pro"
+PLIST_NAME = f"{LABEL}.plist"
+
+# Resolve install directory as the parent of the server/ package.
+# When running as `python3 -m server.installer` from the skill directory,
+# __file__ is <install_dir>/server/installer.py.
+_INSTALL_DIR = Path(__file__).parent.parent.resolve()
+
+
+def _plist_path() -> Path:
+    return Path.home() / "Library" / "LaunchAgents" / PLIST_NAME
+
+
+def _openclaw_config_path() -> Path:
+    return Path.home() / ".openclaw" / "config.json"
+
+
+def _render_plist(install_dir: Path) -> str:
+    """Return the launchd plist XML for the daemon."""
+    log_path = Path.home() / ".friday-bp" / "daemon.log"
+    python_bin = sys.executable
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{LABEL}</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>{python_bin}</string>
+        <string>-m</string>
+        <string>server.daemon</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>{install_dir}</string>
+
+    <key>StandardOutPath</key>
+    <string>{log_path}</string>
+
+    <key>StandardErrorPath</key>
+    <string>{log_path}</string>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>
+"""
+
+
+def _register_mcp(install_dir: Path) -> None:
+    """Add friday-budgeting-pro to OpenClaw's mcpServers config (idempotent)."""
+    config_path = _openclaw_config_path()
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if config_path.exists():
+        try:
+            config = json.loads(config_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            config = {}
+    else:
+        config = {}
+
+    mcp_servers = config.get("mcpServers", {})
+    mcp_servers["friday-budgeting-pro"] = {
+        "command": sys.executable,
+        "args": ["-m", "server.main"],
+        "cwd": str(install_dir),
+    }
+    config["mcpServers"] = mcp_servers
+    config_path.write_text(json.dumps(config, indent=2) + "\n")
+
+
+def install(install_dir: Path | None = None) -> None:
+    """Install the Friday Budgeting Pro daemon and register it with OpenClaw.
+
+    Steps:
+      1. Write ~/Library/LaunchAgents/<label>.plist
+      2. Register the service with launchd (bootstrap)
+      3. Add the MCP server entry to ~/.openclaw/config.json
+    """
+    if install_dir is None:
+        install_dir = _INSTALL_DIR
+
+    plist_path = _plist_path()
+
+    # 1. Ensure the LaunchAgents directory exists and write the plist.
+    plist_path.parent.mkdir(parents=True, exist_ok=True)
+    plist_path.write_text(_render_plist(install_dir))
+    plist_path.chmod(0o644)
+
+    # 2. Register with launchd — ignore errors (already loaded is harmless).
+    subprocess.run(
+        ["launchctl", "bootstrap", f"gui/{os.getuid()}", str(plist_path)],
+        check=False,
+    )
+
+    # 3. Register MCP server in OpenClaw config.
+    _register_mcp(install_dir)
+
+    print("✓ Friday Budgeting Pro installed. Open http://127.0.0.1:6789 to finish setup.")
+
+
+def uninstall() -> None:
+    """Remove the launchd service and plist.
+
+    Data in ~/.friday-bp/ is intentionally preserved.
+    The OpenClaw config entry is intentionally preserved (ClawHub manages it).
+    """
+    plist_path = _plist_path()
+
+    # 1. Unload from launchd (ignore errors if not loaded).
+    subprocess.run(
+        ["launchctl", "bootout", f"gui/{os.getuid()}/{LABEL}"],
+        check=False,
+    )
+
+    # 2. Remove the plist.
+    plist_path.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    action = sys.argv[1] if len(sys.argv) > 1 else "install"
+    if action == "install":
+        install()
+    elif action == "uninstall":
+        uninstall()
+    else:
+        print(f"Unknown action: {action!r}. Use 'install' or 'uninstall'.", file=sys.stderr)
+        sys.exit(1)

--- a/tests/test_installer_py.py
+++ b/tests/test_installer_py.py
@@ -1,0 +1,250 @@
+"""tests/test_installer_py.py — Unit tests for server/installer.py.
+
+All filesystem writes and subprocess calls are mocked — no real
+~/Library/LaunchAgents/ or launchctl interaction occurs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+import server.installer as installer
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _patch_paths(tmp_path: Path):
+    """Return context managers that redirect plist + config paths to tmp_path."""
+    plist_target = tmp_path / "Library" / "LaunchAgents" / installer.PLIST_NAME
+    config_target = tmp_path / ".openclaw" / "config.json"
+
+    plist_cm = patch.object(installer, "_plist_path", return_value=plist_target)
+    config_cm = patch.object(installer, "_openclaw_config_path", return_value=config_target)
+    return plist_cm, config_cm
+
+
+# ---------------------------------------------------------------------------
+# install() — plist content
+# ---------------------------------------------------------------------------
+
+
+def test_install_writes_plist(tmp_path: Path) -> None:
+    """install() must create the plist file with correct content."""
+    plist_cm, config_cm = _patch_paths(tmp_path)
+    with plist_cm, config_cm, patch("subprocess.run"):
+        installer.install(install_dir=tmp_path)
+
+    plist_path = tmp_path / "Library" / "LaunchAgents" / installer.PLIST_NAME
+    assert plist_path.exists(), "plist was not written"
+    content = plist_path.read_text()
+    assert "<true/>" in content, "plist missing <true/> (KeepAlive or RunAtLoad)"
+    assert "KeepAlive" in content
+    assert "RunAtLoad" in content
+    assert "server.daemon" in content, "ProgramArguments must reference server.daemon"
+    assert str(tmp_path) in content, "WorkingDirectory must be the install_dir"
+    assert installer.LABEL in content
+
+
+def test_install_plist_keep_alive(tmp_path: Path) -> None:
+    """KeepAlive key must be <true/>."""
+    import xml.etree.ElementTree as ET
+
+    plist_cm, config_cm = _patch_paths(tmp_path)
+    with plist_cm, config_cm, patch("subprocess.run"):
+        installer.install(install_dir=tmp_path)
+
+    plist_path = tmp_path / "Library" / "LaunchAgents" / installer.PLIST_NAME
+    tree = ET.parse(str(plist_path))
+    root = tree.getroot()
+    d = root.find("dict")
+    assert d is not None
+    keys = [el.text for el in d.findall("key")]
+    assert "KeepAlive" in keys
+    ka_idx = list(d).index(d.findall("key")[keys.index("KeepAlive")])
+    assert list(d)[ka_idx + 1].tag == "true"
+
+
+def test_install_plist_run_at_load(tmp_path: Path) -> None:
+    """RunAtLoad key must be <true/>."""
+    import xml.etree.ElementTree as ET
+
+    plist_cm, config_cm = _patch_paths(tmp_path)
+    with plist_cm, config_cm, patch("subprocess.run"):
+        installer.install(install_dir=tmp_path)
+
+    plist_path = tmp_path / "Library" / "LaunchAgents" / installer.PLIST_NAME
+    tree = ET.parse(str(plist_path))
+    root = tree.getroot()
+    d = root.find("dict")
+    assert d is not None
+    keys = [el.text for el in d.findall("key")]
+    assert "RunAtLoad" in keys
+    ral_idx = list(d).index(d.findall("key")[keys.index("RunAtLoad")])
+    assert list(d)[ral_idx + 1].tag == "true"
+
+
+def test_install_plist_program_arguments(tmp_path: Path) -> None:
+    """ProgramArguments must include sys.executable and server.daemon."""
+    import xml.etree.ElementTree as ET
+
+    plist_cm, config_cm = _patch_paths(tmp_path)
+    with plist_cm, config_cm, patch("subprocess.run"):
+        installer.install(install_dir=tmp_path)
+
+    plist_path = tmp_path / "Library" / "LaunchAgents" / installer.PLIST_NAME
+    tree = ET.parse(str(plist_path))
+    root = tree.getroot()
+    d = root.find("dict")
+    assert d is not None
+    keys = [el.text for el in d.findall("key")]
+    pa_idx = list(d).index(d.findall("key")[keys.index("ProgramArguments")])
+    args_el = list(d)[pa_idx + 1]
+    args = [el.text for el in args_el.findall("string")]
+    assert sys.executable in args, "sys.executable must be the first ProgramArguments entry"
+    assert "server.daemon" in args
+
+
+# ---------------------------------------------------------------------------
+# install() — launchctl bootstrap
+# ---------------------------------------------------------------------------
+
+
+def test_install_calls_launchctl_bootstrap(tmp_path: Path) -> None:
+    """install() must call launchctl bootstrap with the right args."""
+    plist_cm, config_cm = _patch_paths(tmp_path)
+    with plist_cm, config_cm, patch("subprocess.run") as mock_run:
+        installer.install(install_dir=tmp_path)
+
+    plist_path = tmp_path / "Library" / "LaunchAgents" / installer.PLIST_NAME
+    expected_cmd = ["launchctl", "bootstrap", f"gui/{os.getuid()}", str(plist_path)]
+    mock_run.assert_called_once_with(expected_cmd, check=False)
+
+
+# ---------------------------------------------------------------------------
+# install() — OpenClaw config
+# ---------------------------------------------------------------------------
+
+
+def test_install_creates_config_when_missing(tmp_path: Path) -> None:
+    """install() must create ~/.openclaw/config.json with mcpServers if absent."""
+    plist_cm, config_cm = _patch_paths(tmp_path)
+    config_path = tmp_path / ".openclaw" / "config.json"
+    assert not config_path.exists()
+
+    with plist_cm, config_cm, patch("subprocess.run"):
+        installer.install(install_dir=tmp_path)
+
+    assert config_path.exists(), "config.json was not created"
+    data = json.loads(config_path.read_text())
+    assert "mcpServers" in data
+    assert "friday-budgeting-pro" in data["mcpServers"]
+    entry = data["mcpServers"]["friday-budgeting-pro"]
+    assert entry["command"] == sys.executable
+    assert "-m" in entry["args"]
+    assert "server.main" in entry["args"]
+    assert "cwd" in entry
+
+
+def test_install_adds_to_existing_config_without_clobbering(tmp_path: Path) -> None:
+    """install() must add the entry without removing other mcpServers keys."""
+    plist_cm, config_cm = _patch_paths(tmp_path)
+    config_path = tmp_path / ".openclaw" / "config.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    existing = {
+        "mcpServers": {
+            "other-server": {"command": "node", "args": ["index.js"]},
+        },
+        "someOtherKey": "preserved",
+    }
+    config_path.write_text(json.dumps(existing))
+
+    with plist_cm, config_cm, patch("subprocess.run"):
+        installer.install(install_dir=tmp_path)
+
+    data = json.loads(config_path.read_text())
+    assert "friday-budgeting-pro" in data["mcpServers"]
+    assert "other-server" in data["mcpServers"], "pre-existing entry was clobbered"
+    assert data["someOtherKey"] == "preserved", "non-mcpServers key was clobbered"
+
+
+def test_install_adds_when_no_mcp_servers_key(tmp_path: Path) -> None:
+    """install() must create mcpServers if config.json exists but lacks the key."""
+    plist_cm, config_cm = _patch_paths(tmp_path)
+    config_path = tmp_path / ".openclaw" / "config.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps({"someOtherKey": 42}))
+
+    with plist_cm, config_cm, patch("subprocess.run"):
+        installer.install(install_dir=tmp_path)
+
+    data = json.loads(config_path.read_text())
+    assert "mcpServers" in data
+    assert "friday-budgeting-pro" in data["mcpServers"]
+    assert data["someOtherKey"] == 42
+
+
+# ---------------------------------------------------------------------------
+# uninstall()
+# ---------------------------------------------------------------------------
+
+
+def test_uninstall_calls_launchctl_bootout(tmp_path: Path) -> None:
+    """uninstall() must call launchctl bootout with the right service path."""
+    plist_cm, _ = _patch_paths(tmp_path)
+    with plist_cm, patch("subprocess.run") as mock_run:
+        installer.uninstall()
+
+    expected_cmd = ["launchctl", "bootout", f"gui/{os.getuid()}/{installer.LABEL}"]
+    mock_run.assert_called_once_with(expected_cmd, check=False)
+
+
+def test_uninstall_removes_plist(tmp_path: Path) -> None:
+    """uninstall() must delete the plist if it exists."""
+    plist_cm, config_cm = _patch_paths(tmp_path)
+    plist_path = tmp_path / "Library" / "LaunchAgents" / installer.PLIST_NAME
+    plist_path.parent.mkdir(parents=True, exist_ok=True)
+    plist_path.write_text("<plist/>")
+
+    with plist_cm, patch("subprocess.run"):
+        installer.uninstall()
+
+    assert not plist_path.exists(), "plist was not removed by uninstall()"
+
+
+def test_uninstall_no_error_when_plist_missing(tmp_path: Path) -> None:
+    """uninstall() must not raise if the plist doesn't exist."""
+    plist_cm, _ = _patch_paths(tmp_path)
+    with plist_cm, patch("subprocess.run"):
+        installer.uninstall()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_install_is_idempotent(tmp_path: Path) -> None:
+    """Calling install() twice must not duplicate or corrupt the config."""
+    plist_cm, config_cm = _patch_paths(tmp_path)
+    with plist_cm, config_cm, patch("subprocess.run"):
+        installer.install(install_dir=tmp_path)
+        installer.install(install_dir=tmp_path)
+
+    config_path = tmp_path / ".openclaw" / "config.json"
+    data = json.loads(config_path.read_text())
+    assert isinstance(data["mcpServers"]["friday-budgeting-pro"], dict), (
+        "Re-running install() corrupted the mcpServers entry"
+    )
+    # Ensure there's exactly one top-level "mcpServers" key (no duplication).
+    raw = config_path.read_text()
+    assert raw.count('"mcpServers"') == 1, "mcpServers key duplicated"
+    assert raw.count('"friday-budgeting-pro"') == 1, "friday-budgeting-pro entry duplicated"


### PR DESCRIPTION
Closes #94

Python installer replaces the bash scripts/install.sh from #59. Writes launchd plist + adds friday-budgeting-pro entry to OpenClaw config's mcpServers.