### PR TITLE
[P5] Plaid setup via OpenClaw agent + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ finish setup.
 
 ---
 
+## Connecting to Plaid
+
+1. Create a free account at https://dashboard.plaid.com
+2. Team Settings → Keys → copy your **Client ID** and **Production Secret**
+3. Ask your OpenClaw agent: `Set up my Plaid credentials — client ID is <your_id>, secret is <your_secret>`
+4. Agent writes the config and you’re ready to connect banks via the setup wizard.
+
+For sandbox testing, use `env=sandbox` and your sandbox secret instead.
+
+---
+
 ## First Run
 
 When you visit `http://127.0.0.1:6789` for the first time, you see a

--- a/server/main.py
+++ b/server/main.py
@@ -12,6 +12,11 @@ import time as _time
 import uuid
 from typing import List, Optional
 
+import logging
+import os
+import tempfile
+from pathlib import Path
+
 import fastmcp
 
 import server.excel_export as excel_export
@@ -27,6 +32,11 @@ import server.health_monitor
 _plaid = PlaidProvider()
 
 mcp = fastmcp.FastMCP("friday-budgeting-pro")
+
+_logger = logging.getLogger(__name__)
+
+# Project root — tests monkeypatch this to a tmp dir so .env writes stay isolated.
+project_root: Path = Path(__file__).resolve().parent.parent
 
 # ---------------------------------------------------------------------------
 # Setup tools
@@ -806,6 +816,83 @@ def undo_auto_promoted_rule(rule_id: str) -> dict:
         return {"ok": True, "rule_deleted": True, "entries_reverted": entries_reverted}
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Configuration tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool
+def configure_plaid(
+    client_id: str,
+    secret: str,
+    env: str = "production",
+) -> dict:
+    """Write Plaid credentials to .env and update the running process environment.
+
+    Parameters
+    ----------
+    client_id : str
+        Plaid client ID (non-empty).
+    secret : str
+        Plaid secret for the target environment (non-empty).
+    env : str
+        One of ``sandbox``, ``development``, or ``production``.
+        Defaults to ``production``.
+
+    The .env file is written atomically (temp file + os.replace) with mode
+    0o600.  If .env already exists it is fully replaced, not appended.
+    os.environ is updated immediately so the next sync() call picks up the
+    new credentials without a daemon restart.
+
+    Returns
+    -------
+    dict
+        ``{"ok": True, "env": <env>}``
+    """
+    _VALID_ENVS = {"sandbox", "development", "production"}
+
+    if not client_id:
+        raise ValueError("client_id must be non-empty")
+    if not secret:
+        raise ValueError("secret must be non-empty")
+    if env not in _VALID_ENVS:
+        raise ValueError(
+            f"env must be one of {sorted(_VALID_ENVS)!r}, got {env!r}"
+        )
+
+    env_path = project_root / ".env"
+    content = (
+        f"PLAID_CLIENT_ID={client_id}\n"
+        f"PLAID_SECRET={secret}\n"
+        f"PLAID_ENV={env}\n"
+    )
+
+    # Atomic write: write to a sibling temp file, then os.replace into place.
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path_str = tempfile.mkstemp(dir=env_path.parent, prefix=".env.tmp")
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(content)
+    except Exception:
+        try:
+            os.unlink(tmp_path_str)
+        except OSError:
+            pass
+        raise
+
+    os.replace(tmp_path_str, env_path)
+    os.chmod(env_path, 0o600)
+
+    # Update the running process so the next sync() call picks up new creds.
+    os.environ["PLAID_CLIENT_ID"] = client_id
+    os.environ["PLAID_SECRET"] = secret
+    os.environ["PLAID_ENV"] = env
+
+    _logger.info("configure_plaid: wrote .env (env=%s)", env)
+
+    return {"ok": True, "env": env}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_configure_plaid.py
+++ b/tests/test_configure_plaid.py
@@ -1,0 +1,116 @@
+"""
+tests/test_configure_plaid.py — Tests for the configure_plaid MCP tool.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import logging
+from pathlib import Path
+
+import pytest
+
+import server.main as main_module
+from server.main import configure_plaid
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def patch_project_root(tmp_path, monkeypatch):
+    """Redirect all .env writes to tmp_path so tests never touch the real repo."""
+    monkeypatch.setattr(main_module, "project_root", tmp_path)
+    yield tmp_path
+
+
+@pytest.fixture(autouse=True)
+def clean_environ():
+    """Remove Plaid env vars before/after each test to avoid cross-test pollution."""
+    keys = ("PLAID_CLIENT_ID", "PLAID_SECRET", "PLAID_ENV")
+    saved = {k: os.environ.pop(k, None) for k in keys}
+    yield
+    for k, v in saved.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestConfigurePlaid:
+    def test_writes_env_file_and_returns_ok(self, tmp_path):
+        result = configure_plaid("abc", "xyz", "sandbox")
+
+        assert result == {"ok": True, "env": "sandbox"}
+        env_file = tmp_path / ".env"
+        assert env_file.exists()
+        content = env_file.read_text()
+        assert "PLAID_CLIENT_ID=abc" in content
+        assert "PLAID_SECRET=xyz" in content
+        assert "PLAID_ENV=sandbox" in content
+
+    def test_env_file_mode_is_0o600(self, tmp_path):
+        configure_plaid("abc", "xyz", "sandbox")
+        env_file = tmp_path / ".env"
+        mode = stat.S_IMODE(env_file.stat().st_mode)
+        assert mode == 0o600
+
+    def test_invalid_env_raises_value_error(self):
+        with pytest.raises(ValueError, match="env must be one of"):
+            configure_plaid("abc", "xyz", "staging")
+
+    def test_empty_client_id_raises_value_error(self):
+        with pytest.raises(ValueError, match="client_id must be non-empty"):
+            configure_plaid("", "xyz", "sandbox")
+
+    def test_empty_secret_raises_value_error(self):
+        with pytest.raises(ValueError, match="secret must be non-empty"):
+            configure_plaid("abc", "", "sandbox")
+
+    def test_os_environ_updated_after_call(self):
+        configure_plaid("myid", "mysecret", "production")
+        assert os.environ["PLAID_CLIENT_ID"] == "myid"
+        assert os.environ["PLAID_SECRET"] == "mysecret"
+        assert os.environ["PLAID_ENV"] == "production"
+
+    def test_calling_twice_replaces_file(self, tmp_path):
+        configure_plaid("first_id", "first_secret", "sandbox")
+        configure_plaid("second_id", "second_secret", "production")
+
+        env_file = tmp_path / ".env"
+        content = env_file.read_text()
+
+        # Only the second call's values should be present.
+        assert "second_id" in content
+        assert "second_secret" in content
+        assert "production" in content
+        assert "first_id" not in content
+        assert "first_secret" not in content
+        # Sanity: file is not just appended lines.
+        assert content.count("PLAID_CLIENT_ID") == 1
+
+    def test_secret_never_appears_in_stdout_stderr(self, tmp_path, capsys, caplog):
+        secret = "super_secret_12345"
+        with caplog.at_level(logging.DEBUG):
+            configure_plaid("myid", secret, "sandbox")
+
+        captured = capsys.readouterr()
+        assert secret not in captured.out
+        assert secret not in captured.err
+        assert secret not in caplog.text
+
+    def test_default_env_is_production(self, tmp_path):
+        result = configure_plaid("myid", "mysecret")
+        assert result["env"] == "production"
+        content = (tmp_path / ".env").read_text()
+        assert "PLAID_ENV=production" in content
+
+    def test_development_env_accepted(self, tmp_path):
+        result = configure_plaid("myid", "mysecret", "development")
+        assert result == {"ok": True, "env": "development"}


### PR DESCRIPTION
Closes #104

configure_plaid MCP tool writes .env atomically (temp + os.replace) with mode 0o600 and updates os.environ so the next sync() call picks up the creds without a daemon restart. README section walks the user through dashboard.plaid.com → agent.