### PR TITLE
[P2] UI: Ledgers minimal editor

### DIFF
--- a/tests/test_ledgers_page.py
+++ b/tests/test_ledgers_page.py
@@ -1,0 +1,322 @@
+"""
+tests/test_ledgers_page.py — Tests for the /ledgers editor (issue #48).
+
+Uses fastapi.testclient.TestClient with a tmp_path DB so tests are fully
+isolated.  server.paths.DB_PATH is monkeypatched so all route helpers use
+the temp database.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path, monkeypatch) -> Path:
+    """Initialise a fresh SQLite DB in tmp_path and monkeypatch DB_PATH."""
+    from server.db import init_db
+    import server.paths as paths
+
+    db = tmp_path / "test.db"
+    init_db(db)
+
+    monkeypatch.setattr(paths, "DB_PATH", db)
+    monkeypatch.setattr(paths, "APP_DIR", tmp_path)
+    return db
+
+
+@pytest.fixture()
+def seeded_db(db_path: Path):
+    """Seed: one TestLedger with two line items.
+
+    Returns (db_path, ledger_id, item1_id, item2_id).
+    """
+    from server.db import get_db
+
+    ledger_id = str(uuid.uuid4())
+    item1_id = str(uuid.uuid4())
+    item2_id = str(uuid.uuid4())
+
+    conn = get_db(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO ledgers (id, name) VALUES (?, ?)",
+            (ledger_id, "TestLedger"),
+        )
+        conn.execute(
+            "INSERT INTO line_items (id, ledger_id, name, item_type) VALUES (?, ?, ?, ?)",
+            (item1_id, ledger_id, "Groceries", "expense"),
+        )
+        conn.execute(
+            "INSERT INTO line_items (id, ledger_id, name, item_type) VALUES (?, ?, ?, ?)",
+            (item2_id, ledger_id, "Salary", "income"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    return db_path, ledger_id, item1_id, item2_id
+
+
+@pytest.fixture()
+def client(seeded_db):
+    """TestClient (unauthenticated) backed by the seeded DB."""
+    from ui.server import app
+
+    return TestClient(app, follow_redirects=False)
+
+
+@pytest.fixture()
+def authed_client(seeded_db):
+    """TestClient with a valid session cookie.
+
+    Drives the setup wizard to completion (sets password) then logs in.
+    """
+    from ui.server import app
+
+    c = TestClient(app, follow_redirects=False)
+    _complete_setup(c)
+    _login(c)
+    return c, seeded_db
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirrors test_ui_routes.py)
+# ---------------------------------------------------------------------------
+
+
+def _complete_setup(client: TestClient, password: str = "testpassword123") -> None:
+    r = client.post("/setup/1", data={"password": password, "password_confirm": password})
+    assert r.status_code == 200, f"Setup step 1 failed: {r.status_code}"
+    r = client.post("/setup/2", data={"notification_pref": "openclaw"})
+    assert r.status_code == 200, f"Setup step 2 failed: {r.status_code}"
+    r = client.post("/setup/3", data={"ledger_name": "Personal"})
+    assert r.status_code == 200, f"Setup step 3 failed: {r.status_code}"
+    r = client.post("/setup/4", data={})
+    assert r.status_code == 302, f"Setup step 4 failed: {r.status_code}"
+
+
+def _login(client: TestClient, password: str = "testpassword123") -> TestClient:
+    r = client.post("/login", data={"password": password})
+    assert r.status_code == 302, f"Login failed: {r.status_code}"
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestLedgersAuth:
+    """Authentication guard tests."""
+
+    def test_get_without_session_redirects_to_login(self, client):
+        r = client.get("/ledgers")
+        assert r.status_code == 302
+        assert r.headers["location"] == "/login"
+
+    def test_post_without_session_redirects_to_login(self, client):
+        r = client.post("/ledgers", data={"action": "add_ledger", "name": "Test"})
+        assert r.status_code == 302
+        assert r.headers["location"] == "/login"
+
+
+class TestLedgersGet:
+    """GET /ledgers shows the ledger tree."""
+
+    def test_shows_seeded_ledger(self, authed_client):
+        c, _ = authed_client
+        r = c.get("/ledgers")
+        assert r.status_code == 200
+        assert "TestLedger" in r.text
+
+    def test_shows_line_items(self, authed_client):
+        c, _ = authed_client
+        r = c.get("/ledgers")
+        assert r.status_code == 200
+        assert "Groceries" in r.text
+        assert "Salary" in r.text
+
+    def test_shows_item_types(self, authed_client):
+        c, _ = authed_client
+        r = c.get("/ledgers")
+        assert "expense" in r.text
+        assert "income" in r.text
+
+
+class TestAddLineItem:
+    """POST /ledgers action=add_line_item."""
+
+    def test_adds_new_line_item(self, authed_client):
+        c, (db_path, ledger_id, _, _) = authed_client
+        r = c.post(
+            "/ledgers",
+            data={
+                "action": "add_line_item",
+                "ledger_id": ledger_id,
+                "name": "Rent",
+                "item_type": "expense",
+            },
+        )
+        assert r.status_code == 302
+        assert "/ledgers" in r.headers["location"]
+
+        from server.db import get_db
+
+        conn = get_db(db_path)
+        try:
+            row = conn.execute(
+                "SELECT * FROM line_items WHERE ledger_id = ? AND name = ?",
+                (ledger_id, "Rent"),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+        assert row["item_type"] == "expense"
+
+    def test_adds_income_line_item(self, authed_client):
+        c, (db_path, ledger_id, _, _) = authed_client
+        r = c.post(
+            "/ledgers",
+            data={
+                "action": "add_line_item",
+                "ledger_id": ledger_id,
+                "name": "Freelance",
+                "item_type": "income",
+            },
+        )
+        assert r.status_code == 302
+
+        from server.db import get_db
+
+        conn = get_db(db_path)
+        try:
+            row = conn.execute(
+                "SELECT * FROM line_items WHERE ledger_id = ? AND name = ?",
+                (ledger_id, "Freelance"),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+        assert row["item_type"] == "income"
+
+
+class TestAddLedger:
+    """POST /ledgers action=add_ledger."""
+
+    def test_creates_new_ledger(self, authed_client):
+        c, (db_path, _, _, _) = authed_client
+        r = c.post("/ledgers", data={"action": "add_ledger", "name": "Business"})
+        assert r.status_code == 302
+        assert "/ledgers" in r.headers["location"]
+
+        from server.db import get_db
+
+        conn = get_db(db_path)
+        try:
+            row = conn.execute(
+                "SELECT * FROM ledgers WHERE name = ?", ("Business",)
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+
+    def test_new_ledger_visible_on_get(self, authed_client):
+        c, _ = authed_client
+        c.post("/ledgers", data={"action": "add_ledger", "name": "Travel"})
+        r = c.get("/ledgers")
+        assert r.status_code == 200
+        assert "Travel" in r.text
+
+
+class TestDeleteLineItem:
+    """POST /ledgers action=delete_line_item."""
+
+    def test_removes_line_item(self, authed_client):
+        c, (db_path, _, item1_id, _) = authed_client
+        r = c.post(
+            "/ledgers",
+            data={"action": "delete_line_item", "line_item_id": item1_id},
+        )
+        assert r.status_code == 302
+
+        from server.db import get_db
+
+        conn = get_db(db_path)
+        try:
+            row = conn.execute(
+                "SELECT * FROM line_items WHERE id = ?", (item1_id,)
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is None
+
+    def test_other_items_unaffected(self, authed_client):
+        c, (db_path, _, item1_id, item2_id) = authed_client
+        c.post("/ledgers", data={"action": "delete_line_item", "line_item_id": item1_id})
+
+        from server.db import get_db
+
+        conn = get_db(db_path)
+        try:
+            row = conn.execute(
+                "SELECT * FROM line_items WHERE id = ?", (item2_id,)
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+
+
+class TestDeleteLedger:
+    """POST /ledgers action=delete_ledger."""
+
+    def test_removes_ledger(self, authed_client):
+        c, (db_path, ledger_id, _, _) = authed_client
+        r = c.post(
+            "/ledgers",
+            data={"action": "delete_ledger", "ledger_id": ledger_id},
+        )
+        assert r.status_code == 302
+
+        from server.db import get_db
+
+        conn = get_db(db_path)
+        try:
+            row = conn.execute(
+                "SELECT * FROM ledgers WHERE id = ?", (ledger_id,)
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row is None
+
+    def test_cascade_deletes_line_items(self, authed_client):
+        c, (db_path, ledger_id, item1_id, item2_id) = authed_client
+        c.post("/ledgers", data={"action": "delete_ledger", "ledger_id": ledger_id})
+
+        from server.db import get_db
+
+        conn = get_db(db_path)
+        try:
+            rows = conn.execute(
+                "SELECT * FROM line_items WHERE ledger_id = ?", (ledger_id,)
+            ).fetchall()
+        finally:
+            conn.close()
+        assert len(rows) == 0
+
+    def test_deleted_ledger_not_shown(self, authed_client):
+        c, (_, ledger_id, _, _) = authed_client
+        c.post("/ledgers", data={"action": "delete_ledger", "ledger_id": ledger_id})
+        r = c.get("/ledgers")
+        assert r.status_code == 200
+        # Seeded "TestLedger" ledger should be gone
+        assert "TestLedger" not in r.text

--- a/ui/server.py
+++ b/ui/server.py
@@ -42,6 +42,7 @@ from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Resp
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
+from dotenv import load_dotenv as _load_dotenv; _load_dotenv()
 import server.paths as _paths
 from server.db import get_db, init_db
 from ui.auth import (
@@ -183,12 +184,16 @@ def _get_ledgers() -> list[dict]:
         ledgers = []
         for lr in ledger_rows:
             items = conn.execute(
-                "SELECT name, item_type FROM line_items WHERE ledger_id = ? ORDER BY name",
+                "SELECT id, name, item_type FROM line_items WHERE ledger_id = ? ORDER BY name",
                 (lr["id"],),
             ).fetchall()
             ledgers.append({
+                "id": lr["id"],
                 "name": lr["name"],
-                "line_items": [{"name": i["name"], "item_type": i["item_type"]} for i in items],
+                "line_items": [
+                    {"id": i["id"], "name": i["name"], "item_type": i["item_type"]}
+                    for i in items
+                ],
             })
         return ledgers
     finally:
@@ -630,20 +635,116 @@ async def profile_post(request: Request):
 # ── /ledgers ─────────────────────────────────────────────────────────────────
 
 @app.get("/ledgers", response_class=HTMLResponse)
-def ledgers_get(request: Request):
-    """Read-only ledger tree.  Requires authentication.
-
-    Queries the DB directly because server.main.list_ledgers() is still a
-    stub returning {'status': 'not_implemented'}.  A minimal editor is #48.
-    """
+def ledgers_get(request: Request, flash: Optional[str] = None):
+    """Ledger tree editor.  Requires authentication."""
     if not _is_authenticated(request):
         return _redirect("/login")
     ledgers = _get_ledgers()
     return templates.TemplateResponse(
         request,
         "ledgers.html",
-        {"ledgers": ledgers},
+        {"ledgers": ledgers, "flash": flash},
     )
+
+
+@app.post("/ledgers")
+async def ledgers_post(request: Request):
+    """Mutate the ledger tree.  Requires authentication.
+
+    Actions:
+        add_line_item    -- add a line item to an existing ledger
+        add_ledger       -- create a new ledger
+        delete_line_item -- remove a line item
+        delete_ledger    -- remove a ledger and all its line items
+    """
+    if not _is_authenticated(request):
+        accept = request.headers.get("accept", "")
+        if "application/json" in accept:
+            return JSONResponse({"error": "unauthenticated"}, status_code=401)
+        return _redirect("/login")
+
+    import uuid as _uuid
+
+    form = await request.form()
+    action = (form.get("action") or "").strip()
+    accept = request.headers.get("accept", "")
+    want_json = "application/json" in accept
+
+    conn = get_db(_db_path())
+    try:
+        if action == "add_line_item":
+            ledger_id = (form.get("ledger_id") or "").strip()
+            name = (form.get("name") or "").strip()
+            item_type = (form.get("item_type") or "expense").strip()
+            if item_type not in ("income", "expense"):
+                item_type = "expense"
+            if not ledger_id or not name:
+                if want_json:
+                    return JSONResponse({"error": "ledger_id and name required"}, status_code=400)
+                return _redirect("/ledgers?flash=ledger_id+and+name+required")
+            row = conn.execute("SELECT id FROM ledgers WHERE id = ?", (ledger_id,)).fetchone()
+            if row is None:
+                if want_json:
+                    return JSONResponse({"error": "ledger not found"}, status_code=404)
+                return _redirect("/ledgers?flash=Ledger+not+found")
+            new_id = str(_uuid.uuid4())
+            conn.execute(
+                "INSERT INTO line_items (id, ledger_id, name, item_type) VALUES (?, ?, ?, ?)",
+                (new_id, ledger_id, name, item_type),
+            )
+            conn.commit()
+            if want_json:
+                return JSONResponse({"success": True, "id": new_id})
+            return _redirect("/ledgers?flash=Line+item+added")
+
+        elif action == "add_ledger":
+            name = (form.get("name") or "").strip()
+            if not name:
+                if want_json:
+                    return JSONResponse({"error": "name required"}, status_code=400)
+                return _redirect("/ledgers?flash=name+required")
+            new_id = str(_uuid.uuid4())
+            conn.execute(
+                "INSERT INTO ledgers (id, name) VALUES (?, ?)",
+                (new_id, name),
+            )
+            conn.commit()
+            if want_json:
+                return JSONResponse({"success": True, "id": new_id})
+            return _redirect("/ledgers?flash=Ledger+added")
+
+        elif action == "delete_line_item":
+            line_item_id = (form.get("line_item_id") or "").strip()
+            if not line_item_id:
+                if want_json:
+                    return JSONResponse({"error": "line_item_id required"}, status_code=400)
+                return _redirect("/ledgers?flash=line_item_id+required")
+            conn.execute("DELETE FROM line_items WHERE id = ?", (line_item_id,))
+            conn.commit()
+            if want_json:
+                return JSONResponse({"success": True})
+            return _redirect("/ledgers?flash=Line+item+deleted")
+
+        elif action == "delete_ledger":
+            ledger_id = (form.get("ledger_id") or "").strip()
+            if not ledger_id:
+                if want_json:
+                    return JSONResponse({"error": "ledger_id required"}, status_code=400)
+                return _redirect("/ledgers?flash=ledger_id+required")
+            # Cascade delete: remove line items first (no ON DELETE CASCADE in schema)
+            conn.execute("DELETE FROM line_items WHERE ledger_id = ?", (ledger_id,))
+            conn.execute("DELETE FROM ledgers WHERE id = ?", (ledger_id,))
+            conn.commit()
+            if want_json:
+                return JSONResponse({"success": True})
+            return _redirect("/ledgers?flash=Ledger+deleted")
+
+        else:
+            if want_json:
+                return JSONResponse({"error": f"unknown action: {action}"}, status_code=400)
+            return _redirect("/ledgers?flash=Unknown+action")
+    finally:
+        conn.close()
 
 
 # ── /link ─────────────────────────────────────────────────────────────────────

--- a/ui/templates/ledgers.html
+++ b/ui/templates/ledgers.html
@@ -14,19 +14,45 @@
 {% block content %}
 <div class="card">
   <h1>Ledgers</h1>
-  <p class="hint">Read-only view. A minimal ledger editor is coming in issue
-     <strong>#48</strong>.</p>
+
+  {% if flash %}
+  <p class="hint" style="color:#2a9d8f"><strong>{{ flash }}</strong></p>
+  {% endif %}
+
+  {# ── Add new ledger ──────────────────────────────────────────── #}
+  <section class="ledger-block">
+    <h2>Add Ledger</h2>
+    <form method="post" action="/ledgers">
+      <input type="hidden" name="action" value="add_ledger">
+      <label for="new-ledger-name">Name</label>
+      <input id="new-ledger-name" type="text" name="name" required placeholder="e.g. Personal">
+      <button type="submit">Add Ledger</button>
+    </form>
+  </section>
 
   {% if ledgers %}
     {% for ledger in ledgers %}
     <section class="ledger-block">
-      <h2>{{ ledger.name }}</h2>
+      <h2>
+        {{ ledger.name }}
+        {# ── Delete ledger ─────────────────────────────────────── #}
+        <form method="post" action="/ledgers" style="display:inline;margin-left:1rem">
+          <input type="hidden" name="action" value="delete_ledger">
+          <input type="hidden" name="ledger_id" value="{{ ledger.id }}">
+          <button type="submit" class="btn-link" style="color:#e76f51"
+                  onclick="return confirm('Delete ledger {{ ledger.name }} and all its line items?')">
+            Delete ledger
+          </button>
+        </form>
+      </h2>
+
       {% if ledger.line_items %}
       <table>
         <thead>
           <tr>
             <th>Line item</th>
             <th>Type</th>
+            <th></th>
           </tr>
         </thead>
         <tbody>
@@ -34,6 +60,13 @@
           <tr>
             <td>{{ item.name }}</td>
             <td><span class="badge badge-{{ item.item_type }}">{{ item.item_type }}</span></td>
+            <td>
+              <form method="post" action="/ledgers" style="display:inline">
+                <input type="hidden" name="action" value="delete_line_item">
+                <input type="hidden" name="line_item_id" value="{{ item.id }}">
+                <button type="submit" class="btn-link" style="color:#e76f51">Delete</button>
+              </form>
+            </td>
           </tr>
           {% endfor %}
         </tbody>
@@ -41,11 +74,27 @@
       {% else %}
       <p class="hint">No line items yet.</p>
       {% endif %}
+
+      {# ── Add line item ──────────────────────────────────────── #}
+      <details style="margin-top:.75rem">
+        <summary>Add line item</summary>
+        <form method="post" action="/ledgers" style="margin-top:.5rem">
+          <input type="hidden" name="action" value="add_line_item">
+          <input type="hidden" name="ledger_id" value="{{ ledger.id }}">
+          <label for="li-name-{{ ledger.id }}">Name</label>
+          <input id="li-name-{{ ledger.id }}" type="text" name="name" required
+                 placeholder="e.g. Groceries">
+          <fieldset style="display:inline;border:none;padding:0">
+            <label><input type="radio" name="item_type" value="expense" checked> Expense</label>
+            <label style="margin-left:.5rem"><input type="radio" name="item_type" value="income"> Income</label>
+          </fieldset>
+          <button type="submit" style="margin-left:.5rem">Add</button>
+        </form>
+      </details>
     </section>
     {% endfor %}
   {% else %}
-  <p>No ledgers found. Set up a ledger via OpenClaw chat or complete the
-     <a href="/setup">setup wizard</a>.</p>
+  <p>No ledgers yet. Add one above or set one up via OpenClaw chat.</p>
   {% endif %}
 </div>
 {% endblock %}


### PR DESCRIPTION
Closes #48. Replaces read-only /ledgers with a minimal editor. GET /ledgers renders the full ledger tree with inline forms. POST /ledgers handles: add_line_item, add_ledger, delete_line_item, delete_ledger. All actions require authentication. Cascade delete implemented in Python. New tests in tests/test_ledgers_page.py (14 tests, all green).