### PR TITLE
[P2] MCP tool: get_ui_url (#50)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,19 +24,40 @@ jobs:
         with:
           python-version: "3.11"
       - run: pip install -r requirements.txt
-      # Smoke test: every MCP tool must import cleanly and return a dict (not crash on import)
+      # Smoke test: server imports cleanly and setup_status returns a dict
+      # Uses a temp dir for DB so CI doesn't need ~/.friday-bp
       - run: |
           python3 -c "
-          import os, sys
+          import os, sys, tempfile, pathlib
+
+          # Point DB at a writable temp dir
+          tmp = tempfile.mkdtemp()
+          os.environ['FRIDAY_BP_APP_DIR'] = tmp
           os.environ.setdefault('PLAID_CLIENT_ID', 'test')
           os.environ.setdefault('PLAID_SECRET', 'test')
           os.environ.setdefault('PLAID_ENV', 'sandbox')
           sys.path.insert(0, '.')
+
+          # Patch paths before import
+          import server.paths as paths
+          paths.APP_DIR = pathlib.Path(tmp)
+          paths.DB_PATH = paths.APP_DIR / 'data.db'
+          paths.SYNC_LOCK_PATH = paths.APP_DIR / 'sync.lock'
+          paths.EXPORTS_DIR = paths.APP_DIR / 'exports'
+          paths.APP_DIR.mkdir(parents=True, exist_ok=True)
+          paths.EXPORTS_DIR.mkdir(parents=True, exist_ok=True)
+
           import server.main as m
+
+          # Init the DB schema
+          from server.db import init_db
+          init_db(paths.DB_PATH)
+
           tools = [k for k in dir(m) if not k.startswith('_')]
           print(f'Server imported OK, {len(tools)} exports')
-          # Verify setup_status returns a dict
+
           r = m.setup_status()
           assert isinstance(r, dict), f'setup_status returned {type(r)}'
+          assert r.get('status') != 'not_implemented', f'setup_status is a stub: {r}'
           print('setup_status OK:', r)
           "

--- a/server/main.py
+++ b/server/main.py
@@ -1120,6 +1120,49 @@ def configure_plaid(
 
 
 # ---------------------------------------------------------------------------
+# UI URL tool
+# ---------------------------------------------------------------------------
+
+_VALID_PAGES = {"accounts", "ledgers", "profile", "dashboard"}
+
+
+@mcp.tool
+def get_ui_url(page: str = None) -> dict:
+    """Return the local UI URL, optionally deep-linked to a specific page.
+
+    Parameters
+    ----------
+    page : str, optional
+        One of ``'accounts'``, ``'ledgers'``, ``'profile'``, or
+        ``'dashboard'``.  When provided the returned URL includes the page
+        path so the user can navigate directly there.  Omit (or pass
+        ``None``) to get the base URL.
+
+    Returns
+    -------
+    dict
+        ``{"url": "http://127.0.0.1:<port>[/<page>]"}``
+    """
+    raw = os.environ.get("FRIDAY_BP_UI_PORT")
+    try:
+        port = int(raw) if raw is not None else 6789
+    except ValueError:
+        port = 6789
+
+    base = f"http://127.0.0.1:{port}"
+
+    if page is None:
+        return {"url": base}
+
+    if page not in _VALID_PAGES:
+        raise ValueError(
+            f"page must be one of {sorted(_VALID_PAGES)!r}, got {page!r}"
+        )
+
+    return {"url": f"{base}/{page}"}
+
+
+# ---------------------------------------------------------------------------
 # Entrypoint
 # ---------------------------------------------------------------------------
 

--- a/tests/test_get_ui_url.py
+++ b/tests/test_get_ui_url.py
@@ -1,0 +1,53 @@
+"""
+tests/test_get_ui_url.py — Tests for the get_ui_url MCP tool.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from server.main import get_ui_url
+
+
+class TestGetUiUrl:
+    def test_no_args_returns_base_url(self, monkeypatch):
+        """Calling get_ui_url() with no args returns the base URL on default port."""
+        monkeypatch.delenv("FRIDAY_BP_UI_PORT", raising=False)
+        result = get_ui_url()
+        assert result == {"url": "http://127.0.0.1:6789"}
+
+    def test_no_args_respects_env_port(self, monkeypatch):
+        """FRIDAY_BP_UI_PORT env var is honoured."""
+        monkeypatch.setenv("FRIDAY_BP_UI_PORT", "9000")
+        result = get_ui_url()
+        assert result == {"url": "http://127.0.0.1:9000"}
+
+    def test_page_ledgers(self, monkeypatch):
+        """page='ledgers' appends /ledgers to the URL."""
+        monkeypatch.delenv("FRIDAY_BP_UI_PORT", raising=False)
+        result = get_ui_url(page="ledgers")
+        assert result == {"url": "http://127.0.0.1:6789/ledgers"}
+
+    def test_page_accounts(self, monkeypatch):
+        monkeypatch.delenv("FRIDAY_BP_UI_PORT", raising=False)
+        assert get_ui_url(page="accounts") == {"url": "http://127.0.0.1:6789/accounts"}
+
+    def test_page_profile(self, monkeypatch):
+        monkeypatch.delenv("FRIDAY_BP_UI_PORT", raising=False)
+        assert get_ui_url(page="profile") == {"url": "http://127.0.0.1:6789/profile"}
+
+    def test_page_dashboard(self, monkeypatch):
+        monkeypatch.delenv("FRIDAY_BP_UI_PORT", raising=False)
+        assert get_ui_url(page="dashboard") == {"url": "http://127.0.0.1:6789/dashboard"}
+
+    def test_invalid_page_raises(self, monkeypatch):
+        """An invalid page argument raises ValueError."""
+        monkeypatch.delenv("FRIDAY_BP_UI_PORT", raising=False)
+        with pytest.raises(ValueError, match="page must be one of"):
+            get_ui_url(page="settings")
+
+    def test_invalid_port_env_falls_back_to_default(self, monkeypatch):
+        """A non-integer FRIDAY_BP_UI_PORT silently falls back to 6789."""
+        monkeypatch.setenv("FRIDAY_BP_UI_PORT", "not-a-number")
+        result = get_ui_url()
+        assert result == {"url": "http://127.0.0.1:6789"}


### PR DESCRIPTION
Closes #50

Adds the `get_ui_url(page=None)` MCP tool that returns the local UI URL (default `http://127.0.0.1:6789`), with optional deep-linking to `accounts`, `ledgers`, `profile`, or `dashboard`. Port is read from `FRIDAY_BP_UI_PORT` env var (same logic as the daemon). Invalid page values raise `ValueError`.

**Interactive check:** called `get_ui_url()` → `{'url': 'http://127.0.0.1:6789'}` and `get_ui_url(page='ledgers')` → `{'url': 'http://127.0.0.1:6789/ledgers'}` directly in Python — both returned correct dicts.