### PR TITLE
[P2] UI: Ledgers editor page (#48)

### DIFF
--- a/tests/test_ui_ledgers.py
+++ b/tests/test_ui_ledgers.py
@@ -1,0 +1,353 @@
+"""
+tests/test_ui_ledgers.py — Tests for the /ledgers CRUD endpoints (issue #48).
+
+Uses the same fixture pattern as tests/test_ui_routes.py.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirrors test_ui_routes.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path, monkeypatch) -> Path:
+    from server.db import init_db
+    import server.paths as paths
+
+    db = tmp_path / "test.db"
+    init_db(db)
+
+    monkeypatch.setattr(paths, "DB_PATH", db)
+    monkeypatch.setattr(paths, "APP_DIR", tmp_path)
+    return db
+
+
+@pytest.fixture()
+def client(db_path: Path) -> TestClient:
+    from ui.server import app
+    return TestClient(app, follow_redirects=False)
+
+
+@pytest.fixture()
+def authed_client(db_path: Path) -> TestClient:
+    from ui.server import app
+    c = TestClient(app, follow_redirects=False)
+    _complete_setup(c)
+    return _login(c)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _complete_setup(client: TestClient, password: str = "testpass123") -> None:
+    r = client.post("/setup/1", data={"password": password, "password_confirm": password})
+    assert r.status_code == 200
+    r = client.post("/setup/2", data={"notification_pref": "openclaw"})
+    assert r.status_code == 200
+    r = client.post("/setup/3", data={"ledger_name": "Personal"})
+    assert r.status_code == 200
+    r = client.post("/setup/4", data={})
+    assert r.status_code == 302
+
+
+def _login(client: TestClient, password: str = "testpass123") -> TestClient:
+    r = client.post("/login", data={"password": password})
+    assert r.status_code == 302
+    return client
+
+
+def _insert_ledger(db_path: Path, name: str = "Personal") -> str:
+    """Directly insert a ledger into the DB and return its id."""
+    from server.db import get_db
+    lid = str(uuid.uuid4())
+    conn = get_db(db_path)
+    try:
+        conn.execute("INSERT INTO ledgers (id, name) VALUES (?, ?)", (lid, name))
+        conn.commit()
+    finally:
+        conn.close()
+    return lid
+
+
+def _insert_item(db_path: Path, ledger_id: str, name: str, item_type: str = "expense") -> str:
+    from server.db import get_db
+    iid = str(uuid.uuid4())
+    conn = get_db(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO line_items (id, ledger_id, name, item_type) VALUES (?, ?, ?, ?)",
+            (iid, ledger_id, name, item_type),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return iid
+
+
+# ---------------------------------------------------------------------------
+# Tests — auth guard
+# ---------------------------------------------------------------------------
+
+
+class TestAuthGuard:
+    def test_get_ledgers_unauthenticated_redirects(self, client):
+        r = client.get("/ledgers")
+        assert r.status_code == 302
+        assert r.headers["location"] == "/login"
+
+    def test_post_ledgers_unauthenticated_returns_401(self, client):
+        r = client.post("/ledgers", json={"name": "Test"})
+        assert r.status_code == 401
+
+    def test_delete_ledger_unauthenticated_returns_401(self, client, db_path):
+        lid = _insert_ledger(db_path)
+        r = client.delete(f"/ledgers/{lid}")
+        assert r.status_code == 401
+
+    def test_patch_ledger_unauthenticated_returns_401(self, client, db_path):
+        lid = _insert_ledger(db_path)
+        r = client.patch(f"/ledgers/{lid}", json={"name": "New"})
+        assert r.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Tests — GET /ledgers
+# ---------------------------------------------------------------------------
+
+
+class TestGetLedgers:
+    def test_ledgers_page_renders(self, authed_client, db_path):
+        # setup wizard creates a Personal ledger with Salary (income) + 9 expenses
+        r = authed_client.get("/ledgers")
+        assert r.status_code == 200
+        assert "Income" in r.text
+        assert "Expenses" in r.text
+
+    def test_ledgers_page_shows_ledger_name(self, authed_client, db_path):
+        # setup creates Personal; insert another one
+        _insert_ledger(db_path, "MyLedger")
+        r = authed_client.get("/ledgers")
+        assert r.status_code == 200
+        assert "MyLedger" in r.text
+
+    def test_ledgers_page_shows_line_items(self, authed_client, db_path):
+        # setup creates Personal with Salary + Groceries already
+        r = authed_client.get("/ledgers")
+        assert r.status_code == 200
+        assert "Salary" in r.text
+        assert "Groceries" in r.text
+
+
+# ---------------------------------------------------------------------------
+# Tests — POST /ledgers
+# ---------------------------------------------------------------------------
+
+
+class TestCreateLedger:
+    def test_create_ledger_returns_201(self, authed_client):
+        r = authed_client.post("/ledgers", json={"name": "Business"})
+        assert r.status_code == 201
+        data = r.json()
+        assert data["name"] == "Business"
+        assert "id" in data
+
+    def test_create_ledger_missing_name_returns_400(self, authed_client):
+        r = authed_client.post("/ledgers", json={})
+        assert r.status_code == 400
+
+    def test_create_ledger_blank_name_returns_400(self, authed_client):
+        r = authed_client.post("/ledgers", json={"name": "  "})
+        assert r.status_code == 400
+
+    def test_create_ledger_persists(self, authed_client, db_path):
+        authed_client.post("/ledgers", json={"name": "Rental"})
+        from server.db import get_db
+        conn = get_db(db_path)
+        try:
+            row = conn.execute("SELECT name FROM ledgers WHERE name='Rental'").fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+
+
+# ---------------------------------------------------------------------------
+# Tests — DELETE /ledgers/{ledger_id}
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteLedger:
+    def test_delete_ledger_success(self, authed_client, db_path):
+        # setup created Personal; insert a second ledger to delete
+        lid2 = _insert_ledger(db_path, "Business")
+        r = authed_client.delete(f"/ledgers/{lid2}")
+        assert r.status_code == 200
+
+    def test_delete_only_ledger_returns_409(self, authed_client, db_path):
+        # setup creates Personal ledger; use that one (it's the only ledger)
+        from server.db import get_db
+        conn = get_db(db_path)
+        try:
+            row = conn.execute("SELECT id FROM ledgers WHERE name='Personal'").fetchone()
+        finally:
+            conn.close()
+        assert row is not None, "Expected Personal ledger from setup"
+        r = authed_client.delete(f"/ledgers/{row['id']}")
+        assert r.status_code == 409
+
+    def test_delete_ledger_removes_line_items(self, authed_client, db_path):
+        # setup already created Personal; add a second ledger to delete
+        lid2 = _insert_ledger(db_path, "Business")
+        iid = _insert_item(db_path, lid2, "Office", "expense")
+        authed_client.delete(f"/ledgers/{lid2}")
+        from server.db import get_db
+        conn = get_db(db_path)
+        try:
+            row = conn.execute("SELECT id FROM line_items WHERE id=?", (iid,)).fetchone()
+        finally:
+            conn.close()
+        assert row is None
+
+
+# ---------------------------------------------------------------------------
+# Tests — PATCH /ledgers/{ledger_id}
+# ---------------------------------------------------------------------------
+
+
+class TestRenameLedger:
+    def test_rename_ledger_success(self, authed_client, db_path):
+        lid = _insert_ledger(db_path, "Old Name")
+        r = authed_client.patch(f"/ledgers/{lid}", json={"name": "New Name"})
+        assert r.status_code == 200
+        assert r.json()["name"] == "New Name"
+
+    def test_rename_ledger_missing_name_returns_400(self, authed_client, db_path):
+        lid = _insert_ledger(db_path, "Test")
+        r = authed_client.patch(f"/ledgers/{lid}", json={})
+        assert r.status_code == 400
+
+    def test_rename_ledger_not_found_returns_404(self, authed_client):
+        r = authed_client.patch(f"/ledgers/nonexistent-id", json={"name": "X"})
+        assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Tests — POST /ledgers/{ledger_id}/items
+# ---------------------------------------------------------------------------
+
+
+class TestCreateItem:
+    def test_add_income_item(self, authed_client, db_path):
+        lid = _insert_ledger(db_path, "Personal")
+        r = authed_client.post(f"/ledgers/{lid}/items", json={"name": "Salary", "section": "income"})
+        assert r.status_code == 201
+        data = r.json()
+        assert data["name"] == "Salary"
+        assert data["item_type"] == "income"
+
+    def test_add_expense_item(self, authed_client, db_path):
+        lid = _insert_ledger(db_path, "Personal")
+        r = authed_client.post(f"/ledgers/{lid}/items", json={"name": "Groceries", "section": "expenses"})
+        assert r.status_code == 201
+        data = r.json()
+        assert data["item_type"] == "expense"
+
+    def test_add_item_missing_name_returns_400(self, authed_client, db_path):
+        lid = _insert_ledger(db_path, "Personal")
+        r = authed_client.post(f"/ledgers/{lid}/items", json={"section": "expenses"})
+        assert r.status_code == 400
+
+    def test_add_item_ledger_not_found_returns_404(self, authed_client):
+        r = authed_client.post("/ledgers/nonexistent/items", json={"name": "X", "section": "expenses"})
+        assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Tests — PATCH /ledgers/{ledger_id}/items/{item_id}
+# ---------------------------------------------------------------------------
+
+
+class TestRenameItem:
+    def test_rename_item_success(self, authed_client, db_path):
+        lid = _insert_ledger(db_path, "Personal")
+        iid = _insert_item(db_path, lid, "Groceries", "expense")
+        r = authed_client.patch(f"/ledgers/{lid}/items/{iid}", json={"name": "Food"})
+        assert r.status_code == 200
+        assert r.json()["name"] == "Food"
+
+    def test_rename_item_missing_name_returns_400(self, authed_client, db_path):
+        lid = _insert_ledger(db_path, "Personal")
+        iid = _insert_item(db_path, lid, "Groceries", "expense")
+        r = authed_client.patch(f"/ledgers/{lid}/items/{iid}", json={})
+        assert r.status_code == 400
+
+    def test_rename_item_not_found_returns_404(self, authed_client, db_path):
+        lid = _insert_ledger(db_path, "Personal")
+        r = authed_client.patch(f"/ledgers/{lid}/items/nonexistent", json={"name": "X"})
+        assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Tests — DELETE /ledgers/{ledger_id}/items/{item_id}
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteItem:
+    def test_delete_item_success(self, authed_client, db_path):
+        lid = _insert_ledger(db_path, "Personal")
+        iid = _insert_item(db_path, lid, "Groceries", "expense")
+        r = authed_client.delete(f"/ledgers/{lid}/items/{iid}")
+        assert r.status_code == 200
+
+    def test_delete_item_not_found_returns_404(self, authed_client, db_path):
+        lid = _insert_ledger(db_path, "Personal")
+        r = authed_client.delete(f"/ledgers/{lid}/items/nonexistent")
+        assert r.status_code == 404
+
+    def test_delete_item_with_entries_returns_409(self, authed_client, db_path):
+        from server.db import get_db
+        lid = _insert_ledger(db_path, "Personal")
+        iid = _insert_item(db_path, lid, "Groceries", "expense")
+        # Insert a dummy transaction_entry referencing this item
+        conn = get_db(db_path)
+        try:
+            entry_id = str(uuid.uuid4())
+            conn.execute(
+                "INSERT INTO transaction_entries (id, transaction_id, ledger_id, line_item_id, amount)"
+                " VALUES (?, NULL, ?, ?, 10.0)",
+                (entry_id, lid, iid),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        r = authed_client.delete(f"/ledgers/{lid}/items/{iid}")
+        assert r.status_code == 409
+        assert "entry_count" in r.json()
+
+    def test_delete_item_with_entries_confirm_true_succeeds(self, authed_client, db_path):
+        from server.db import get_db
+        lid = _insert_ledger(db_path, "Personal")
+        iid = _insert_item(db_path, lid, "Groceries", "expense")
+        conn = get_db(db_path)
+        try:
+            entry_id = str(uuid.uuid4())
+            conn.execute(
+                "INSERT INTO transaction_entries (id, transaction_id, ledger_id, line_item_id, amount)"
+                " VALUES (?, NULL, ?, ?, 10.0)",
+                (entry_id, lid, iid),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        r = authed_client.delete(f"/ledgers/{lid}/items/{iid}?confirm=true")
+        assert r.status_code == 200

--- a/ui/server.py
+++ b/ui/server.py
@@ -183,12 +183,16 @@ def _get_ledgers() -> list[dict]:
         ledgers = []
         for lr in ledger_rows:
             items = conn.execute(
-                "SELECT name, item_type FROM line_items WHERE ledger_id = ? ORDER BY name",
+                "SELECT id, name, item_type FROM line_items WHERE ledger_id = ? ORDER BY name",
                 (lr["id"],),
             ).fetchall()
             ledgers.append({
+                "id": lr["id"],
                 "name": lr["name"],
-                "line_items": [{"name": i["name"], "item_type": i["item_type"]} for i in items],
+                "line_items": [
+                    {"id": i["id"], "name": i["name"], "item_type": i["item_type"]}
+                    for i in items
+                ],
             })
         return ledgers
     finally:
@@ -644,6 +648,169 @@ def ledgers_get(request: Request):
         "ledgers.html",
         {"ledgers": ledgers},
     )
+
+
+# -- /ledgers CRUD (issue #48) -------------------------------------------------
+
+import uuid as _uuid
+
+
+@app.post("/ledgers")
+async def ledgers_create(request: Request):
+    """Create a new ledger. JSON body: {name: str}."""
+    if not _is_authenticated(request):
+        return JSONResponse({"error": "Unauthorized"}, status_code=401)
+    body = await request.json()
+    name = (body.get("name") or "").strip()
+    if not name:
+        return JSONResponse({"error": "name is required"}, status_code=400)
+    ledger_id = str(_uuid.uuid4())
+    conn = get_db(_db_path())
+    try:
+        conn.execute(
+            "INSERT INTO ledgers (id, name) VALUES (?, ?)",
+            (ledger_id, name),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return JSONResponse({"id": ledger_id, "name": name}, status_code=201)
+
+
+@app.delete("/ledgers/{ledger_id}")
+def ledgers_delete(request: Request, ledger_id: str):
+    """Delete a ledger. Returns 409 if it is the only ledger."""
+    if not _is_authenticated(request):
+        return JSONResponse({"error": "Unauthorized"}, status_code=401)
+    conn = get_db(_db_path())
+    try:
+        count = conn.execute("SELECT COUNT(*) FROM ledgers").fetchone()[0]
+        if count <= 1:
+            return JSONResponse(
+                {"error": "Cannot delete the only ledger"}, status_code=409
+            )
+        conn.execute("DELETE FROM line_items WHERE ledger_id = ?", (ledger_id,))
+        conn.execute("DELETE FROM ledgers WHERE id = ?", (ledger_id,))
+        conn.commit()
+    finally:
+        conn.close()
+    return JSONResponse({"deleted": ledger_id})
+
+
+@app.patch("/ledgers/{ledger_id}")
+async def ledgers_rename(request: Request, ledger_id: str):
+    """Rename a ledger. JSON body: {name: str}."""
+    if not _is_authenticated(request):
+        return JSONResponse({"error": "Unauthorized"}, status_code=401)
+    body = await request.json()
+    name = (body.get("name") or "").strip()
+    if not name:
+        return JSONResponse({"error": "name is required"}, status_code=400)
+    conn = get_db(_db_path())
+    try:
+        row = conn.execute("SELECT id FROM ledgers WHERE id = ?", (ledger_id,)).fetchone()
+        if row is None:
+            return JSONResponse({"error": "Ledger not found"}, status_code=404)
+        conn.execute("UPDATE ledgers SET name = ? WHERE id = ?", (name, ledger_id))
+        conn.commit()
+    finally:
+        conn.close()
+    return JSONResponse({"id": ledger_id, "name": name})
+
+
+@app.post("/ledgers/{ledger_id}/items")
+async def ledger_items_create(request: Request, ledger_id: str):
+    """Add a line item. JSON body: {name: str, section: 'income'|'expenses'}."""
+    if not _is_authenticated(request):
+        return JSONResponse({"error": "Unauthorized"}, status_code=401)
+    body = await request.json()
+    name = (body.get("name") or "").strip()
+    section = (body.get("section") or "expenses").strip().lower()
+    if not name:
+        return JSONResponse({"error": "name is required"}, status_code=400)
+    # Map 'expenses' -> 'expense', 'income' -> 'income'
+    item_type = "income" if section == "income" else "expense"
+    conn = get_db(_db_path())
+    try:
+        row = conn.execute("SELECT id FROM ledgers WHERE id = ?", (ledger_id,)).fetchone()
+        if row is None:
+            return JSONResponse({"error": "Ledger not found"}, status_code=404)
+        item_id = str(_uuid.uuid4())
+        conn.execute(
+            "INSERT INTO line_items (id, ledger_id, name, item_type) VALUES (?, ?, ?, ?)",
+            (item_id, ledger_id, name, item_type),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return JSONResponse(
+        {"id": item_id, "ledger_id": ledger_id, "name": name, "item_type": item_type},
+        status_code=201,
+    )
+
+
+@app.patch("/ledgers/{ledger_id}/items/{item_id}")
+async def ledger_items_rename(request: Request, ledger_id: str, item_id: str):
+    """Rename a line item. JSON body: {name: str}."""
+    if not _is_authenticated(request):
+        return JSONResponse({"error": "Unauthorized"}, status_code=401)
+    body = await request.json()
+    name = (body.get("name") or "").strip()
+    if not name:
+        return JSONResponse({"error": "name is required"}, status_code=400)
+    conn = get_db(_db_path())
+    try:
+        row = conn.execute(
+            "SELECT id FROM line_items WHERE id = ? AND ledger_id = ?",
+            (item_id, ledger_id),
+        ).fetchone()
+        if row is None:
+            return JSONResponse({"error": "Item not found"}, status_code=404)
+        conn.execute("UPDATE line_items SET name = ? WHERE id = ?", (name, item_id))
+        conn.commit()
+    finally:
+        conn.close()
+    return JSONResponse({"id": item_id, "name": name})
+
+
+@app.delete("/ledgers/{ledger_id}/items/{item_id}")
+def ledger_items_delete(request: Request, ledger_id: str, item_id: str):
+    """Delete a line item.  Returns 409 if transaction_entries are attached
+    unless ?confirm=true is supplied."""
+    if not _is_authenticated(request):
+        return JSONResponse({"error": "Unauthorized"}, status_code=401)
+    confirm = request.query_params.get("confirm", "").lower() == "true"
+    conn = get_db(_db_path())
+    try:
+        row = conn.execute(
+            "SELECT id FROM line_items WHERE id = ? AND ledger_id = ?",
+            (item_id, ledger_id),
+        ).fetchone()
+        if row is None:
+            return JSONResponse({"error": "Item not found"}, status_code=404)
+        # Check for attached entries
+        entry_count = conn.execute(
+            "SELECT COUNT(*) FROM transaction_entries WHERE line_item_id = ?",
+            (item_id,),
+        ).fetchone()[0]
+        if entry_count > 0 and not confirm:
+            return JSONResponse(
+                {
+                    "error": "Item has attached transaction entries",
+                    "entry_count": entry_count,
+                    "hint": "Add ?confirm=true to force delete",
+                },
+                status_code=409,
+            )
+        if entry_count > 0 and confirm:
+            conn.execute(
+                "DELETE FROM transaction_entries WHERE line_item_id = ?", (item_id,)
+            )
+        conn.execute("DELETE FROM line_items WHERE id = ?", (item_id,))
+        conn.commit()
+    finally:
+        conn.close()
+    return JSONResponse({"deleted": item_id})
 
 
 # ── /link ─────────────────────────────────────────────────────────────────────

--- a/ui/templates/ledgers.html
+++ b/ui/templates/ledgers.html
@@ -13,39 +13,307 @@
 
 {% block content %}
 <div class="card">
-  <h1>Ledgers</h1>
-  <p class="hint">Read-only view. A minimal ledger editor is coming in issue
-     <strong>#48</strong>.</p>
+  <div style="display:flex;justify-content:space-between;align-items:baseline;">
+    <h1>Ledgers</h1>
+    <button class="btn-primary" id="btn-add-ledger">+ Add Ledger</button>
+  </div>
 
-  {% if ledgers %}
-    {% for ledger in ledgers %}
-    <section class="ledger-block">
-      <h2>{{ ledger.name }}</h2>
-      {% if ledger.line_items %}
-      <table>
-        <thead>
-          <tr>
-            <th>Line item</th>
-            <th>Type</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for item in ledger.line_items %}
-          <tr>
-            <td>{{ item.name }}</td>
-            <td><span class="badge badge-{{ item.item_type }}">{{ item.item_type }}</span></td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-      {% else %}
-      <p class="hint">No line items yet.</p>
-      {% endif %}
-    </section>
-    {% endfor %}
-  {% else %}
-  <p>No ledgers found. Set up a ledger via OpenClaw chat or complete the
-     <a href="/setup">setup wizard</a>.</p>
-  {% endif %}
+  <div id="add-ledger-form" style="display:none;margin-bottom:1em;">
+    <input type="text" id="new-ledger-name" placeholder="Ledger name" style="margin-right:.5em;">
+    <button class="btn-primary" id="btn-add-ledger-submit">Create</button>
+    <button class="btn-secondary" id="btn-add-ledger-cancel">Cancel</button>
+  </div>
+
+  <div id="error-banner" style="display:none;" class="alert alert-error"></div>
+
+  <div id="ledgers-list">
+    {% if ledgers %}
+      {% for ledger in ledgers %}
+      <section class="ledger-block" data-ledger-id="{{ ledger.id }}">
+        <div style="display:flex;justify-content:space-between;align-items:center;">
+          <h2>
+            <span class="ledger-name-display">{{ ledger.name }}</span>
+            <input class="ledger-name-input" type="text" value="{{ ledger.name }}"
+              style="display:none;font-size:inherit;font-weight:inherit;"
+              data-ledger-id="{{ ledger.id }}">
+          </h2>
+          <button class="btn-danger btn-delete-ledger" data-ledger-id="{{ ledger.id }}"
+            style="margin-left:1em;">x</button>
+        </div>
+
+        <div class="item-section" data-section="income">
+          <h3>Income</h3>
+          <table>
+            <tbody class="items-tbody" data-section="income">
+              {% for item in ledger.line_items %}
+              {% if item.item_type == "income" %}
+              <tr data-item-id="{{ item.id }}">
+                <td>
+                  <span class="item-name-display">{{ item.name }}</span>
+                  <input class="item-name-input" type="text" value="{{ item.name }}"
+                    style="display:none;" data-item-id="{{ item.id }}"
+                    data-ledger-id="{{ ledger.id }}">
+                </td>
+                <td>
+                  <button class="btn-danger btn-delete-item" data-item-id="{{ item.id }}"
+                    data-ledger-id="{{ ledger.id }}">x</button>
+                </td>
+              </tr>
+              {% endif %}
+              {% endfor %}
+            </tbody>
+          </table>
+          <div class="add-item-row">
+            <input type="text" class="add-item-input" placeholder="Add item..."
+              data-ledger-id="{{ ledger.id }}" data-section="income">
+          </div>
+        </div>
+
+        <div class="item-section" data-section="expenses">
+          <h3>Expenses</h3>
+          <table>
+            <tbody class="items-tbody" data-section="expenses">
+              {% for item in ledger.line_items %}
+              {% if item.item_type == "expense" %}
+              <tr data-item-id="{{ item.id }}">
+                <td>
+                  <span class="item-name-display">{{ item.name }}</span>
+                  <input class="item-name-input" type="text" value="{{ item.name }}"
+                    style="display:none;" data-item-id="{{ item.id }}"
+                    data-ledger-id="{{ ledger.id }}">
+                </td>
+                <td>
+                  <button class="btn-danger btn-delete-item" data-item-id="{{ item.id }}"
+                    data-ledger-id="{{ ledger.id }}">x</button>
+                </td>
+              </tr>
+              {% endif %}
+              {% endfor %}
+            </tbody>
+          </table>
+          <div class="add-item-row">
+            <input type="text" class="add-item-input" placeholder="Add item..."
+              data-ledger-id="{{ ledger.id }}" data-section="expenses">
+          </div>
+        </div>
+      </section>
+      {% endfor %}
+    {% else %}
+    <p id="no-ledgers-msg">No ledgers yet. Click <strong>+ Add Ledger</strong> to create one.</p>
+    {% endif %}
+  </div>
 </div>
+
+<script>
+(function () {
+  "use strict";
+
+  function showError(msg) {
+    var b = document.getElementById("error-banner");
+    b.textContent = msg;
+    b.style.display = "";
+    setTimeout(function () { b.style.display = "none"; }, 5000);
+  }
+
+  document.getElementById("btn-add-ledger").addEventListener("click", function () {
+    document.getElementById("add-ledger-form").style.display = "";
+    document.getElementById("new-ledger-name").focus();
+  });
+
+  document.getElementById("btn-add-ledger-cancel").addEventListener("click", function () {
+    document.getElementById("add-ledger-form").style.display = "none";
+    document.getElementById("new-ledger-name").value = "";
+  });
+
+  document.getElementById("btn-add-ledger-submit").addEventListener("click", function () {
+    var name = document.getElementById("new-ledger-name").value.trim();
+    if (!name) return;
+    fetch("/ledgers", {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({name: name})
+    }).then(function (r) {
+      if (!r.ok) return r.json().then(function (d) { showError(d.error || "Error"); });
+      return r.json().then(function (data) {
+        document.getElementById("add-ledger-form").style.display = "none";
+        document.getElementById("new-ledger-name").value = "";
+        var msg = document.getElementById("no-ledgers-msg");
+        if (msg) msg.remove();
+        document.getElementById("ledgers-list").appendChild(buildLedgerSection(data.id, data.name));
+      });
+    }).catch(function (e) { showError(e.message); });
+  });
+
+  document.addEventListener("click", function (e) {
+    if (!e.target.classList.contains("btn-delete-ledger")) return;
+    var ledgerId = e.target.dataset.ledgerId;
+    if (!confirm("Delete this ledger and all its line items?")) return;
+    fetch("/ledgers/" + ledgerId, {method: "DELETE"}).then(function (r) {
+      if (r.status === 409) return r.json().then(function (d) { showError(d.error || "Cannot delete."); });
+      if (!r.ok) return r.json().then(function (d) { showError(d.error || "Error"); });
+      var section = document.querySelector("section[data-ledger-id='" + ledgerId + "']");
+      if (section) section.remove();
+    }).catch(function (e) { showError(e.message); });
+  });
+
+  document.addEventListener("click", function (e) {
+    if (!e.target.classList.contains("ledger-name-display")) return;
+    var section = e.target.closest("section[data-ledger-id]");
+    var ledgerId = section.dataset.ledgerId;
+    var display = e.target;
+    var input = section.querySelector("input.ledger-name-input[data-ledger-id='" + ledgerId + "']");
+    display.style.display = "none";
+    input.style.display = "";
+    input.focus();
+    input.select();
+  });
+
+  document.addEventListener("blur", function (e) {
+    if (!e.target.classList.contains("ledger-name-input")) return;
+    var input = e.target;
+    var ledgerId = input.dataset.ledgerId;
+    var name = input.value.trim();
+    var section = document.querySelector("section[data-ledger-id='" + ledgerId + "']");
+    var display = section.querySelector("span.ledger-name-display");
+    if (!name) { input.style.display = "none"; display.style.display = ""; return; }
+    fetch("/ledgers/" + ledgerId, {
+      method: "PATCH",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({name: name})
+    }).then(function (r) {
+      if (!r.ok) return r.json().then(function (d) { showError(d.error || "Rename failed"); });
+      display.textContent = name;
+      input.style.display = "none";
+      display.style.display = "";
+    }).catch(function (e) { showError(e.message); });
+  }, true);
+
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Enter" && e.target.classList.contains("ledger-name-input")) e.target.blur();
+  });
+
+  document.addEventListener("keydown", function (e) {
+    if (e.key !== "Enter" || !e.target.classList.contains("add-item-input")) return;
+    var input = e.target;
+    var ledgerId = input.dataset.ledgerId;
+    var section = input.dataset.section;
+    var name = input.value.trim();
+    if (!name) return;
+    fetch("/ledgers/" + ledgerId + "/items", {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({name: name, section: section})
+    }).then(function (r) {
+      if (!r.ok) return r.json().then(function (d) { showError(d.error || "Error"); });
+      return r.json().then(function (data) {
+        input.value = "";
+        var tbody = input.closest(".item-section").querySelector("tbody.items-tbody");
+        tbody.appendChild(buildItemRow(data.id, data.name, ledgerId));
+      });
+    }).catch(function (e) { showError(e.message); });
+  });
+
+  document.addEventListener("click", function (e) {
+    if (!e.target.classList.contains("btn-delete-item")) return;
+    var itemId = e.target.dataset.itemId;
+    var ledgerId = e.target.dataset.ledgerId;
+    fetch("/ledgers/" + ledgerId + "/items/" + itemId, {method: "DELETE"})
+      .then(function (r) {
+        if (r.status === 409) {
+          return r.json().then(function (d) {
+            if (confirm(d.error + " (" + d.entry_count + " entries). Force delete?")) {
+              fetch("/ledgers/" + ledgerId + "/items/" + itemId + "?confirm=true", {method: "DELETE"})
+                .then(function (r2) {
+                  if (!r2.ok) return r2.json().then(function (d2) { showError(d2.error || "Error"); });
+                  removeItemRow(itemId);
+                });
+            }
+          });
+        }
+        if (!r.ok) return r.json().then(function (d) { showError(d.error || "Error"); });
+        removeItemRow(itemId);
+      }).catch(function (e) { showError(e.message); });
+  });
+
+  function removeItemRow(itemId) {
+    var row = document.querySelector("tr[data-item-id='" + itemId + "']");
+    if (row) row.remove();
+  }
+
+  document.addEventListener("click", function (e) {
+    if (!e.target.classList.contains("item-name-display")) return;
+    var row = e.target.closest("tr[data-item-id]");
+    var display = e.target;
+    var input = row.querySelector("input.item-name-input");
+    display.style.display = "none";
+    input.style.display = "";
+    input.focus();
+    input.select();
+  });
+
+  document.addEventListener("blur", function (e) {
+    if (!e.target.classList.contains("item-name-input")) return;
+    var input = e.target;
+    var itemId = input.dataset.itemId;
+    var ledgerId = input.dataset.ledgerId;
+    var name = input.value.trim();
+    var row = document.querySelector("tr[data-item-id='" + itemId + "']");
+    var display = row.querySelector("span.item-name-display");
+    if (!name) { input.style.display = "none"; display.style.display = ""; return; }
+    fetch("/ledgers/" + ledgerId + "/items/" + itemId, {
+      method: "PATCH",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({name: name})
+    }).then(function (r) {
+      if (!r.ok) return r.json().then(function (d) { showError(d.error || "Rename failed"); });
+      display.textContent = name;
+      input.value = name;
+      input.style.display = "none";
+      display.style.display = "";
+    }).catch(function (e) { showError(e.message); });
+  }, true);
+
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Enter" && e.target.classList.contains("item-name-input")) e.target.blur();
+  });
+
+  function buildItemRow(itemId, name, ledgerId) {
+    var tr = document.createElement("tr");
+    tr.dataset.itemId = itemId;
+    tr.innerHTML =
+      '<td><span class="item-name-display">' + esc(name) + '</span>' +
+      '<input class="item-name-input" type="text" value="' + esc(name) + '"' +
+      ' style="display:none;" data-item-id="' + itemId + '" data-ledger-id="' + ledgerId + '"></td>' +
+      '<td><button class="btn-danger btn-delete-item" data-item-id="' + itemId +
+      '" data-ledger-id="' + ledgerId + '">x</button></td>';
+    return tr;
+  }
+
+  function buildLedgerSection(ledgerId, name) {
+    var section = document.createElement("section");
+    section.className = "ledger-block";
+    section.dataset.ledgerId = ledgerId;
+    section.innerHTML =
+      '<div style="display:flex;justify-content:space-between;align-items:center;">' +
+      '<h2><span class="ledger-name-display">' + esc(name) + '</span>' +
+      '<input class="ledger-name-input" type="text" value="' + esc(name) + '"' +
+      ' style="display:none;font-size:inherit;font-weight:inherit;" data-ledger-id="' + ledgerId + '"></h2>' +
+      '<button class="btn-danger btn-delete-ledger" data-ledger-id="' + ledgerId + '" style="margin-left:1em;">x</button>' +
+      '</div>' + sub(ledgerId, "income", "Income") + sub(ledgerId, "expenses", "Expenses");
+    return section;
+  }
+
+  function sub(ledgerId, key, label) {
+    return '<div class="item-section" data-section="' + key + '">' +
+      '<h3>' + label + '</h3>' +
+      '<table><tbody class="items-tbody" data-section="' + key + '"></tbody></table>' +
+      '<div class="add-item-row"><input type="text" class="add-item-input" placeholder="Add item..."' +
+      ' data-ledger-id="' + ledgerId + '" data-section="' + key + '"></div></div>';
+  }
+
+  function esc(s) {
+    return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;");
+  }
+})();
+</script>
 {% endblock %}


### PR DESCRIPTION
Closes #48

Replaces the read-only ledger tree with a minimal structure editor. All interactions are inline via vanilla JS `fetch()` — no framework, no build step.

**What's in this PR:**
- 6 new REST endpoints on `/ledgers` (create, rename, delete ledger; add, rename, delete line item) with full auth guards and appropriate error codes (409 for last-ledger delete, 409 for item delete with attached transaction entries unless `?confirm=true`)
- Updated `ledgers.html`: Income/Expenses subsections per ledger, click-to-edit names, + Add Ledger button, add-item inputs at the bottom of each subsection, × delete buttons
- 28 new tests in `tests/test_ui_ledgers.py` covering auth guards and all CRUD endpoints

**Interactive check:** Started server on port 6790, authenticated via `/login`, confirmed `GET /ledgers` returns 200 with "Income", "Expenses", and "Add Ledger" in the HTML.