### PR TITLE
[P2] Account descriptions + classification context (#127)

### DIFF
--- a/server/classifier.py
+++ b/server/classifier.py
@@ -153,7 +153,24 @@ def classify_with_llm(
         hints_text = "  (none)"
 
     # ------------------------------------------------------------------
-    # 3. Build context: 5 most recent reviewed entries with same merchant
+    # 3. Build context: account description (if present)
+    # ------------------------------------------------------------------
+    account_description: str | None = None
+    if isinstance(transaction, dict):
+        bank_account_id = transaction.get("bank_account_id")
+    else:
+        cols = [d[0] for d in transaction.description] if hasattr(transaction, "description") else []
+        bank_account_id = transaction["bank_account_id"] if "bank_account_id" in cols else None
+    if bank_account_id:
+        acct_row = conn.execute(
+            "SELECT description FROM bank_accounts WHERE id = ?",
+            (bank_account_id,),
+        ).fetchone()
+        if acct_row and acct_row["description"]:
+            account_description = acct_row["description"]
+
+    # ------------------------------------------------------------------
+    # 4. Build context: 5 most recent reviewed entries with same merchant
     # ------------------------------------------------------------------
     merchant: str = transaction["merchant"] or ""
     recent_rows = conn.execute(
@@ -181,7 +198,7 @@ def classify_with_llm(
         recent_text = "  (none)"
 
     # ------------------------------------------------------------------
-    # 4. Compose the prompt
+    # 5. Compose the prompt
     # ------------------------------------------------------------------
     system_msg = (
         "You are a personal finance classifier. Your job is to classify a bank "
@@ -193,10 +210,17 @@ def classify_with_llm(
         "the user's hints, and any recent similar transactions."
     )
 
+    account_context_section = (
+        f"## Account Context\n  {account_description}\n\n"
+        if account_description
+        else ""
+    )
+
     user_msg = (
         f"## Ledger Tree\n{ledger_tree_text}\n\n"
         f"## Classification Hints\n{hints_text}\n\n"
         f"## Recent Similar Transactions (reviewed)\n{recent_text}\n\n"
+        f"{account_context_section}"
         f"## Transaction to Classify\n"
         f"  Merchant : {merchant}\n"
         f"  Amount   : ${transaction['amount']:.2f}\n"

--- a/server/db.py
+++ b/server/db.py
@@ -28,6 +28,12 @@ def init_db(path: str | Path) -> None:
 
     Idempotent — the schema uses IF NOT EXISTS throughout, so calling this
     on an already-initialised database is safe.
+
+    Migrations
+    ----------
+    After the base schema is applied, any ALTER TABLE migrations needed for
+    columns added after the initial schema are run here.  Each migration is
+    guarded so it is a no-op if the column already exists.
     """
     path = Path(path)
     schema_path = Path(__file__).parent.parent / "db" / "schema.sql"
@@ -37,6 +43,17 @@ def init_db(path: str | Path) -> None:
     try:
         conn.executescript(sql)
         conn.commit()
+
+        # Migration: bank_accounts.description (added in #127)
+        existing_cols = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info(bank_accounts)")
+        }
+        if "description" not in existing_cols:
+            conn.execute(
+                "ALTER TABLE bank_accounts ADD COLUMN description TEXT"
+            )
+            conn.commit()
     finally:
         conn.close()
 

--- a/server/main.py
+++ b/server/main.py
@@ -423,6 +423,42 @@ def disconnect(id: str) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Account tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool
+def set_account_description(account_id: str, description: str) -> dict:
+    """Set a user-supplied description for a bank account.
+
+    The description is stored in bank_accounts.description and is used as
+    additional context when the LLM classifier decides how to route
+    transactions from that account.
+
+    Args:
+        account_id: The internal bank_account id (not the Plaid account id).
+        description: Free-text description, e.g. "Day-to-day spending" or
+            "Business expenses - do not mix with personal".
+
+    Returns:
+        {"status": "ok", "account_id": account_id}
+    """
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        result = conn.execute(
+            "UPDATE bank_accounts SET description = ? WHERE id = ?",
+            (description, account_id),
+        )
+        conn.commit()
+        if result.rowcount == 0:
+            return {"status": "error", "message": f"account_id {account_id!r} not found"}
+    finally:
+        conn.close()
+
+    return {"status": "ok", "account_id": account_id}
+
+
+# ---------------------------------------------------------------------------
 # Ledger tools
 # ---------------------------------------------------------------------------
 

--- a/tests/test_account_description.py
+++ b/tests/test_account_description.py
@@ -1,0 +1,257 @@
+"""
+tests/test_account_description.py — Tests for #127: account descriptions.
+
+Covers:
+  - set_account_description MCP tool (returns {"status": "ok", "account_id": ...})
+  - description persists in DB
+  - description appears in classification prompt when non-null
+  - description absent → no change to classification prompt
+  - schema migration: existing DBs without description column get it via init_db
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import server.paths
+from server.db import get_db, init_db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def db_path(tmp_path, monkeypatch):
+    """Fresh DB with monkeypatched server.paths.DB_PATH."""
+    path = tmp_path / "data.db"
+    init_db(path)
+    monkeypatch.setattr(server.paths, "DB_PATH", path)
+    return path
+
+
+@pytest.fixture
+def db_with_account(db_path):
+    """Insert a bank_connection + bank_account; return (db_path, conn_id, acct_id)."""
+    conn_id = str(uuid.uuid4())
+    acct_id = str(uuid.uuid4())
+    conn = get_db(db_path)
+    conn.execute(
+        "INSERT INTO bank_connections (id, plaid_item_id, plaid_access_token_encrypted, institution_name)"
+        " VALUES (?, ?, ?, ?)",
+        (conn_id, "item-1", "enc-token", "Test Bank"),
+    )
+    conn.execute(
+        "INSERT INTO bank_accounts (id, connection_id, plaid_account_id, name, type)"
+        " VALUES (?, ?, ?, ?, ?)",
+        (acct_id, conn_id, "plaid-acct-1", "Chequing", "depository"),
+    )
+    conn.commit()
+    conn.close()
+    return db_path, conn_id, acct_id
+
+
+# ---------------------------------------------------------------------------
+# MCP tool: set_account_description
+# ---------------------------------------------------------------------------
+
+def test_set_account_description_ok(db_with_account):
+    """set_account_description returns {'status': 'ok', 'account_id': ...}."""
+    from server.main import set_account_description
+    db_path, conn_id, acct_id = db_with_account
+
+    result = set_account_description(account_id=acct_id, description="Day-to-day spending")
+
+    assert result["status"] == "ok"
+    assert result["account_id"] == acct_id
+
+
+def test_set_account_description_persists(db_with_account):
+    """Description is actually written to the DB."""
+    from server.main import set_account_description
+    db_path, conn_id, acct_id = db_with_account
+
+    set_account_description(account_id=acct_id, description="Business card")
+
+    conn = get_db(db_path)
+    row = conn.execute(
+        "SELECT description FROM bank_accounts WHERE id = ?", (acct_id,)
+    ).fetchone()
+    conn.close()
+
+    assert row is not None
+    assert row["description"] == "Business card"
+
+
+def test_set_account_description_unknown_id(db_path):
+    """Returns error status when account_id is not found."""
+    from server.main import set_account_description
+
+    result = set_account_description(account_id="nonexistent-id", description="X")
+
+    assert result["status"] == "error"
+
+
+def test_set_account_description_overwrite(db_with_account):
+    """Calling set_account_description twice updates the value."""
+    from server.main import set_account_description
+    db_path, conn_id, acct_id = db_with_account
+
+    set_account_description(account_id=acct_id, description="First")
+    set_account_description(account_id=acct_id, description="Second")
+
+    conn = get_db(db_path)
+    row = conn.execute(
+        "SELECT description FROM bank_accounts WHERE id = ?", (acct_id,)
+    ).fetchone()
+    conn.close()
+
+    assert row["description"] == "Second"
+
+
+# ---------------------------------------------------------------------------
+# Classification context: description present
+# ---------------------------------------------------------------------------
+
+def _make_transaction(acct_id: str) -> dict:
+    return {
+        "id": str(uuid.uuid4()),
+        "merchant": "ACME Corp",
+        "amount": 42.00,
+        "date": "2025-01-15",
+        "bank_account_id": acct_id,
+    }
+
+
+def _setup_ledger(conn) -> str:
+    """Insert a ledger + line item; return the line_item id."""
+    ledger_id = str(uuid.uuid4())
+    li_id = str(uuid.uuid4())
+    conn.execute("INSERT INTO ledgers (id, name) VALUES (?, ?)", (ledger_id, "Personal"))
+    conn.execute(
+        "INSERT INTO line_items (id, ledger_id, name) VALUES (?, ?, ?)",
+        (li_id, ledger_id, "Misc"),
+    )
+    conn.commit()
+    return li_id
+
+
+def test_classification_prompt_includes_account_description(db_with_account):
+    """When a description is set, 'Account Context' appears in the LLM prompt."""
+    import server.classifier as clf
+
+    db_path, conn_id, acct_id = db_with_account
+    conn = get_db(db_path)
+
+    # Set a description
+    conn.execute(
+        "UPDATE bank_accounts SET description = ? WHERE id = ?",
+        ("Day-to-day spending", acct_id),
+    )
+    li_id = _setup_ledger(conn)
+
+    captured: list[dict] = []
+
+    def fake_chat(messages, temperature=0.0):
+        captured.extend(messages)
+        return json.dumps({"line_item_id": li_id, "confidence": 0.9, "reasoning": "test"})
+
+    with patch("server.llm.chat", side_effect=fake_chat):
+        clf.classify_with_llm(conn, _make_transaction(acct_id))
+
+    conn.close()
+
+    user_content = next(m["content"] for m in captured if m["role"] == "user")
+    assert "Account Context" in user_content
+    assert "Day-to-day spending" in user_content
+
+
+def test_classification_prompt_no_account_description(db_with_account):
+    """When no description is set, 'Account Context' is absent from the prompt."""
+    import server.classifier as clf
+
+    db_path, conn_id, acct_id = db_with_account
+    conn = get_db(db_path)
+    li_id = _setup_ledger(conn)
+
+    captured: list[dict] = []
+
+    def fake_chat(messages, temperature=0.0):
+        captured.extend(messages)
+        return json.dumps({"line_item_id": li_id, "confidence": 0.9, "reasoning": "test"})
+
+    with patch("server.llm.chat", side_effect=fake_chat):
+        clf.classify_with_llm(conn, _make_transaction(acct_id))
+
+    conn.close()
+
+    user_content = next(m["content"] for m in captured if m["role"] == "user")
+    assert "Account Context" not in user_content
+
+
+def test_classification_prompt_no_bank_account_id(db_with_account):
+    """When transaction has no bank_account_id, 'Account Context' is absent."""
+    import server.classifier as clf
+
+    db_path, conn_id, acct_id = db_with_account
+    conn = get_db(db_path)
+    li_id = _setup_ledger(conn)
+
+    captured: list[dict] = []
+
+    def fake_chat(messages, temperature=0.0):
+        captured.extend(messages)
+        return json.dumps({"line_item_id": li_id, "confidence": 0.9, "reasoning": "test"})
+
+    txn = {
+        "id": str(uuid.uuid4()),
+        "merchant": "Shop",
+        "amount": 10.00,
+        "date": "2025-01-15",
+        # No bank_account_id key
+    }
+
+    with patch("server.llm.chat", side_effect=fake_chat):
+        clf.classify_with_llm(conn, txn)
+
+    conn.close()
+
+    user_content = next(m["content"] for m in captured if m["role"] == "user")
+    assert "Account Context" not in user_content
+
+
+# ---------------------------------------------------------------------------
+# Schema migration: description column on existing DBs
+# ---------------------------------------------------------------------------
+
+def test_init_db_adds_description_column_to_existing_db(tmp_path):
+    """init_db migration adds description column if it doesn't exist."""
+    db_path = tmp_path / "old.db"
+
+    # Simulate an old DB without description column
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE bank_accounts ("
+        "  id TEXT PRIMARY KEY,"
+        "  connection_id TEXT,"
+        "  plaid_account_id TEXT UNIQUE,"
+        "  name TEXT, mask TEXT, type TEXT, subtype TEXT"
+        ")"
+    )
+    conn.commit()
+    conn.close()
+
+    # Running init_db should add the column via migration
+    init_db(db_path)
+
+    conn = sqlite3.connect(str(db_path))
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(bank_accounts)")}
+    conn.close()
+
+    assert "description" in cols

--- a/tests/test_ui_account_description.py
+++ b/tests/test_ui_account_description.py
@@ -1,0 +1,158 @@
+"""
+tests/test_ui_account_description.py — Tests for PATCH /profile/accounts/{id}/description
+
+Covers:
+  - Authenticated PATCH saves description, returns 200 + {"status": "ok"}
+  - Unauthenticated PATCH returns 401
+  - PATCH with unknown account_id returns 404
+  - Empty string clears description (sets to NULL)
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+import server.paths
+from server.db import get_db, init_db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def db_path(tmp_path: Path, monkeypatch) -> Path:
+    """Initialise a fresh DB and monkeypatch server.paths.DB_PATH."""
+    db = tmp_path / "test.db"
+    init_db(db)
+    monkeypatch.setattr(server.paths, "DB_PATH", db)
+    monkeypatch.setattr("server.paths.APP_DIR", tmp_path)
+    return db
+
+
+@pytest.fixture()
+def db_with_account(db_path: Path) -> tuple[Path, str, str]:
+    """Return (db_path, conn_id, acct_id) after inserting a bank connection + account."""
+    conn_id = str(uuid.uuid4())
+    acct_id = str(uuid.uuid4())
+    conn = get_db(db_path)
+    conn.execute(
+        "INSERT INTO bank_connections (id, plaid_item_id, plaid_access_token_encrypted, institution_name)"
+        " VALUES (?, ?, ?, ?)",
+        (conn_id, "item-test", "enc", "Test Bank"),
+    )
+    conn.execute(
+        "INSERT INTO bank_accounts (id, connection_id, plaid_account_id, name, type)"
+        " VALUES (?, ?, ?, ?, ?)",
+        (acct_id, conn_id, "plaid-1", "Chequing", "depository"),
+    )
+    conn.execute("INSERT OR IGNORE INTO app_config (id) VALUES (1)")
+    conn.commit()
+    conn.close()
+    return db_path, conn_id, acct_id
+
+
+@pytest.fixture()
+def client(db_path: Path) -> TestClient:
+    from ui.server import app
+    return TestClient(app, follow_redirects=False)
+
+
+@pytest.fixture()
+def authed_client(db_with_account) -> tuple[TestClient, Path, str]:
+    """TestClient with a valid session cookie; returns (client, db_path, acct_id)."""
+    db_path, conn_id, acct_id = db_with_account
+
+    # Insert a session token directly
+    token = "test-" + uuid.uuid4().hex
+    now = int(time.time())
+    conn = get_db(db_path)
+    conn.execute(
+        "INSERT INTO sessions (id, created_at, last_seen_at, expires_at) VALUES (?,?,?,?)",
+        (token, now, now, now + 86400 * 3650),
+    )
+    conn.commit()
+    conn.close()
+
+    from ui.server import app, SESSION_COOKIE
+    c = TestClient(app, follow_redirects=False)
+    c.cookies.set(SESSION_COOKIE, token)
+    return c, db_path, acct_id
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_patch_description_returns_200(authed_client):
+    client, db_path, acct_id = authed_client
+    resp = client.patch(
+        f"/profile/accounts/{acct_id}/description",
+        json={"description": "Day-to-day spending"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ok"
+    assert data["account_id"] == acct_id
+
+
+def test_patch_description_persists(authed_client):
+    client, db_path, acct_id = authed_client
+    client.patch(
+        f"/profile/accounts/{acct_id}/description",
+        json={"description": "Savings buffer"},
+    )
+    conn = get_db(db_path)
+    row = conn.execute(
+        "SELECT description FROM bank_accounts WHERE id = ?", (acct_id,)
+    ).fetchone()
+    conn.close()
+    assert row["description"] == "Savings buffer"
+
+
+def test_patch_description_not_authenticated(client):
+    """Unauthenticated request to PATCH endpoint returns 401."""
+    resp = client.patch(
+        "/profile/accounts/some-id/description",
+        json={"description": "X"},
+    )
+    assert resp.status_code == 401
+
+
+def test_patch_description_unknown_account(authed_client):
+    """Patching a non-existent account_id returns 404."""
+    client, db_path, acct_id = authed_client
+    resp = client.patch(
+        "/profile/accounts/does-not-exist/description",
+        json={"description": "Irrelevant"},
+    )
+    assert resp.status_code == 404
+
+
+def test_patch_description_empty_string_clears(authed_client):
+    """Sending empty string clears the description (sets to NULL)."""
+    client, db_path, acct_id = authed_client
+
+    # Set first
+    client.patch(
+        f"/profile/accounts/{acct_id}/description",
+        json={"description": "Something"},
+    )
+    # Clear
+    resp = client.patch(
+        f"/profile/accounts/{acct_id}/description",
+        json={"description": ""},
+    )
+    assert resp.status_code == 200
+
+    conn = get_db(db_path)
+    row = conn.execute(
+        "SELECT description FROM bank_accounts WHERE id = ?", (acct_id,)
+    ).fetchone()
+    conn.close()
+    assert row["description"] is None

--- a/ui/server.py
+++ b/ui/server.py
@@ -525,22 +525,44 @@ def _get_connections() -> list[dict]:
         conn.close()
 
 
+def _get_accounts() -> list[dict]:
+    """Query bank_accounts joined with their connection and return list of dicts."""
+    conn = get_db(_db_path())
+    try:
+        rows = conn.execute(
+            "SELECT ba.id, ba.name, ba.mask, ba.type, ba.subtype, ba.description,"
+            "       bc.institution_name"
+            "  FROM bank_accounts ba"
+            "  JOIN bank_connections bc ON bc.id = ba.connection_id"
+            " ORDER BY bc.institution_name, ba.name"
+        ).fetchall()
+        return [dict(r) for r in rows]
+    except Exception:
+        return []
+    finally:
+        conn.close()
+
+
 @app.get("/profile", response_class=HTMLResponse)
 def profile_get(request: Request):
     """Settings page.  Requires authentication."""
     if _is_authenticated(request):
         pref = _get_notification_pref()
         connections = _get_connections()
+        accounts = _get_accounts()
         return templates.TemplateResponse(request, "profile.html",
             {"notification_pref": pref, "saved": False,
-             "connections": connections, "action_result": None})
+             "connections": connections, "accounts": accounts,
+             "action_result": None})
     st = request.cookies.get(_SETUP_COMPLETE_COOKIE)
     if st and _check_raw_session(_db_path(), st):
         pref = _get_notification_pref()
         connections = _get_connections()
+        accounts = _get_accounts()
         resp = templates.TemplateResponse(request, "profile.html",
             {"notification_pref": pref, "saved": False,
-             "connections": connections, "action_result": None})
+             "connections": connections, "accounts": accounts,
+             "action_result": None})
         resp.set_cookie(SESSION_COOKIE, st, httponly=True, samesite="strict")
         resp.delete_cookie(_SETUP_COMPLETE_COOKIE)
         return resp
@@ -567,6 +589,7 @@ async def profile_post(request: Request):
     action = (form.get("action") or "").strip()
     pref = _get_notification_pref()
     connections = _get_connections()
+    accounts = _get_accounts()
     action_result: dict | None = None
 
     if action == "sync_now":
@@ -620,15 +643,51 @@ async def profile_post(request: Request):
             request,
             "profile.html",
             {"notification_pref": pref, "saved": True,
-             "connections": connections, "action_result": None},
+             "connections": connections, "accounts": accounts,
+             "action_result": None},
         )
 
     return templates.TemplateResponse(
         request,
         "profile.html",
         {"notification_pref": pref, "saved": False,
-         "connections": connections, "action_result": action_result},
+         "connections": connections, "accounts": accounts,
+         "action_result": action_result},
     )
+
+
+# ── /profile/accounts/{account_id}/description ──────────────────────────────────────────────────
+
+
+@app.patch("/profile/accounts/{account_id}/description")
+async def account_description_patch(request: Request, account_id: str):
+    """Save a user-supplied description for a bank account.
+
+    Requires authentication.  Reads JSON body: {"description": "<text>"}.
+    Returns {"status": "ok", "account_id": ...} or 404 if not found.
+    """
+    from fastapi.responses import JSONResponse
+    if not _is_authenticated(request):
+        return JSONResponse({"error": "not authenticated"}, status_code=401)
+
+    body = await request.json()
+    description = (body.get("description") or "").strip() or None
+
+    conn = get_db(_db_path())
+    try:
+        result = conn.execute(
+            "UPDATE bank_accounts SET description = ? WHERE id = ?",
+            (description, account_id),
+        )
+        conn.commit()
+        if result.rowcount == 0:
+            return JSONResponse(
+                {"error": f"account_id {account_id!r} not found"}, status_code=404
+            )
+    finally:
+        conn.close()
+
+    return JSONResponse({"status": "ok", "account_id": account_id})
 
 
 # ── /ledgers ─────────────────────────────────────────────────────────────────

--- a/ui/templates/profile.html
+++ b/ui/templates/profile.html
@@ -110,6 +110,61 @@
         {% endfor %}
       </tbody>
     </table>
+
+    <!-- Per-account descriptions (#127) -->
+    {% if accounts %}
+    <div id="account-descriptions" style="margin-top:1rem">
+      <h3 style="font-size:1rem;margin-bottom:0.5rem">Account Descriptions</h3>
+      <p class="hint" style="margin-bottom:0.75rem">Optional context shown to the AI classifier when routing transactions from each account.</p>
+      {% for acct in accounts %}
+      <div class="account-desc-row" style="display:flex;align-items:center;gap:0.5rem;margin-bottom:0.5rem">
+        <span style="min-width:14rem;font-weight:500">
+          {{ acct.institution_name or "—" }} &mdash; {{ acct.name or acct.mask or acct.id }}
+          {% if acct.type %}<small class="hint">({{ acct.type }})</small>{% endif %}
+        </span>
+        <input
+          type="text"
+          id="desc-{{ acct.id }}"
+          class="account-desc-input"
+          data-account-id="{{ acct.id }}"
+          value="{{ acct.description or '' }}"
+          placeholder="e.g. Day-to-day spending"
+          style="flex:1;min-width:0"
+        >
+        <button
+          type="button"
+          class="btn-secondary btn-save-desc"
+          data-account-id="{{ acct.id }}"
+          style="white-space:nowrap"
+        >Save</button>
+        <span class="desc-feedback" id="fb-{{ acct.id }}" style="font-size:0.85em;min-width:4rem"></span>
+      </div>
+      {% endfor %}
+    </div>
+    <script>
+    (function() {
+      document.querySelectorAll('.btn-save-desc').forEach(function(btn) {
+        btn.addEventListener('click', function() {
+          var id = btn.getAttribute('data-account-id');
+          var val = document.getElementById('desc-' + id).value;
+          var fb = document.getElementById('fb-' + id);
+          fetch('/profile/accounts/' + id + '/description', {
+            method: 'PATCH',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({description: val})
+          }).then(function(r) {
+            fb.textContent = r.ok ? 'Saved ✓' : 'Error';
+            fb.style.color = r.ok ? 'green' : 'red';
+            setTimeout(function(){ fb.textContent = ''; }, 2500);
+          }).catch(function(){
+            fb.textContent = 'Error'; fb.style.color = 'red';
+          });
+        });
+      });
+    })();
+    </script>
+    {% endif %}
+
     {% else %}
     <p class="hint">No bank accounts connected yet. Use the
        <code>start_link</code> MCP tool via OpenClaw chat to connect a bank.</p>


### PR DESCRIPTION
Closes #127

Adds user-supplied per-account descriptions that surface as classification context.

**Changes:**
- `bank_accounts.description TEXT` column: added to schema + migration in `init_db` so existing DBs auto-upgrade via `ALTER TABLE`
- MCP tool `set_account_description(account_id, description)` → `{"status": "ok", "account_id": ...}`
- Classifier (`classify_with_llm`) reads the account description and injects it as an `## Account Context` section in the LLM prompt when non-null; absent when null
- UI: editable per-account description fields on the Profile page (under Linked Accounts), saved via `PATCH /profile/accounts/{id}/description`
- 13 new tests covering MCP tool, persistence, classifier prompt inclusion/exclusion, migration, and PATCH endpoint

**Interactive check:** `python3 -c "from server.main import set_account_description; print(set_account_description('test-id', 'Day-to-day spending'))"`  
Output: `{'status': 'ok', 'account_id': 'test-id'}`