### PR TITLE
[P2] Multi-profile support: users table + per-user data isolation (#131)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ This doc is the operating manual for agent contributors.
 ## Anti-Patterns (Don't Do These)
 
 - ❌ Refactoring code outside your ticket
-- ❌ Adding multi-user logic ("for future flexibility")
+- ❌ Adding multi-user logic ("for future flexibility") — multi-profile is ✅ (see issue #131); concurrent sessions are ❌
 - ❌ Building a CLI on top of MCP tools
 - ❌ Adding a web UI element beyond the existing Plaid Link page
 - ❌ Pulling in ORMs, async frameworks, or "nice to have" libraries

--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@ to your banks, classifying every transaction, and keeping a spreadsheet
 up to date. It runs as a small daemon on your Mac with **multiple equal
 ways to interact with it** - no single one is the "main" way.
 
-**Single user. Local-only. AI does the heavy lifting; you stay in control.**
+**Local profiles. Local-only. AI does the heavy lifting; you stay in control.**
+
+Supports multiple named local profiles — each with their own password, linked banks,
+ledgers, and transactions. Only one profile can be active at a time (like switching
+accounts on a Mac, not a SaaS system).
 
 📐 [Read the architecture](./ARCHITECTURE.md) (this is the source of truth)
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,6 +1,14 @@
 -- Friday Budgeting Pro — SQLite schema
 -- Single-user, local-only personal finance database.
 
+-- Users (local profiles — multiple allowed, one active at a time)
+CREATE TABLE IF NOT EXISTS users (
+  id TEXT PRIMARY KEY,             -- UUID
+  username TEXT UNIQUE NOT NULL,
+  password_hash TEXT NOT NULL,     -- argon2id hash
+  created_at INTEGER NOT NULL
+);
+
 -- Plaid bank connections
 CREATE TABLE IF NOT EXISTS bank_connections (
   id TEXT PRIMARY KEY,
@@ -8,7 +16,8 @@ CREATE TABLE IF NOT EXISTS bank_connections (
   plaid_access_token_encrypted TEXT NOT NULL,
   institution_name TEXT,
   status TEXT DEFAULT 'active',  -- active | needs_reauth
-  last_synced_at INTEGER
+  last_synced_at INTEGER,
+  user_id TEXT REFERENCES users(id)
 );
 
 CREATE TABLE IF NOT EXISTS bank_accounts (
@@ -24,7 +33,8 @@ CREATE TABLE IF NOT EXISTS bank_accounts (
 -- Tracking structure (usually just one ledger called "Personal")
 CREATE TABLE IF NOT EXISTS ledgers (
   id TEXT PRIMARY KEY,
-  name TEXT NOT NULL
+  name TEXT NOT NULL,
+  user_id TEXT REFERENCES users(id)
 );
 
 CREATE TABLE IF NOT EXISTS line_items (
@@ -67,7 +77,8 @@ CREATE TABLE IF NOT EXISTS routing_rules (
 -- Tier 2: natural-language hints fed to the LLM
 CREATE TABLE IF NOT EXISTS classification_hints (
   id TEXT PRIMARY KEY,
-  text TEXT NOT NULL
+  text TEXT NOT NULL,
+  user_id TEXT REFERENCES users(id)
 );
 
 -- Plaid sync cursors
@@ -95,7 +106,8 @@ CREATE TABLE IF NOT EXISTS sessions (
   created_at INTEGER NOT NULL,
   last_seen_at INTEGER NOT NULL,
   expires_at INTEGER NOT NULL,  -- TODO: unused; kept for backward compat with existing DBs
-  user_agent TEXT
+  user_agent TEXT,
+  user_id TEXT REFERENCES users(id)
 );
 
 -- Notification log — every send() call writes a row; the UI reads this for banners

--- a/server/db.py
+++ b/server/db.py
@@ -35,6 +35,9 @@ def init_db(path: str | Path) -> None:
     columns added after the initial schema are run here.  Each migration is
     guarded so it is a no-op if the column already exists.
     """
+    import uuid as _uuid
+    import time as _time
+
     path = Path(path)
     schema_path = Path(__file__).parent.parent / "db" / "schema.sql"
     sql = schema_path.read_text()
@@ -45,17 +48,92 @@ def init_db(path: str | Path) -> None:
         conn.commit()
 
         # Migration: bank_accounts.description (added in #127)
-        existing_cols = {
-            row[1]
-            for row in conn.execute("PRAGMA table_info(bank_accounts)")
-        }
-        if "description" not in existing_cols:
-            conn.execute(
-                "ALTER TABLE bank_accounts ADD COLUMN description TEXT"
-            )
+        ba_cols = {row[1] for row in conn.execute("PRAGMA table_info(bank_accounts)")}
+        if "description" not in ba_cols:
+            conn.execute("ALTER TABLE bank_accounts ADD COLUMN description TEXT")
             conn.commit()
+
+        # Migration: user_id columns (#131 — multi-profile support)
+        # These are guarded so they are no-ops if the column already exists.
+        _add_col_if_missing(conn, "bank_connections", "user_id", "TEXT")
+        _add_col_if_missing(conn, "ledgers", "user_id", "TEXT")
+        _add_col_if_missing(conn, "classification_hints", "user_id", "TEXT")
+        _add_col_if_missing(conn, "sessions", "user_id", "TEXT")
+
+        # Migration: create default user only when there is existing data to migrate
+        # (i.e. rows exist that need a user_id) but no users have been created yet.
+        # On truly fresh DBs, we leave users empty so the setup wizard can create
+        # the first user with a real username and password.
+        user_count = conn.execute("SELECT COUNT(*) FROM users").fetchone()[0]
+        if user_count == 0:
+            # Check if any existing rows need migration
+            existing_data = (
+                conn.execute("SELECT COUNT(*) FROM bank_connections").fetchone()[0] > 0
+                or conn.execute("SELECT COUNT(*) FROM ledgers").fetchone()[0] > 0
+                or conn.execute("SELECT COUNT(*) FROM classification_hints").fetchone()[0] > 0
+                or conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] > 0
+            )
+
+            # Also check if app_config has a password hash (old single-user DB)
+            legacy_hash: str | None = None
+            try:
+                row = conn.execute(
+                    "SELECT ui_password_hash FROM app_config WHERE id = 1"
+                ).fetchone()
+                if row and row[0]:
+                    legacy_hash = row[0]
+            except Exception:
+                pass
+
+            if existing_data or legacy_hash is not None:
+                # This is a legacy single-user DB — create the default user.
+                default_user_id = "default-user-id"
+                now = int(_time.time())
+
+                if legacy_hash is None:
+                    # Has data but no password hash — use a non-verifiable placeholder.
+                    import secrets as _secrets
+                    from argon2 import PasswordHasher as _PH
+                    legacy_hash = _PH().hash(_secrets.token_hex(32))
+
+                conn.execute(
+                    "INSERT INTO users (id, username, password_hash, created_at) "
+                    "VALUES (?, ?, ?, ?)",
+                    (default_user_id, "default", legacy_hash, now),
+                )
+                conn.commit()
+
+                # Backfill NULL user_id on all existing rows.
+                for table in ("bank_connections", "ledgers", "classification_hints", "sessions"):
+                    conn.execute(
+                        f"UPDATE {table} SET user_id = ? WHERE user_id IS NULL",
+                        (default_user_id,),
+                    )
+                conn.commit()
+            # else: fresh DB, no migration needed — setup wizard creates the first user.
+        else:
+            # Users already exist — backfill any rows that slipped through without a user_id.
+            default_user_row = conn.execute(
+                "SELECT id FROM users ORDER BY created_at LIMIT 1"
+            ).fetchone()
+            if default_user_row:
+                first_uid = default_user_row["id"]
+                for table in ("bank_connections", "ledgers", "classification_hints", "sessions"):
+                    conn.execute(
+                        f"UPDATE {table} SET user_id = ? WHERE user_id IS NULL",
+                        (first_uid,),
+                    )
+                conn.commit()
     finally:
         conn.close()
+
+
+def _add_col_if_missing(conn: sqlite3.Connection, table: str, col: str, col_type: str) -> None:
+    """ALTER TABLE to add *col* if it is not already present."""
+    existing = {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+    if col not in existing:
+        conn.execute(f"ALTER TABLE {table} ADD COLUMN {col} {col_type}")
+        conn.commit()
 
 
 @contextmanager

--- a/server/main.py
+++ b/server/main.py
@@ -30,6 +30,7 @@ import server.paths
 import server.crypto
 from server.providers.plaid import PlaidProvider
 import server.health_monitor
+from ui.auth import get_active_user_id
 
 _plaid = PlaidProvider()
 
@@ -153,19 +154,49 @@ def _register_openclaw_cron() -> bool:
 
 
 @mcp.tool
+def list_profiles() -> dict:
+    """Return a list of local profiles (usernames).
+
+    Does not require authentication.  Returns usernames only (no hashes).
+    """
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        rows = conn.execute(
+            "SELECT id, username, created_at FROM users ORDER BY created_at"
+        ).fetchall()
+        return {
+            "profiles": [
+                {"id": r["id"], "username": r["username"], "created_at": r["created_at"]}
+                for r in rows
+            ]
+        }
+    finally:
+        conn.close()
+
+
+@mcp.tool
 def setup_status() -> dict:
     """Return whether initial setup is not_started, in_progress, or complete.
 
     Status rules:
-      - "not_started"  → 0 ledgers AND 0 bank_connections
+      - "not_started"  → 0 ledgers AND 0 bank_connections (for current user)
       - "in_progress"  → ≥1 ledger AND 0 bank_connections
                          (user picked a ledger but hasn't linked a bank yet)
       - "complete"     → ≥1 ledger AND ≥1 bank_connection
     """
+    uid = get_active_user_id(server.paths.DB_PATH)
     conn = get_db(server.paths.DB_PATH)
     try:
-        ledger_count = conn.execute("SELECT COUNT(*) FROM ledgers").fetchone()[0]
-        bank_count = conn.execute("SELECT COUNT(*) FROM bank_connections").fetchone()[0]
+        if uid:
+            ledger_count = conn.execute(
+                "SELECT COUNT(*) FROM ledgers WHERE user_id = ?", (uid,)
+            ).fetchone()[0]
+            bank_count = conn.execute(
+                "SELECT COUNT(*) FROM bank_connections WHERE user_id = ?", (uid,)
+            ).fetchone()[0]
+        else:
+            ledger_count = conn.execute("SELECT COUNT(*) FROM ledgers").fetchone()[0]
+            bank_count = conn.execute("SELECT COUNT(*) FROM bank_connections").fetchone()[0]
     finally:
         conn.close()
 
@@ -241,23 +272,31 @@ def apply_initial_setup(
     line_items_created = 0
     hints_created = 0
 
+    uid = get_active_user_id(server.paths.DB_PATH)
+
     conn = get_db(server.paths.DB_PATH)
     try:
         with db_txn(conn):
             for spec in ledger_specs:
                 ledger_name = spec["name"]
 
-                # Upsert ledger — skip if already present.
-                existing_ledger = conn.execute(
-                    "SELECT id FROM ledgers WHERE name = ?", (ledger_name,)
-                ).fetchone()
+                # Upsert ledger — skip if already present for this user.
+                if uid:
+                    existing_ledger = conn.execute(
+                        "SELECT id FROM ledgers WHERE name = ? AND user_id = ?",
+                        (ledger_name, uid),
+                    ).fetchone()
+                else:
+                    existing_ledger = conn.execute(
+                        "SELECT id FROM ledgers WHERE name = ?", (ledger_name,)
+                    ).fetchone()
                 if existing_ledger:
                     ledger_id = existing_ledger["id"]
                 else:
                     ledger_id = str(uuid.uuid4())
                     conn.execute(
-                        "INSERT INTO ledgers (id, name) VALUES (?, ?)",
-                        (ledger_id, ledger_name),
+                        "INSERT INTO ledgers (id, name, user_id) VALUES (?, ?, ?)",
+                        (ledger_id, ledger_name, uid),
                     )
                     ledgers_created.append(ledger_name)
 
@@ -279,15 +318,21 @@ def apply_initial_setup(
 
             # Upsert hints — de-dupe on exact text.
             for hint_text in (hints or []):
-                existing_hint = conn.execute(
-                    "SELECT id FROM classification_hints WHERE text = ?",
-                    (hint_text,),
-                ).fetchone()
+                if uid:
+                    existing_hint = conn.execute(
+                        "SELECT id FROM classification_hints WHERE text = ? AND user_id = ?",
+                        (hint_text, uid),
+                    ).fetchone()
+                else:
+                    existing_hint = conn.execute(
+                        "SELECT id FROM classification_hints WHERE text = ?",
+                        (hint_text,),
+                    ).fetchone()
                 if existing_hint:
                     continue
                 conn.execute(
-                    "INSERT INTO classification_hints (id, text) VALUES (?, ?)",
-                    (str(uuid.uuid4()), hint_text),
+                    "INSERT INTO classification_hints (id, text, user_id) VALUES (?, ?, ?)",
+                    (str(uuid.uuid4()), hint_text, uid),
                 )
                 hints_created += 1
     finally:
@@ -338,16 +383,17 @@ def complete_link(public_token: str) -> dict:
 
     encrypted_token = server.crypto.encrypt(access_token)
     connection_id = str(uuid.uuid4())
+    uid = get_active_user_id(server.paths.DB_PATH)
 
     conn = get_db(server.paths.DB_PATH)
     try:
         conn.execute(
             """
             INSERT INTO bank_connections
-                (id, plaid_item_id, plaid_access_token_encrypted, status)
-            VALUES (?, ?, ?, 'active')
+                (id, plaid_item_id, plaid_access_token_encrypted, status, user_id)
+            VALUES (?, ?, ?, 'active', ?)
             """,
-            (connection_id, item_id, encrypted_token),
+            (connection_id, item_id, encrypted_token, uid),
         )
         conn.commit()
     finally:
@@ -358,20 +404,25 @@ def complete_link(public_token: str) -> dict:
 
 @mcp.tool
 def list_connections() -> dict:
-    """List all saved Plaid bank connections.
+    """List all saved bank connections for the current user.
 
     Returns id, institution_name, status, and last_synced_at for each
     connection.  The encrypted access token is NEVER included in the output.
     """
+    uid = get_active_user_id(server.paths.DB_PATH)
     conn = get_db(server.paths.DB_PATH)
     try:
-        rows = conn.execute(
-            """
-            SELECT id, institution_name, status, last_synced_at
-            FROM bank_connections
-            ORDER BY rowid
-            """
-        ).fetchall()
+        if uid:
+            rows = conn.execute(
+                "SELECT id, institution_name, status, last_synced_at "
+                "FROM bank_connections WHERE user_id = ? ORDER BY rowid",
+                (uid,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT id, institution_name, status, last_synced_at "
+                "FROM bank_connections ORDER BY rowid"
+            ).fetchall()
         connections = [dict(r) for r in rows]
     finally:
         conn.close()
@@ -824,22 +875,29 @@ def route(transaction_id: str, allocations: List) -> dict:
 
 @mcp.tool
 def add_hint(text: str) -> dict:
-    """Save a natural-language classification hint."""
+    """Save a natural-language classification hint for the current user."""
     cleaned = text.strip()
     if len(cleaned) < 1:
         raise ValueError("hint text must be non-empty")
+    uid = get_active_user_id(server.paths.DB_PATH)
     conn = get_db(server.paths.DB_PATH)
     try:
-        existing = conn.execute(
-            "SELECT id FROM classification_hints WHERE text = ?",
-            (cleaned,),
-        ).fetchone()
+        if uid:
+            existing = conn.execute(
+                "SELECT id FROM classification_hints WHERE text = ? AND user_id = ?",
+                (cleaned, uid),
+            ).fetchone()
+        else:
+            existing = conn.execute(
+                "SELECT id FROM classification_hints WHERE text = ?",
+                (cleaned,),
+            ).fetchone()
         if existing:
             return {"id": existing["id"], "text": cleaned, "created": False}
         new_id = str(uuid.uuid4())
         conn.execute(
-            "INSERT INTO classification_hints (id, text) VALUES (?, ?)",
-            (new_id, cleaned),
+            "INSERT INTO classification_hints (id, text, user_id) VALUES (?, ?, ?)",
+            (new_id, cleaned, uid),
         )
         conn.commit()
         return {"id": new_id, "text": cleaned, "created": True}
@@ -849,12 +907,19 @@ def add_hint(text: str) -> dict:
 
 @mcp.tool
 def list_hints() -> dict:
-    """Return all classification hints."""
+    """Return all classification hints for the current user."""
+    uid = get_active_user_id(server.paths.DB_PATH)
     conn = get_db(server.paths.DB_PATH)
     try:
-        rows = conn.execute(
-            "SELECT id, text FROM classification_hints ORDER BY rowid"
-        ).fetchall()
+        if uid:
+            rows = conn.execute(
+                "SELECT id, text FROM classification_hints WHERE user_id = ? ORDER BY rowid",
+                (uid,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT id, text FROM classification_hints ORDER BY rowid"
+            ).fetchall()
         return {"hints": [{"id": row["id"], "text": row["text"]} for row in rows]}
     finally:
         conn.close()

--- a/tests/test_multi_profile.py
+++ b/tests/test_multi_profile.py
@@ -1,0 +1,541 @@
+"""
+tests/test_multi_profile.py — Tests for multi-profile support (#131).
+
+Covers:
+  - Profile creation via create_user helper
+  - Login with username+password
+  - Data isolation (user A can't see user B's bank connections / ledgers)
+  - list_profiles() MCP tool
+  - Migration: existing single-user DB gets wrapped in default profile
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def db_path(tmp_path: Path, monkeypatch) -> Path:
+    """Initialise a fresh SQLite DB and monkeypatch paths."""
+    from server.db import init_db
+    import server.paths as paths
+
+    db = tmp_path / "test_multi_profile.db"
+    init_db(db)
+
+    monkeypatch.setattr(paths, "DB_PATH", db)
+    monkeypatch.setattr(paths, "APP_DIR", tmp_path)
+    return db
+
+
+@pytest.fixture()
+def client(db_path: Path) -> TestClient:
+    from ui.server import app
+    return TestClient(app, follow_redirects=False)
+
+
+def _do_setup(client: TestClient, username: str = "alice", password: str = "alicepass123") -> None:
+    """Drive the setup wizard to completion (creates first user)."""
+    r = client.post("/setup/1", data={
+        "username": username,
+        "password": password,
+        "password_confirm": password,
+    })
+    assert r.status_code == 200
+    r = client.post("/setup/2", data={"notification_pref": "openclaw"})
+    assert r.status_code == 200
+    r = client.post("/setup/3", data={"ledger_name": "Personal"})
+    assert r.status_code == 200
+    r = client.post("/setup/4", data={})
+    assert r.status_code == 302
+
+
+def _login(client: TestClient, username: str = "alice", password: str = "alicepass123") -> TestClient:
+    """Log in and return the client with session cookie."""
+    r = client.post("/login", data={"username": username, "password": password})
+    assert r.status_code == 302, f"Login failed (status {r.status_code})"
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Profile creation
+# ---------------------------------------------------------------------------
+
+class TestProfileCreation:
+    def test_create_user_helper(self, db_path):
+        from ui.auth import create_user, get_user_by_username
+        uid = create_user(db_path, "bob", "bobspassword1")
+        assert uid is not None
+        user = get_user_by_username(db_path, "bob")
+        assert user is not None
+        assert user["username"] == "bob"
+        assert user["id"] == uid
+
+    def test_duplicate_username_raises(self, db_path):
+        from ui.auth import create_user
+        create_user(db_path, "dup", "password12")
+        with pytest.raises(ValueError, match="already taken"):
+            create_user(db_path, "dup", "password12")
+
+    def test_has_any_user_false_on_fresh_db(self, db_path):
+        """Fresh DB (no data) has no users — setup wizard creates the first one."""
+        from ui.auth import has_any_user
+        assert has_any_user(db_path) is False
+
+    def test_list_users_returns_created_users(self, db_path):
+        from ui.auth import create_user, list_users
+        create_user(db_path, "u1", "password11")
+        create_user(db_path, "u2", "password22")
+        users = list_users(db_path)
+        usernames = {u["username"] for u in users}
+        assert "u1" in usernames
+        assert "u2" in usernames
+
+    def test_create_profile_via_ui(self, client, db_path):
+        """Create profile via the profile page UI action."""
+        _do_setup(client, "alice", "alicepass123")
+        _login(client, "alice", "alicepass123")
+
+        r = client.post("/profile", data={
+            "action": "create_profile",
+            "new_username": "bob",
+            "new_password": "bobpassword1",
+        })
+        assert r.status_code == 200
+        assert b"bob" in r.content
+
+        from ui.auth import get_user_by_username
+        bob = get_user_by_username(db_path, "bob")
+        assert bob is not None
+
+    def test_create_profile_short_password_rejected(self, client):
+        """Short passwords are rejected."""
+        _do_setup(client, "alice", "alicepass123")
+        _login(client, "alice", "alicepass123")
+        r = client.post("/profile", data={
+            "action": "create_profile",
+            "new_username": "bob",
+            "new_password": "short",
+        })
+        assert r.status_code == 200
+        assert b"8 characters" in r.content or b"short" in r.content.lower() or b"least" in r.content
+
+
+# ---------------------------------------------------------------------------
+# Login with username+password
+# ---------------------------------------------------------------------------
+
+class TestLoginWithUsernamePwd:
+    def test_login_requires_username_when_multiple_users(self, client, db_path):
+        """When multiple users exist, login without username fails."""
+        _do_setup(client, "alice", "alicepass123")
+        from ui.auth import create_user
+        create_user(db_path, "bob", "bobpassword1")
+
+        fresh = TestClient(client.app, follow_redirects=False)
+        r = fresh.post("/login", data={"password": "alicepass123"})
+        # Should fail because no username and multiple users
+        assert r.status_code == 200  # re-rendered login with error
+        assert b"Incorrect" in r.content or b"username" in r.content.lower()
+
+    def test_login_single_user_no_username_needed(self, client):
+        """With one user, login works without username (backward compat)."""
+        _do_setup(client, "alice", "alicepass123")
+        # Log out first
+        client.post("/logout")
+        fresh = TestClient(client.app, follow_redirects=False)
+        r = fresh.post("/login", data={"password": "alicepass123"})
+        # Single user — should work
+        assert r.status_code == 302
+
+    def test_login_with_username(self, client):
+        _do_setup(client, "alice", "alicepass123")
+        fresh = TestClient(client.app, follow_redirects=False)
+        r = fresh.post("/login", data={"username": "alice", "password": "alicepass123"})
+        assert r.status_code == 302
+        assert r.headers["location"] == "/profile"
+
+    def test_login_wrong_password_fails(self, client):
+        _do_setup(client, "alice", "alicepass123")
+        fresh = TestClient(client.app, follow_redirects=False)
+        r = fresh.post("/login", data={"username": "alice", "password": "wrongpassword"})
+        assert r.status_code == 200
+        assert b"Incorrect" in r.content
+
+    def test_login_unknown_username_fails(self, client):
+        _do_setup(client, "alice", "alicepass123")
+        fresh = TestClient(client.app, follow_redirects=False)
+        r = fresh.post("/login", data={"username": "nobody", "password": "alicepass123"})
+        assert r.status_code == 200
+        assert b"Incorrect" in r.content
+
+    def test_session_carries_user_id(self, client, db_path):
+        """After login, the session row has the correct user_id."""
+        from server.db import get_db
+        from ui.auth import SESSION_COOKIE, get_user_by_username
+
+        _do_setup(client, "alice", "alicepass123")
+        fresh = TestClient(client.app, follow_redirects=False)
+        r = fresh.post("/login", data={"username": "alice", "password": "alicepass123"})
+        assert r.status_code == 302
+
+        token = fresh.cookies.get(SESSION_COOKIE)
+        assert token is not None
+
+        conn = get_db(db_path)
+        try:
+            row = conn.execute(
+                "SELECT user_id FROM sessions WHERE id = ?", (token,)
+            ).fetchone()
+        finally:
+            conn.close()
+
+        alice = get_user_by_username(db_path, "alice")
+        assert alice is not None
+        assert row is not None
+        assert row["user_id"] == alice["id"]
+
+
+# ---------------------------------------------------------------------------
+# Data isolation
+# ---------------------------------------------------------------------------
+
+class TestDataIsolation:
+    def test_bank_connections_are_isolated(self, db_path):
+        """Bank connections created for user A are not visible to user B."""
+        from server.db import get_db
+        from ui.auth import create_user
+
+        uid_a = create_user(db_path, "userA", "passwordabc1")
+        uid_b = create_user(db_path, "userB", "passwordabc2")
+
+        conn = get_db(db_path)
+        try:
+            # Insert a connection for user A
+            conn.execute(
+                "INSERT INTO bank_connections (id, plaid_access_token_encrypted, status, user_id) "
+                "VALUES (?, ?, 'active', ?)",
+                (str(uuid.uuid4()), "encrypted_token_a", uid_a),
+            )
+            conn.commit()
+
+            a_conns = conn.execute(
+                "SELECT id FROM bank_connections WHERE user_id = ?", (uid_a,)
+            ).fetchall()
+            b_conns = conn.execute(
+                "SELECT id FROM bank_connections WHERE user_id = ?", (uid_b,)
+            ).fetchall()
+        finally:
+            conn.close()
+
+        assert len(a_conns) == 1
+        assert len(b_conns) == 0
+
+    def test_ledgers_are_isolated(self, db_path):
+        """Ledgers created for user A are not visible to user B."""
+        from server.db import get_db
+        from ui.auth import create_user
+
+        uid_a = create_user(db_path, "ledger_a", "passwordabc1")
+        uid_b = create_user(db_path, "ledger_b", "passwordabc2")
+
+        conn = get_db(db_path)
+        try:
+            conn.execute(
+                "INSERT INTO ledgers (id, name, user_id) VALUES (?, ?, ?)",
+                (str(uuid.uuid4()), "Alice Budget", uid_a),
+            )
+            conn.commit()
+
+            a_ledgers = conn.execute(
+                "SELECT id FROM ledgers WHERE user_id = ?", (uid_a,)
+            ).fetchall()
+            b_ledgers = conn.execute(
+                "SELECT id FROM ledgers WHERE user_id = ?", (uid_b,)
+            ).fetchall()
+        finally:
+            conn.close()
+
+        assert len(a_ledgers) == 1
+        assert len(b_ledgers) == 0
+
+    def test_hints_are_isolated(self, db_path):
+        """Classification hints created for user A are not visible to user B."""
+        from server.db import get_db
+        from ui.auth import create_user
+
+        uid_a = create_user(db_path, "hint_a", "passwordabc1")
+        uid_b = create_user(db_path, "hint_b", "passwordabc2")
+
+        conn = get_db(db_path)
+        try:
+            conn.execute(
+                "INSERT INTO classification_hints (id, text, user_id) VALUES (?, ?, ?)",
+                (str(uuid.uuid4()), "Always grocery for Walmart", uid_a),
+            )
+            conn.commit()
+
+            a_hints = conn.execute(
+                "SELECT id FROM classification_hints WHERE user_id = ?", (uid_a,)
+            ).fetchall()
+            b_hints = conn.execute(
+                "SELECT id FROM classification_hints WHERE user_id = ?", (uid_b,)
+            ).fetchall()
+        finally:
+            conn.close()
+
+        assert len(a_hints) == 1
+        assert len(b_hints) == 0
+
+    def test_profile_page_shows_only_current_user_connections(self, client, db_path):
+        """Profile page only shows bank connections for the logged-in user."""
+        from ui.auth import create_user
+        from server.db import get_db
+
+        _do_setup(client, "alice", "alicepass123")
+        uid_alice = client.app  # placeholder
+
+        # Create bob's user and a connection for bob
+        uid_bob = create_user(db_path, "bob", "bobpassword1")
+        conn = get_db(db_path)
+        try:
+            conn.execute(
+                "INSERT INTO bank_connections (id, plaid_access_token_encrypted, "
+                "status, institution_name, user_id) VALUES (?, ?, 'active', ?, ?)",
+                (str(uuid.uuid4()), "enc_token", "Bob's Secret Bank", uid_bob),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Alice's profile page should NOT show Bob's bank
+        _login(client, "alice", "alicepass123")
+        r = client.get("/profile")
+        assert r.status_code == 200
+        assert b"Bob's Secret Bank" not in r.content
+
+
+# ---------------------------------------------------------------------------
+# list_profiles() MCP tool
+# ---------------------------------------------------------------------------
+
+class TestListProfilesMCP:
+    def test_list_profiles_returns_list(self, db_path, monkeypatch):
+        """list_profiles() returns a list (not a stub or error)."""
+        import server.paths as paths
+        monkeypatch.setattr(paths, "DB_PATH", db_path)
+
+        from server.main import list_profiles
+        result = list_profiles()
+        assert isinstance(result, dict)
+        assert "profiles" in result
+        assert isinstance(result["profiles"], list)
+
+    def test_list_profiles_includes_created_users(self, db_path, monkeypatch):
+        import server.paths as paths
+        monkeypatch.setattr(paths, "DB_PATH", db_path)
+
+        from ui.auth import create_user
+        create_user(db_path, "carol", "carolpass12")
+        create_user(db_path, "dave", "davepass123")
+
+        from server.main import list_profiles
+        result = list_profiles()
+        usernames = {p["username"] for p in result["profiles"]}
+        assert "carol" in usernames
+        assert "dave" in usernames
+
+    def test_list_profiles_no_password_hash_exposed(self, db_path, monkeypatch):
+        """Password hashes must not appear in list_profiles output."""
+        import server.paths as paths
+        monkeypatch.setattr(paths, "DB_PATH", db_path)
+
+        from server.main import list_profiles
+        result = list_profiles()
+        for profile in result["profiles"]:
+            assert "password_hash" not in profile
+            assert "password" not in profile
+
+
+# ---------------------------------------------------------------------------
+# Migration: existing single-user DB
+# ---------------------------------------------------------------------------
+
+class TestMigration:
+    def test_existing_db_gets_default_user(self, tmp_path):
+        """A DB with existing rows but no users table gets a default user on init_db."""
+        db_file = tmp_path / "legacy.db"
+
+        # Create a "legacy" DB with the old schema (no users table, no user_id columns)
+        conn = sqlite3.connect(str(db_file))
+        conn.executescript("""
+            CREATE TABLE IF NOT EXISTS bank_connections (
+                id TEXT PRIMARY KEY,
+                plaid_item_id TEXT UNIQUE,
+                plaid_access_token_encrypted TEXT NOT NULL,
+                institution_name TEXT,
+                status TEXT DEFAULT 'active',
+                last_synced_at INTEGER
+            );
+            CREATE TABLE IF NOT EXISTS ledgers (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS classification_hints (
+                id TEXT PRIMARY KEY,
+                text TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS sessions (
+                id TEXT PRIMARY KEY,
+                created_at INTEGER NOT NULL,
+                last_seen_at INTEGER NOT NULL,
+                expires_at INTEGER NOT NULL,
+                user_agent TEXT
+            );
+            CREATE TABLE IF NOT EXISTS app_config (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                username TEXT,
+                ui_password_hash TEXT,
+                ui_password_set_at INTEGER
+            );
+            INSERT INTO bank_connections (id, plaid_access_token_encrypted, status)
+                VALUES ('bc-1', 'enc_token', 'active');
+            INSERT INTO ledgers (id, name) VALUES ('led-1', 'Personal');
+            INSERT INTO classification_hints (id, text) VALUES ('hint-1', 'Test hint');
+        """)
+        conn.commit()
+        conn.close()
+
+        # Run init_db — should create users table + default user + backfill user_id
+        from server.db import init_db
+        init_db(db_file)
+
+        conn = sqlite3.connect(str(db_file))
+        conn.row_factory = sqlite3.Row
+        try:
+            # A default user should exist
+            users = conn.execute("SELECT id, username FROM users").fetchall()
+            assert len(users) >= 1
+
+            default_uid = users[0]["id"]
+
+            # Existing rows should have been backfilled with user_id
+            bc = conn.execute("SELECT user_id FROM bank_connections WHERE id = 'bc-1'").fetchone()
+            assert bc is not None
+            assert bc["user_id"] == default_uid
+
+            led = conn.execute("SELECT user_id FROM ledgers WHERE id = 'led-1'").fetchone()
+            assert led is not None
+            assert led["user_id"] == default_uid
+
+            hint = conn.execute("SELECT user_id FROM classification_hints WHERE id = 'hint-1'").fetchone()
+            assert hint is not None
+            assert hint["user_id"] == default_uid
+        finally:
+            conn.close()
+
+    def test_migration_uses_legacy_password_hash(self, tmp_path):
+        """If app_config has a password hash, it is copied to the default user."""
+        from argon2 import PasswordHasher
+        db_file = tmp_path / "legacy_pw.db"
+
+        ph = PasswordHasher()
+        legacy_hash = ph.hash("mysecretpassword")
+
+        conn = sqlite3.connect(str(db_file))
+        conn.executescript(f"""
+            CREATE TABLE IF NOT EXISTS ledgers (id TEXT PRIMARY KEY, name TEXT NOT NULL);
+            CREATE TABLE IF NOT EXISTS bank_connections (
+                id TEXT PRIMARY KEY,
+                plaid_access_token_encrypted TEXT NOT NULL,
+                status TEXT DEFAULT 'active'
+            );
+            CREATE TABLE IF NOT EXISTS classification_hints (id TEXT PRIMARY KEY, text TEXT NOT NULL);
+            CREATE TABLE IF NOT EXISTS sessions (
+                id TEXT PRIMARY KEY,
+                created_at INTEGER NOT NULL,
+                last_seen_at INTEGER NOT NULL,
+                expires_at INTEGER NOT NULL,
+                user_agent TEXT
+            );
+            CREATE TABLE IF NOT EXISTS app_config (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                username TEXT,
+                ui_password_hash TEXT,
+                ui_password_set_at INTEGER
+            );
+            INSERT INTO app_config (id, ui_password_hash) VALUES (1, '{legacy_hash}');
+        """)
+        conn.commit()
+        conn.close()
+
+        from server.db import init_db
+        init_db(db_file)
+
+        from ui.auth import verify_password, get_password_hash
+        stored = get_password_hash(db_file)
+        assert stored is not None
+        assert verify_password("mysecretpassword", stored)
+
+    def test_init_db_idempotent_with_existing_users(self, db_path):
+        """Re-running init_db does not create duplicate users."""
+        from server.db import init_db
+        from ui.auth import list_users
+
+        # init_db was already called (by the db_path fixture)
+        count_before = len(list_users(db_path))
+
+        init_db(db_path)
+
+        count_after = len(list_users(db_path))
+        assert count_after == count_before
+
+    def test_delete_profile_removes_data(self, db_path):
+        """Deleting a profile removes all associated data."""
+        from ui.auth import create_user, delete_user, list_users, get_user_by_username
+        from server.db import get_db
+
+        uid = create_user(db_path, "tobedeleted", "password123")
+
+        conn = get_db(db_path)
+        try:
+            conn.execute(
+                "INSERT INTO bank_connections (id, plaid_access_token_encrypted, status, user_id) "
+                "VALUES (?, 'enc', 'active', ?)",
+                (str(uuid.uuid4()), uid),
+            )
+            conn.execute(
+                "INSERT INTO ledgers (id, name, user_id) VALUES (?, 'Budget', ?)",
+                (str(uuid.uuid4()), uid),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        delete_user(db_path, uid)
+
+        assert get_user_by_username(db_path, "tobedeleted") is None
+
+        conn = get_db(db_path)
+        try:
+            bc = conn.execute(
+                "SELECT id FROM bank_connections WHERE user_id = ?", (uid,)
+            ).fetchall()
+            leds = conn.execute(
+                "SELECT id FROM ledgers WHERE user_id = ?", (uid,)
+            ).fetchall()
+        finally:
+            conn.close()
+
+        assert len(bc) == 0
+        assert len(leds) == 0

--- a/ui/auth.py
+++ b/ui/auth.py
@@ -3,6 +3,7 @@ ui/auth.py — Auth helpers for Friday Budgeting Pro UI.
 
 Implements:
   - argon2id password hashing via argon2-cffi
+  - Multi-profile user management (users table)
   - Permanent sessions (persist until explicit logout — no idle expiry)
   - No login rate limiting (single-user local app per d4403c0)
 """
@@ -11,6 +12,7 @@ from __future__ import annotations
 
 import secrets
 import time
+import uuid
 from typing import Optional
 
 from argon2 import PasswordHasher
@@ -26,7 +28,7 @@ SESSION_COOKIE = "friday_bp_session"
 _ph = PasswordHasher()
 
 
-# ── Time helper (used by set_password_hash / create_session for timestamps) ──
+# ── Time helper ──────────────────────────────────────────────────────────
 
 def _now() -> int:
     """Return the current Unix timestamp as an integer."""
@@ -48,9 +50,186 @@ def verify_password(plaintext: str, stored_hash: str) -> bool:
         return False
 
 
+# ── User helpers ──────────────────────────────────────────────────────────
+
+def create_user(db_path, username: str, password_plaintext: str) -> str:
+    """Create a new user and return the new user_id.
+
+    Raises ValueError if the username is already taken.
+    """
+    user_id = str(uuid.uuid4())
+    password_hash = hash_password(password_plaintext)
+    now = _now()
+    conn = get_db(db_path)
+    try:
+        existing = conn.execute(
+            "SELECT id FROM users WHERE username = ?", (username,)
+        ).fetchone()
+        if existing:
+            raise ValueError(f"Username {username!r} is already taken")
+        conn.execute(
+            "INSERT INTO users (id, username, password_hash, created_at) VALUES (?, ?, ?, ?)",
+            (user_id, username, password_hash, now),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return user_id
+
+
+def get_user_by_username(db_path, username: str) -> Optional[dict]:
+    """Return the user row as a dict, or None if not found."""
+    conn = get_db(db_path)
+    try:
+        row = conn.execute(
+            "SELECT id, username, password_hash, created_at FROM users WHERE username = ?",
+            (username,),
+        ).fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def get_user_by_id(db_path, user_id: str) -> Optional[dict]:
+    """Return the user row as a dict, or None if not found."""
+    conn = get_db(db_path)
+    try:
+        row = conn.execute(
+            "SELECT id, username, password_hash, created_at FROM users WHERE id = ?",
+            (user_id,),
+        ).fetchone()
+        return dict(row) if row else None
+    finally:
+        conn.close()
+
+
+def list_users(db_path) -> list[dict]:
+    """Return all users as a list of dicts (no password_hash)."""
+    conn = get_db(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT id, username, created_at FROM users ORDER BY created_at"
+        ).fetchall()
+        return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+def delete_user(db_path, user_id: str) -> None:
+    """Delete a user and all their associated data.
+
+    Deletes: bank_connections (+ cascade via FK), ledgers, classification_hints,
+    sessions for this user.
+    """
+    conn = get_db(db_path)
+    try:
+        # Get connection ids for cascade
+        conn_ids = [
+            r["id"]
+            for r in conn.execute(
+                "SELECT id FROM bank_connections WHERE user_id = ?", (user_id,)
+            ).fetchall()
+        ]
+        for cid in conn_ids:
+            conn.execute("DELETE FROM sync_cursors WHERE connection_id = ?", (cid,))
+
+        # Delete accounts for user's connections
+        if conn_ids:
+            placeholders = ",".join("?" * len(conn_ids))
+            account_ids = [
+                r["id"]
+                for r in conn.execute(
+                    f"SELECT id FROM bank_accounts WHERE connection_id IN ({placeholders})",
+                    conn_ids,
+                ).fetchall()
+            ]
+            if account_ids:
+                acc_placeholders = ",".join("?" * len(account_ids))
+                txn_ids = [
+                    r["id"]
+                    for r in conn.execute(
+                        f"SELECT id FROM transactions WHERE bank_account_id IN ({acc_placeholders})",
+                        account_ids,
+                    ).fetchall()
+                ]
+                if txn_ids:
+                    txn_placeholders = ",".join("?" * len(txn_ids))
+                    conn.execute(
+                        f"DELETE FROM transaction_entries WHERE transaction_id IN ({txn_placeholders})",
+                        txn_ids,
+                    )
+                    conn.execute(
+                        f"DELETE FROM transactions WHERE id IN ({txn_placeholders})",
+                        txn_ids,
+                    )
+                conn.execute(
+                    f"DELETE FROM bank_accounts WHERE connection_id IN ({placeholders})",
+                    conn_ids,
+                )
+            conn.execute(
+                f"DELETE FROM bank_connections WHERE id IN ({placeholders})",
+                conn_ids,
+            )
+
+        # Delete user's ledgers and line items
+        ledger_ids = [
+            r["id"]
+            for r in conn.execute(
+                "SELECT id FROM ledgers WHERE user_id = ?", (user_id,)
+            ).fetchall()
+        ]
+        if ledger_ids:
+            l_placeholders = ",".join("?" * len(ledger_ids))
+            conn.execute(
+                f"DELETE FROM line_items WHERE ledger_id IN ({l_placeholders})",
+                ledger_ids,
+            )
+            conn.execute(
+                f"DELETE FROM ledgers WHERE id IN ({l_placeholders})",
+                ledger_ids,
+            )
+
+        # Delete classification hints
+        conn.execute("DELETE FROM classification_hints WHERE user_id = ?", (user_id,))
+
+        # Delete sessions
+        conn.execute("DELETE FROM sessions WHERE user_id = ?", (user_id,))
+
+        # Finally delete the user
+        conn.execute("DELETE FROM users WHERE id = ?", (user_id,))
+
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def update_user_password(db_path, user_id: str, new_password: str) -> None:
+    """Update the password hash for a user."""
+    new_hash = hash_password(new_password)
+    conn = get_db(db_path)
+    try:
+        conn.execute(
+            "UPDATE users SET password_hash = ? WHERE id = ?",
+            (new_hash, user_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def has_any_user(db_path) -> bool:
+    """Return True if at least one user exists in the users table."""
+    conn = get_db(db_path)
+    try:
+        count = conn.execute("SELECT COUNT(*) FROM users").fetchone()[0]
+        return count > 0
+    finally:
+        conn.close()
+
+
 # ── Session helpers ───────────────────────────────────────────────────────
 
-def create_session(db_path, user_agent: Optional[str] = None) -> str:
+def create_session(db_path, user_agent: Optional[str] = None, user_id: Optional[str] = None) -> str:
     """Insert a new session row and return the session token.
 
     Sessions are permanent — they persist until explicitly deleted via
@@ -61,10 +240,9 @@ def create_session(db_path, user_agent: Optional[str] = None) -> str:
     conn = get_db(db_path)
     try:
         conn.execute(
-            "INSERT INTO sessions (id, created_at, last_seen_at, expires_at, user_agent) "
-            "VALUES (?, ?, ?, ?, ?)",
-            # expires_at column kept for backward compat with existing DBs; not used for auth.
-            (token, now, now, 0, user_agent),
+            "INSERT INTO sessions (id, created_at, last_seen_at, expires_at, user_agent, user_id) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (token, now, now, 0, user_agent, user_id),
         )
         conn.commit()
     finally:
@@ -111,34 +289,104 @@ def check_session(request: Request, db_path) -> bool:
         conn.close()
 
 
-# ── App-config helpers ────────────────────────────────────────────────────
-
-def get_password_hash(db_path) -> Optional[str]:
-    """Return the stored UI password hash, or None if not yet set."""
+def get_session_user_id(request: Request, db_path) -> Optional[str]:
+    """Return the user_id for the session in *request*, or None."""
+    token = request.cookies.get(SESSION_COOKIE)
+    if not token:
+        return None
     conn = get_db(db_path)
     try:
         row = conn.execute(
-            "SELECT ui_password_hash FROM app_config WHERE id = 1"
+            "SELECT user_id FROM sessions WHERE id = ?", (token,)
         ).fetchone()
-        if row is None:
-            return None
-        return row["ui_password_hash"]
+        return row["user_id"] if row else None
+    except Exception:
+        return None
+    finally:
+        conn.close()
+
+
+def get_active_user_id(db_path) -> Optional[str]:
+    """Return the user_id of the most recently active session, or the first user.
+
+    Used by MCP tools (no HTTP context) to find the current logged-in user.
+    Falls back to the first user in the DB if no active session exists.
+    """
+    conn = get_db(db_path)
+    try:
+        row = conn.execute(
+            "SELECT user_id FROM sessions ORDER BY last_seen_at DESC LIMIT 1"
+        ).fetchone()
+        if row and row["user_id"]:
+            return row["user_id"]
+        # Fallback: first user
+        row2 = conn.execute(
+            "SELECT id FROM users ORDER BY created_at LIMIT 1"
+        ).fetchone()
+        return row2["id"] if row2 else None
+    finally:
+        conn.close()
+
+
+# ── Legacy app_config helpers (kept for backward compat) ─────────────────
+# These delegate to the users table when a user exists, otherwise fall back
+# to the app_config table.  New code should use the user-centric helpers
+# above.
+
+def get_password_hash(db_path) -> Optional[str]:
+    """Return the stored UI password hash, or None if not yet set.
+
+    Reads from the users table (first user) or falls back to app_config.
+    """
+    conn = get_db(db_path)
+    try:
+        # Prefer users table
+        row = conn.execute(
+            "SELECT password_hash FROM users ORDER BY created_at LIMIT 1"
+        ).fetchone()
+        if row and row[0]:
+            return row[0]
+        # Legacy fallback
+        try:
+            row2 = conn.execute(
+                "SELECT ui_password_hash FROM app_config WHERE id = 1"
+            ).fetchone()
+            if row2 and row2[0]:
+                return row2[0]
+        except Exception:
+            pass
+        return None
     finally:
         conn.close()
 
 
 def set_password_hash(db_path, hashed: str) -> None:
-    """Upsert the UI password hash into app_config (single-row, id=1)."""
+    """Upsert the UI password hash.
+
+    Updates the first user's hash if users exist; otherwise writes to
+    app_config for legacy compatibility.
+    """
     now = _now()
     conn = get_db(db_path)
     try:
-        conn.execute(
-            "INSERT INTO app_config (id, ui_password_hash, ui_password_set_at) "
-            "VALUES (1, ?, ?) "
-            "ON CONFLICT(id) DO UPDATE SET ui_password_hash=excluded.ui_password_hash, "
-            "ui_password_set_at=excluded.ui_password_set_at",
-            (hashed, now),
-        )
-        conn.commit()
+        row = conn.execute(
+            "SELECT id FROM users ORDER BY created_at LIMIT 1"
+        ).fetchone()
+        if row:
+            conn.execute(
+                "UPDATE users SET password_hash = ? WHERE id = ?",
+                (hashed, row["id"]),
+            )
+            conn.commit()
+        else:
+            # Legacy: write to app_config
+            conn.execute(
+                "INSERT INTO app_config (id, ui_password_hash, ui_password_set_at) "
+                "VALUES (1, ?, ?) "
+                "ON CONFLICT(id) DO UPDATE SET ui_password_hash=excluded.ui_password_hash, "
+                "ui_password_set_at=excluded.ui_password_set_at",
+                (hashed, now),
+            )
+            conn.commit()
     finally:
         conn.close()

--- a/ui/server.py
+++ b/ui/server.py
@@ -48,10 +48,19 @@ from ui.auth import (
     SESSION_COOKIE,
     check_session,
     create_session,
+    create_user,
     delete_session,
+    delete_user,
+    get_active_user_id,
     get_password_hash,
+    get_session_user_id,
+    get_user_by_id,
+    get_user_by_username,
+    has_any_user,
     hash_password,
+    list_users,
     set_password_hash,
+    update_user_password,
     verify_password,
 )
 
@@ -77,11 +86,17 @@ def _db_path() -> Path:
 
 
 def _password_is_set() -> bool:
-    return bool(get_password_hash(_db_path()))
+    """Legacy check: True if any user exists (or app_config has a password hash)."""
+    return has_any_user(_db_path()) or bool(get_password_hash(_db_path()))
 
 
 def _is_authenticated(request: Request) -> bool:
     return check_session(request, _db_path())
+
+
+def _current_user_id(request: Request) -> Optional[str]:
+    """Return the user_id from the current session, or None."""
+    return get_session_user_id(request, _db_path())
 
 
 def _check_raw_session(db_path, token: str) -> bool:
@@ -120,11 +135,29 @@ _PREF_TO_CHANNEL = {"openclaw": "openclaw_chat", "ui": "in_ui", "macos": "macos"
                     "openclaw_chat": "openclaw_chat", "in_ui": "in_ui"}
 
 
-def _get_username() -> str:
+def _get_username(user_id: Optional[str] = None) -> str:
+    """Return the username for *user_id* (or first user if not specified)."""
     conn = get_db(_db_path())
     try:
-        row = conn.execute("SELECT username FROM app_config WHERE id=1").fetchone()
-        return row["username"] if row and row["username"] else "User"
+        if user_id:
+            row = conn.execute(
+                "SELECT username FROM users WHERE id = ?", (user_id,)
+            ).fetchone()
+            if row and row["username"]:
+                return row["username"]
+        # Fallback: first user or app_config
+        row2 = conn.execute(
+            "SELECT username FROM users ORDER BY created_at LIMIT 1"
+        ).fetchone()
+        if row2 and row2["username"]:
+            return row2["username"]
+        try:
+            row3 = conn.execute("SELECT username FROM app_config WHERE id=1").fetchone()
+            if row3 and row3["username"]:
+                return row3["username"]
+        except Exception:
+            pass
+        return "User"
     except Exception:
         return "User"
     finally:
@@ -173,13 +206,20 @@ def _set_notification_channel(channel: str) -> None:
 def _set_notification_pref(pref: str) -> None:
     _set_notification_channel(_PREF_TO_CHANNEL.get(pref, pref))
 
-def _get_ledgers() -> list[dict]:
+def _get_ledgers(user_id: Optional[str] = None) -> list[dict]:
     """Query ledgers + line_items from the DB and return a list of dicts."""
     conn = get_db(_db_path())
     try:
-        ledger_rows = conn.execute(
-            "SELECT id, name FROM ledgers ORDER BY name"
-        ).fetchall()
+        if user_id:
+            # Include rows owned by user_id AND unowned rows (NULL user_id = legacy/migration)
+            ledger_rows = conn.execute(
+                "SELECT id, name FROM ledgers WHERE user_id = ? OR user_id IS NULL ORDER BY name",
+                (user_id,),
+            ).fetchall()
+        else:
+            ledger_rows = conn.execute(
+                "SELECT id, name FROM ledgers ORDER BY name"
+            ).fetchall()
         ledgers = []
         for lr in ledger_rows:
             items = conn.execute(
@@ -295,7 +335,7 @@ async def setup_post(request: Request, step: int):
         return HTMLResponse(status_code=404, content="Setup already complete.")
     form = await request.form()
     if step == 1:
-        username = (form.get("username") or "").strip()
+        username = (form.get("username") or "").strip() or "default"
         pw = (form.get("password") or "").strip()
         cf = (form.get("password_confirm") or "").strip()
         dch = "openclaw_chat" if _openclaw_home_exists() else "macos"
@@ -311,18 +351,57 @@ async def setup_post(request: Request, step: int):
                 {"step": 1, "error": err, "default_channel": dch})
             _update_wizard(resp, tok, {"step": 1, "wizard_active": False, "error": err})
             return resp
-        set_password_hash(_db_path(), hash_password(pw))
-        # Save username
-        _conn = get_db(_db_path())
+
+        # Create user in users table (or update existing default user's password).
+        password_hash = hash_password(pw)
+        existing_user = get_user_by_username(_db_path(), username)
+        if existing_user:
+            # Update existing user's password
+            from ui.auth import update_user_password
+            update_user_password(_db_path(), existing_user["id"], pw)
+            new_user_id = existing_user["id"]
+        else:
+            # Check if there's a default user to update (migration scenario)
+            _conn = get_db(_db_path())
+            try:
+                default_row = _conn.execute(
+                    "SELECT id FROM users WHERE id = 'default-user-id'"
+                ).fetchone()
+            finally:
+                _conn.close()
+            if default_row:
+                # Update the migrated default user
+                _conn2 = get_db(_db_path())
+                try:
+                    _conn2.execute(
+                        "UPDATE users SET username = ?, password_hash = ? WHERE id = 'default-user-id'",
+                        (username, password_hash),
+                    )
+                    _conn2.commit()
+                finally:
+                    _conn2.close()
+                new_user_id = "default-user-id"
+            else:
+                new_user_id = create_user(_db_path(), username, pw)
+
+        # Also save to app_config for legacy compat.
+        set_password_hash(_db_path(), password_hash)
+        _conn3 = get_db(_db_path())
         try:
-            try: _conn.execute("ALTER TABLE app_config ADD COLUMN username TEXT")
+            try: _conn3.execute("ALTER TABLE app_config ADD COLUMN username TEXT")
             except: pass
-            _conn.execute("INSERT INTO app_config (id, username) VALUES (1, ?) ON CONFLICT(id) DO UPDATE SET username=excluded.username", (username or "User",))
-            _conn.commit()
-        finally: _conn.close()
+            _conn3.execute(
+                "INSERT INTO app_config (id, username) VALUES (1, ?) "
+                "ON CONFLICT(id) DO UPDATE SET username=excluded.username",
+                (username,),
+            )
+            _conn3.commit()
+        finally: _conn3.close()
+
         ua = request.headers.get("user-agent")
-        stoken = create_session(_db_path(), user_agent=ua)
-        ns = {"step": 2, "wizard_active": True, "session_token": stoken, "error": None}
+        stoken = create_session(_db_path(), user_agent=ua, user_id=new_user_id)
+        ns = {"step": 2, "wizard_active": True, "session_token": stoken,
+              "user_id": new_user_id, "error": None}
         resp = templates.TemplateResponse(request, "setup.html",
             {"step": 2, "error": None, "default_channel": dch})
         _update_wizard(resp, tok, ns)
@@ -359,7 +438,7 @@ async def setup_post(request: Request, step: int):
         return redir
     return HTMLResponse(status_code=404, content="Unknown step.")
 
-def _ensure_ledger(name: str) -> None:
+def _ensure_ledger(name: str, user_id: Optional[str] = None) -> None:
     """Create a ledger row if one with this name doesn't already exist."""
     import uuid as _uuid
     conn = get_db(_db_path())
@@ -369,8 +448,8 @@ def _ensure_ledger(name: str) -> None:
         ).fetchone()
         if existing is None:
             conn.execute(
-                "INSERT INTO ledgers (id, name) VALUES (?, ?)",
-                (str(_uuid.uuid4()), name),
+                "INSERT INTO ledgers (id, name, user_id) VALUES (?, ?, ?)",
+                (str(_uuid.uuid4()), name, user_id),
             )
             conn.commit()
     finally:
@@ -381,17 +460,22 @@ def _ensure_ledger(name: str) -> None:
 
 @app.get("/login", response_class=HTMLResponse)
 def login_get(request: Request):
-    """Render login form.  If no password is set, redirect to /setup."""
+    """Render login form.  If no users exist, redirect to /setup."""
     if not _password_is_set():
         return _redirect("/setup")
-    username = _get_username()
-    return templates.TemplateResponse(request, "login.html", {"error": None, "username": username})
+    profiles = list_users(_db_path())
+    prefill_username = request.query_params.get("username", "")
+    return templates.TemplateResponse(
+        request, "login.html",
+        {"error": None, "profiles": profiles, "prefill_username": prefill_username},
+    )
 
 
 @app.post("/login")
 async def login_post(request: Request):
-    """Verify password; on success create session and redirect to /profile.
+    """Verify username+password; on success create session and redirect to /profile.
 
+    Username is optional when there is only one user (backward compat).
     On failure: re-render login.html with an error.
     No rate limiting — single-user local app (per d4403c0).
     """
@@ -399,16 +483,34 @@ async def login_post(request: Request):
         return _redirect("/setup")
 
     form = await request.form()
+    username = (form.get("username") or "").strip()
     password = (form.get("password") or "")
 
-    stored_hash = get_password_hash(_db_path())
-    success = stored_hash is not None and verify_password(password, stored_hash)
+    profiles = list_users(_db_path())
+
+    # If username not supplied, try to resolve it from the single-user case.
+    user = None
+    if username:
+        user = get_user_by_username(_db_path(), username)
+    elif len(profiles) == 1:
+        # Backward compat: single user, no username required
+        user = get_user_by_id(_db_path(), profiles[0]["id"])
+    elif len(profiles) == 0:
+        # Should never happen (guarded above), but be safe
+        return _redirect("/setup")
+    # else: multiple users, username required — user stays None → error below
+
+    success = (
+        user is not None
+        and verify_password(password, user["password_hash"])
+    )
 
     if not success:
         return templates.TemplateResponse(
             request,
             "login.html",
-            {"error": "Incorrect password."},
+            {"error": "Incorrect username or password.",
+             "profiles": profiles, "prefill_username": username},
             status_code=200,
         )
     # Clear any pending setup session.
@@ -416,9 +518,9 @@ async def login_post(request: Request):
     if st:
         delete_session(_db_path(), st)
 
-    # Create session.
+    # Create session with user_id.
     ua = request.headers.get("user-agent")
-    token = create_session(_db_path(), user_agent=ua)
+    token = create_session(_db_path(), user_agent=ua, user_id=user["id"])
 
     response = _redirect("/profile")
     response.set_cookie(SESSION_COOKIE, token, httponly=True, samesite="strict")
@@ -512,30 +614,48 @@ async def reset_post(request: Request):
 
 # ── /profile ─────────────────────────────────────────────────────────────────
 
-def _get_connections() -> list[dict]:
-    """Query bank_connections and return a list of dicts."""
+def _get_connections(user_id: Optional[str] = None) -> list[dict]:
+    """Query bank_connections for *user_id* and return a list of dicts."""
     conn = get_db(_db_path())
     try:
-        rows = conn.execute(
-            "SELECT id, institution_name, status, last_synced_at "
-            "FROM bank_connections ORDER BY rowid"
-        ).fetchall()
+        if user_id:
+            rows = conn.execute(
+                "SELECT id, institution_name, status, last_synced_at "
+                "FROM bank_connections WHERE user_id = ? ORDER BY rowid",
+                (user_id,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT id, institution_name, status, last_synced_at "
+                "FROM bank_connections ORDER BY rowid"
+            ).fetchall()
         return [dict(r) for r in rows]
     finally:
         conn.close()
 
 
-def _get_accounts() -> list[dict]:
+def _get_accounts(user_id: Optional[str] = None) -> list[dict]:
     """Query bank_accounts joined with their connection and return list of dicts."""
     conn = get_db(_db_path())
     try:
-        rows = conn.execute(
-            "SELECT ba.id, ba.name, ba.mask, ba.type, ba.subtype, ba.description,"
-            "       bc.institution_name"
-            "  FROM bank_accounts ba"
-            "  JOIN bank_connections bc ON bc.id = ba.connection_id"
-            " ORDER BY bc.institution_name, ba.name"
-        ).fetchall()
+        if user_id:
+            rows = conn.execute(
+                "SELECT ba.id, ba.name, ba.mask, ba.type, ba.subtype, ba.description,"
+                "       bc.institution_name"
+                "  FROM bank_accounts ba"
+                "  JOIN bank_connections bc ON bc.id = ba.connection_id"
+                " WHERE bc.user_id = ?"
+                " ORDER BY bc.institution_name, ba.name",
+                (user_id,),
+            ).fetchall()
+        else:
+            rows = conn.execute(
+                "SELECT ba.id, ba.name, ba.mask, ba.type, ba.subtype, ba.description,"
+                "       bc.institution_name"
+                "  FROM bank_accounts ba"
+                "  JOIN bank_connections bc ON bc.id = ba.connection_id"
+                " ORDER BY bc.institution_name, ba.name"
+            ).fetchall()
         return [dict(r) for r in rows]
     except Exception:
         return []
@@ -547,22 +667,39 @@ def _get_accounts() -> list[dict]:
 def profile_get(request: Request):
     """Settings page.  Requires authentication."""
     if _is_authenticated(request):
+        uid = _current_user_id(request)
         pref = _get_notification_pref()
-        connections = _get_connections()
-        accounts = _get_accounts()
+        connections = _get_connections(uid)
+        accounts = _get_accounts(uid)
+        profiles = list_users(_db_path())
+        current_user = get_user_by_id(_db_path(), uid) if uid else None
         return templates.TemplateResponse(request, "profile.html",
             {"notification_pref": pref, "saved": False,
              "connections": connections, "accounts": accounts,
-             "action_result": None})
+             "action_result": None, "profiles": profiles,
+             "current_user": current_user})
     st = request.cookies.get(_SETUP_COMPLETE_COOKIE)
     if st and _check_raw_session(_db_path(), st):
         pref = _get_notification_pref()
-        connections = _get_connections()
-        accounts = _get_accounts()
+        uid = None
+        conn_db = get_db(_db_path())
+        try:
+            row = conn_db.execute("SELECT user_id FROM sessions WHERE id = ?", (st,)).fetchone()
+            if row:
+                uid = row["user_id"]
+        except Exception:
+            pass
+        finally:
+            conn_db.close()
+        connections = _get_connections(uid)
+        accounts = _get_accounts(uid)
+        profiles = list_users(_db_path())
+        current_user = get_user_by_id(_db_path(), uid) if uid else None
         resp = templates.TemplateResponse(request, "profile.html",
             {"notification_pref": pref, "saved": False,
              "connections": connections, "accounts": accounts,
-             "action_result": None})
+             "action_result": None, "profiles": profiles,
+             "current_user": current_user})
         resp.set_cookie(SESSION_COOKIE, st, httponly=True, samesite="strict")
         resp.delete_cookie(_SETUP_COMPLETE_COOKIE)
         return resp
@@ -582,14 +719,19 @@ async def profile_post(request: Request):
       - export_now: trigger server.main.export_excel()
       - disconnect_bank: delete bank_connection by bank_id
       - reconnect_bank: call server.main.refresh_connection(id=bank_id)
+      - create_profile: create a new local profile
+      - delete_profile: delete a local profile and all its data
     """
     if not _is_authenticated(request):
         return _redirect("/login")
+    uid = _current_user_id(request)
     form = await request.form()
     action = (form.get("action") or "").strip()
     pref = _get_notification_pref()
-    connections = _get_connections()
-    accounts = _get_accounts()
+    connections = _get_connections(uid)
+    accounts = _get_accounts(uid)
+    profiles = list_users(_db_path())
+    current_user = get_user_by_id(_db_path(), uid) if uid else None
     action_result: dict | None = None
 
     if action == "sync_now":
@@ -635,6 +777,37 @@ async def profile_post(request: Request):
             except Exception as exc:
                 action_result = {"ok": False, "message": f"Reconnect failed: {exc}"}
 
+    elif action == "create_profile":
+        new_username = (form.get("new_username") or "").strip()
+        new_password = (form.get("new_password") or "").strip()
+        if not new_username:
+            action_result = {"ok": False, "message": "Username is required."}
+        elif len(new_password) < 8:
+            action_result = {"ok": False, "message": "Password must be at least 8 characters."}
+        else:
+            try:
+                create_user(_db_path(), new_username, new_password)
+                profiles = list_users(_db_path())  # refresh
+                action_result = {"ok": True, "message": f"Profile '{new_username}' created."}
+            except ValueError as exc:
+                action_result = {"ok": False, "message": str(exc)}
+
+    elif action == "delete_profile":
+        del_user_id = (form.get("del_user_id") or "").strip()
+        if not del_user_id:
+            action_result = {"ok": False, "message": "No profile specified."}
+        elif del_user_id == uid:
+            action_result = {"ok": False, "message": "Cannot delete the currently active profile. Log in as another profile first."}
+        elif len(list_users(_db_path())) <= 1:
+            action_result = {"ok": False, "message": "Cannot delete the only profile."}
+        else:
+            try:
+                delete_user(_db_path(), del_user_id)
+                profiles = list_users(_db_path())  # refresh
+                action_result = {"ok": True, "message": "Profile deleted."}
+            except Exception as exc:
+                action_result = {"ok": False, "message": f"Delete failed: {exc}"}
+
     else:
         # Default: save notification_pref
         pref = form.get("notification_pref") or "openclaw"
@@ -644,7 +817,8 @@ async def profile_post(request: Request):
             "profile.html",
             {"notification_pref": pref, "saved": True,
              "connections": connections, "accounts": accounts,
-             "action_result": None},
+             "action_result": None, "profiles": profiles,
+             "current_user": current_user},
         )
 
     return templates.TemplateResponse(
@@ -652,7 +826,8 @@ async def profile_post(request: Request):
         "profile.html",
         {"notification_pref": pref, "saved": False,
          "connections": connections, "accounts": accounts,
-         "action_result": action_result},
+         "action_result": action_result, "profiles": profiles,
+         "current_user": current_user},
     )
 
 
@@ -701,7 +876,8 @@ def ledgers_get(request: Request):
     """
     if not _is_authenticated(request):
         return _redirect("/login")
-    ledgers = _get_ledgers()
+    uid = _current_user_id(request)
+    ledgers = _get_ledgers(uid)
     return templates.TemplateResponse(
         request,
         "ledgers.html",
@@ -719,6 +895,7 @@ async def ledgers_create(request: Request):
     """Create a new ledger. JSON body: {name: str}."""
     if not _is_authenticated(request):
         return JSONResponse({"error": "Unauthorized"}, status_code=401)
+    uid = _current_user_id(request)
     body = await request.json()
     name = (body.get("name") or "").strip()
     if not name:
@@ -727,8 +904,8 @@ async def ledgers_create(request: Request):
     conn = get_db(_db_path())
     try:
         conn.execute(
-            "INSERT INTO ledgers (id, name) VALUES (?, ?)",
-            (ledger_id, name),
+            "INSERT INTO ledgers (id, name, user_id) VALUES (?, ?, ?)",
+            (ledger_id, name, uid),
         )
         conn.commit()
     finally:

--- a/ui/templates/login.html
+++ b/ui/templates/login.html
@@ -11,12 +11,30 @@
   {% endif %}
 
   <form method="post" action="/login">
+    <label for="username">Username</label>
+    <input id="username" name="username" type="text" required
+           autofocus autocomplete="username"
+           value="{{ prefill_username or '' }}"
+           placeholder="Your profile username" />
+
     <label for="password">Password</label>
     <input id="password" name="password" type="password" required
-           autofocus autocomplete="current-password"
+           autocomplete="current-password"
            placeholder="Your Friday password" />
+
     <button type="submit" class="btn-primary">Sign in</button>
   </form>
+
+  {% if profiles and profiles|length > 1 %}
+  <div style="margin-top:1rem">
+    <p class="hint">Switch profile:</p>
+    <div style="display:flex;flex-wrap:wrap;gap:0.5rem">
+      {% for p in profiles %}
+      <a href="/login?username={{ p.username }}" class="btn-secondary" style="font-size:0.9em">{{ p.username }}</a>
+      {% endfor %}
+    </div>
+  </div>
+  {% endif %}
 
   <p class="hint"><a href="/forgot">Forgot your password?</a></p>
 </div>

--- a/ui/templates/profile.html
+++ b/ui/templates/profile.html
@@ -5,6 +5,7 @@
 {% block nav %}
 <nav>
   <a href="/ledgers">Ledgers</a>
+  {% if current_user %}<span class="hint" style="margin:0 0.5rem">{{ current_user.username }}</span>{% endif %}
   <form method="post" action="/logout" style="display:inline">
     <button type="submit" class="btn-link">Sign out</button>
   </form>
@@ -66,6 +67,53 @@
         <button type="submit" class="btn-secondary">Export Excel</button>
       </form>
     </div>
+  </section>
+
+  <!-- Local Profiles (#131) -->
+  <section id="profiles">
+    <h2>Local Profiles</h2>
+    {% if action_result and action_result.ok is defined %}
+      {% if action_result.ok %}
+      <div class="alert alert-success">{{ action_result.message }}</div>
+      {% else %}
+      <div class="alert alert-error">{{ action_result.message }}</div>
+      {% endif %}
+    {% endif %}
+
+    {% if profiles %}
+    <ul style="list-style:none;padding:0;margin-bottom:1rem">
+      {% for p in profiles %}
+      <li style="display:flex;align-items:center;gap:0.75rem;padding:0.35rem 0;border-bottom:1px solid #eee">
+        <span style="min-width:12rem;font-weight:{% if current_user and p.id == current_user.id %}600{% else %}400{% endif %}">
+          {{ p.username }}
+          {% if current_user and p.id == current_user.id %}<small class="hint">(you)</small>{% endif %}
+        </span>
+        {% if current_user and p.id != current_user.id %}
+        <a href="/login?username={{ p.username }}" class="btn-secondary" style="font-size:0.85em">Switch</a>
+        <form method="post" action="/profile" style="display:inline">
+          <input type="hidden" name="action" value="delete_profile">
+          <input type="hidden" name="del_user_id" value="{{ p.id }}">
+          <button type="submit" class="btn-danger" style="font-size:0.85em"
+            onclick="return confirm('Delete profile {{ p.username }} and ALL its data? This cannot be undone.')">Delete</button>
+        </form>
+        {% endif %}
+      </li>
+      {% endfor %}
+    </ul>
+    {% endif %}
+
+    <!-- Create new profile -->
+    <details style="margin-top:0.5rem">
+      <summary style="cursor:pointer;font-size:0.95em">+ Create new profile</summary>
+      <form method="post" action="/profile" style="margin-top:0.75rem">
+        <input type="hidden" name="action" value="create_profile">
+        <label for="new_username">Username</label>
+        <input id="new_username" name="new_username" type="text" placeholder="e.g. work" required style="max-width:16rem">
+        <label for="new_password">Password (min 8 chars)</label>
+        <input id="new_password" name="new_password" type="password" placeholder="Password" required style="max-width:16rem">
+        <button type="submit" class="btn-secondary" style="margin-top:0.5rem">Create profile</button>
+      </form>
+    </details>
   </section>
 
   <!-- Linked Accounts (#47) -->


### PR DESCRIPTION
Closes #131

Implements local multi-profile support: multiple named profiles each with their own password, bank connections, ledgers, and classification hints. Only one profile active at a time — no concurrent sessions.

### Changes
- **Schema**: Added `users` table; added `user_id` FK to `bank_connections`, `ledgers`, `classification_hints`, `sessions`
- **Migration**: `init_db()` detects legacy single-user DBs (existing data + no users table) and creates a `default` user, migrating the `app_config.ui_password_hash`. Fresh DBs skip migration; setup wizard creates the first user
- **Auth** (`ui/auth.py`): `create_user`, `delete_user`, `list_users`, `get_user_by_username`, `get_session_user_id`, `get_active_user_id`; sessions now store `user_id`
- **Login** (`ui/server.py`): username+password fields; backward compat when only one user exists (username optional)
- **MCP** (`server/main.py`): Added `list_profiles()` tool; `setup_status()` scoped per active user; `add_hint`/`list_hints`/`list_connections`/`apply_initial_setup` filter by `user_id`
- **UI templates**: `login.html` with username field + profile switcher; `profile.html` with Local Profiles section (create, switch, delete)
- **Tests**: 23 new tests in `tests/test_multi_profile.py`

**Interactive check (MCP):** `python3 -c "from server.main import list_profiles; print(list_profiles())"` → `{'profiles': []}` — returns a real list, not a stub or error

**Interactive check (UI):** Started server via TestClient, completed setup wizard with username `testuser`, logged in via POST /login with username+password, confirmed `/profile` returns 200 with Local Profiles section visible