### PR TITLE
[Sec] Forbidden-pattern lint script + CI (#45)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,15 @@ jobs:
       - run: ruff check .
       - run: black --check .
 
+  security-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python3 scripts/lint_security.py
+
   mcp-smoke:
     runs-on: ubuntu-latest
     steps:

--- a/scripts/lint_security.py
+++ b/scripts/lint_security.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+lint_security.py — Forbidden-pattern security linter.
+
+Walks *.py files under server/, ui/, scripts/ (excluding tests/, .venv/, venv/,
+__pycache__/) and fails if any forbidden pattern is found.
+
+Exit codes:
+  0 — clean
+  1 — one or more violations found
+"""
+
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Forbidden patterns
+# ---------------------------------------------------------------------------
+PATTERNS = [
+    (
+        re.compile(r"\b0\.0\.0\.0\b"),
+        "hardcoded all-interfaces bind address",
+    ),
+    (
+        re.compile(
+            r"""(?:app|uvicorn)\.run\s*\([^)]*host\s*=\s*["\']?(?!127\.0\.0\.1|localhost)[^\s"',)]+"""
+        ),
+        "HTTP server bound to non-localhost host",
+    ),
+    (
+        re.compile(r"""requests\.get\([^)]*\b(ngrok|tunnel|cloudflared?)\b"""),
+        "public-tunnel reference in requests.get()",
+    ),
+    (
+        re.compile(r"""Fernet\(open\("""),
+        "Fernet key loaded from file (use keyring instead)",
+    ),
+    (
+        re.compile(r"""PLAID_SECRET\s*=\s*["'][0-9a-f]{30,}["']"""),
+        "hardcoded Plaid production secret",
+    ),
+    (
+        re.compile(r"""PLAID_CLIENT_ID\s*=\s*["'][0-9a-f]{20,}["']"""),
+        "hardcoded Plaid production client_id",
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Directories to scan / skip
+# ---------------------------------------------------------------------------
+SCAN_DIRS = ["server", "ui", "scripts"]
+SKIP_DIRS = {"tests", ".venv", "venv", "__pycache__"}
+
+
+def iter_python_files(root: Path):
+    for scan_dir in SCAN_DIRS:
+        base = root / scan_dir
+        if not base.is_dir():
+            continue
+        for path in base.rglob("*.py"):
+            # Skip any path component that matches a skip dir
+            if any(part in SKIP_DIRS for part in path.parts):
+                continue
+            yield path
+
+
+def check_file(path: Path):
+    violations = []
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError as exc:
+        print(f"WARNING: could not read {path}: {exc}", file=sys.stderr)
+        return violations
+
+    for lineno, line in enumerate(lines, start=1):
+        for pattern, description in PATTERNS:
+            if pattern.search(line):
+                violations.append(f"{path}:{lineno}: {description} — {line.strip()}")
+    return violations
+
+
+def main():
+    root = Path(__file__).parent.parent.resolve()
+    all_violations = []
+    for py_file in sorted(iter_python_files(root)):
+        all_violations.extend(check_file(py_file))
+
+    if all_violations:
+        for v in all_violations:
+            print(v)
+        sys.exit(1)
+
+    print("lint_security: no violations found.")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_lint_security.py
+++ b/tests/test_lint_security.py
@@ -1,0 +1,103 @@
+"""
+Tests for scripts/lint_security.py
+"""
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+LINTER = Path(__file__).parent.parent / "scripts" / "lint_security.py"
+
+
+def run_linter(*extra_args):
+    result = subprocess.run(
+        [sys.executable, str(LINTER), *extra_args],
+        capture_output=True,
+        text=True,
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Smoke test: linter exits 0 on the actual repo
+# ---------------------------------------------------------------------------
+def test_smoke_clean_repo():
+    result = run_linter()
+    assert (
+        result.returncode == 0
+    ), f"lint_security.py found violations in the current repo:\n{result.stdout}"
+
+
+# ---------------------------------------------------------------------------
+# Synthetic positive: 0.0.0.0 in a non-test source file should be flagged
+# ---------------------------------------------------------------------------
+def test_flags_all_interfaces_bind(tmp_path, monkeypatch):
+    """A file containing the all-interfaces address should be caught."""
+    # Create a fake server/ dir under tmp_path so the linter picks it up
+    fake_server = tmp_path / "server"
+    fake_server.mkdir()
+    bad_file = fake_server / "bad_config.py"
+    bad_file.write_text(textwrap.dedent("""\
+            HOST = "0" + "." + "0" + "." + "0" + "." + "0"  # won't match
+            HOST2 = "0.0.0.0"  # this one should match
+            """))
+
+    # Patch the linter's root so it scans tmp_path instead of the real repo
+    import scripts.lint_security as linter  # noqa: PLC0415
+
+    original_root = None
+
+    def patched_iter(root):
+        return linter.iter_python_files(tmp_path)
+
+    monkeypatch.setattr(linter, "iter_python_files", patched_iter)
+
+    violations = linter.check_file(bad_file)
+    assert any(
+        "all-interfaces" in v for v in violations
+    ), f"Expected a violation for 0.0.0.0 but got: {violations}"
+
+
+# ---------------------------------------------------------------------------
+# Tests/ files are excluded — a violating pattern inside tests/ is ignored
+# ---------------------------------------------------------------------------
+def test_tests_dir_excluded(tmp_path, monkeypatch):
+    """Violations inside tests/ should be silently skipped."""
+    import scripts.lint_security as linter  # noqa: PLC0415
+
+    # Build a fake layout: tests/bad.py with a violation, server/ clean
+    fake_tests = tmp_path / "tests"
+    fake_tests.mkdir()
+    bad_test_file = fake_tests / "bad.py"
+    bad_test_file.write_text('HOST = "0.0.0.0"\n')
+
+    fake_server = tmp_path / "server"
+    fake_server.mkdir()
+    clean_file = fake_server / "good.py"
+    clean_file.write_text("HOST = '127.0.0.1'\n")
+
+    # Collect files the way the real linter would from tmp_path
+    found = list(linter.iter_python_files(tmp_path))
+
+    # tests/bad.py must NOT appear in the scanned file list
+    assert bad_test_file not in found, "lint_security should exclude files under tests/"
+    # server/good.py SHOULD appear
+    assert clean_file in found, "lint_security should scan files under server/"
+
+
+# ---------------------------------------------------------------------------
+# Synthetic Plaid secret flagged
+# ---------------------------------------------------------------------------
+def test_flags_hardcoded_plaid_secret(tmp_path):
+    import scripts.lint_security as linter  # noqa: PLC0415
+
+    fake_server = tmp_path / "server"
+    fake_server.mkdir()
+    bad_file = fake_server / "secrets.py"
+    bad_file.write_text('PLAID_SECRET = "abcdef1234567890abcdef1234567890"\n')
+
+    violations = linter.check_file(bad_file)
+    assert any(
+        "Plaid" in v for v in violations
+    ), f"Expected Plaid secret violation but got: {violations}"

--- a/ui/server.py
+++ b/ui/server.py
@@ -1190,12 +1190,14 @@ def ledger_items_delete(request: Request, ledger_id: str, item_id: str):
 
 # ── /link/start ──────────────────────────────────────────────────────────────
 
+
 @app.get("/link/start")
 def link_start(request: Request):
     """Generate a Plaid link token and redirect to /link?token=..."""
     if not _is_authenticated(request):
         return _redirect("/login")
     import server.main as _sm
+
     result = _sm.start_link()
     # start_link returns {"url": "http://127.0.0.1:6789/link?token=<token>"}
     url = result.get("url", "")


### PR DESCRIPTION
Closes #45

## Summary

Adds a security-focused static linter that fails CI if forbidden patterns are introduced.

### What's included

- **`scripts/lint_security.py`** — stdlib-only script that walks `server/`, `ui/`, `scripts/` (excludes `tests/`, `.venv/`, `venv/`, `__pycache__/`) and rejects:
  - Hardcoded all-interfaces bind address (`0.0.0.0`)
  - HTTP server (`app.run`/`uvicorn.run`) bound to a non-localhost host
  - Public-tunnel references in `requests.get()` (ngrok, tunnel, cloudflare)
  - `Fernet(open(` — key loaded from file instead of keyring
  - Hardcoded Plaid production secrets (client_id / secret matching hex patterns)
  - Exits 0 if clean, 1 if any violations found

- **`.github/workflows/test.yml`** — new `security-lint` job (parallel to `lint`, `unit`, `mcp-smoke`) that runs `python3 scripts/lint_security.py`

- **`tests/test_lint_security.py`** — 4 tests:
  - Smoke: linter exits 0 on current repo
  - Synthetic positive: `0.0.0.0` in a fake server file is flagged
  - Exclusion check: files under `tests/` are not scanned
  - Plaid secret: hardcoded hex secret is flagged

**Interactive check:** ran `python3 scripts/lint_security.py` on the current repo → exit 0 (no violations)