### PR TITLE
[P5] MCP tools: set_ui_password + reset_ui_password (#53)

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json as _json
 import logging
 import os
+import secrets
 import subprocess as _subprocess
 import tempfile
 import time as _time
@@ -29,7 +30,13 @@ from server.db import get_db
 from server.db import transaction as db_txn
 from server.providers.plaid import PlaidProvider
 from server.sync_lock import LockBusy, sync_lock
-from ui.auth import get_active_user_id
+from ui.auth import (
+    add_recovery_token,
+    get_active_user_id,
+    get_user_by_id,
+    update_user_password,
+    verify_password,
+)
 
 _plaid = PlaidProvider()
 
@@ -1269,6 +1276,99 @@ def configure_plaid(
     _logger.info("configure_plaid: wrote .env (env=%s)", env)
 
     return {"ok": True, "env": env}
+
+
+# ---------------------------------------------------------------------------
+# Password MCP tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool
+def set_ui_password(new_password: str, old_password: Optional[str] = None) -> dict:
+    """Change the UI password for the currently active user.
+
+    Parameters
+    ----------
+    new_password : str
+        The new password.  Must be at least 8 characters.
+    old_password : str, optional
+        The current password.  Required whenever the user already has a
+        password set (which is always true after first-run setup).
+
+    Returns
+    -------
+    dict
+        ``{"status": "ok"}`` on success, or
+        ``{"status": "error", "message": "..."}`` on failure.
+    """
+    if len(new_password) < 8:
+        return {"status": "error", "message": "Password too short"}
+
+    user_id = get_active_user_id(server.paths.DB_PATH)
+    if not user_id:
+        return {"status": "error", "message": "Not logged in"}
+
+    user = get_user_by_id(server.paths.DB_PATH, user_id)
+    if user is None:
+        return {"status": "error", "message": "Not logged in"}
+
+    if old_password is not None:
+        if not verify_password(old_password, user["password_hash"]):
+            return {"status": "error", "message": "Old password does not match"}
+    else:
+        # In the multi-profile world, every user always has a password set.
+        return {"status": "error", "message": "Old password required"}
+
+    update_user_password(server.paths.DB_PATH, user_id, new_password)
+    return {"status": "ok"}
+
+
+@mcp.tool
+def reset_ui_password() -> dict:
+    """Generate a password-reset recovery token for the active user.
+
+    Creates a 32-byte hex token, stores it in the shared in-memory recovery
+    token store (same store used by the UI POST /forgot handler), writes it
+    to ``~/.friday-bp/recovery.txt`` with mode 0600, and returns the reset
+    URL.
+
+    Returns
+    -------
+    dict
+        ``{"status": "ok", "recovery_url": "http://127.0.0.1:<port>/reset?t=<token>"}``
+        on success, or ``{"status": "error", "message": "..."}`` on failure.
+    """
+    user_id = get_active_user_id(server.paths.DB_PATH)
+    if not user_id:
+        return {"status": "error", "message": "Not logged in"}
+
+    token = secrets.token_hex(32)
+    add_recovery_token(token, user_id)
+
+    recovery_path = server.paths.APP_DIR / "recovery.txt"
+    try:
+        server.paths.APP_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+        fd = os.open(
+            str(recovery_path),
+            os.O_CREAT | os.O_WRONLY | os.O_TRUNC,
+            0o600,
+        )
+        try:
+            os.write(fd, token.encode())
+        finally:
+            os.close(fd)
+        os.chmod(recovery_path, 0o600)
+    except Exception:
+        pass
+
+    raw = os.environ.get("FRIDAY_BP_UI_PORT")
+    try:
+        port = int(raw) if raw is not None else 6789
+    except ValueError:
+        port = 6789
+
+    recovery_url = f"http://127.0.0.1:{port}/reset?t={token}"
+    return {"status": "ok", "recovery_url": recovery_url}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_password_mcp_tools.py
+++ b/tests/test_password_mcp_tools.py
@@ -1,0 +1,183 @@
+"""
+tests/test_password_mcp_tools.py — Tests for set_ui_password / reset_ui_password MCP tools.
+
+Covers:
+  - set_ui_password with valid old + new (both >= 8 chars) → ok, password verifies
+  - set_ui_password with wrong old_password → error
+  - set_ui_password without old_password when one exists → error
+  - set_ui_password with too-short new password → error
+  - set_ui_password with no active user → error
+  - reset_ui_password → recovery.txt created with 0600 perms, recovery_url contains token
+  - reset_ui_password with no active user → error
+"""
+
+from __future__ import annotations
+
+import stat
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path, monkeypatch) -> Path:
+    """Initialise a fresh SQLite DB in tmp_path and monkeypatch server.paths."""
+    import server.paths as paths
+    from server.db import init_db
+
+    db = tmp_path / "test_pw_mcp.db"
+    init_db(db)
+
+    monkeypatch.setattr(paths, "DB_PATH", db)
+    monkeypatch.setattr(paths, "APP_DIR", tmp_path)
+
+    # Also patch server.main's reference to server.paths so the tools see the
+    # monkeypatched values via server.paths.DB_PATH / server.paths.APP_DIR.
+    return db
+
+
+@pytest.fixture()
+def user(db_path: Path) -> dict:
+    """Create a user in the test DB and return {user_id, username, password}."""
+    from ui.auth import create_session, create_user
+
+    user_id = create_user(db_path, "testuser", "password123")
+    # Create an active session so get_active_user_id() can find this user.
+    create_session(db_path, user_agent="pytest", user_id=user_id)
+    return {"user_id": user_id, "username": "testuser", "password": "password123"}
+
+
+def _clear_tokens() -> None:
+    """Clear the shared in-memory recovery token store between tests."""
+    from ui.auth import _recovery_tokens
+
+    _recovery_tokens.clear()
+
+
+# ---------------------------------------------------------------------------
+# set_ui_password
+# ---------------------------------------------------------------------------
+
+
+class TestSetUiPassword:
+    def test_success_updates_password(self, db_path, user):
+        """Valid old + new password → status ok, new password verifies."""
+        from server.main import set_ui_password
+        from ui.auth import get_user_by_id, verify_password
+
+        result = set_ui_password("newpass99", old_password="password123")
+        assert result == {"status": "ok"}, f"Unexpected result: {result}"
+
+        updated = get_user_by_id(db_path, user["user_id"])
+        assert verify_password("newpass99", updated["password_hash"])
+
+    def test_wrong_old_password(self, db_path, user):
+        """Wrong old_password → error."""
+        from server.main import set_ui_password
+
+        result = set_ui_password("newpass99", old_password="wrongpassword")
+        assert result["status"] == "error"
+        assert "old password" in result["message"].lower()
+
+    def test_missing_old_password(self, db_path, user):
+        """old_password omitted when user has a password → error."""
+        from server.main import set_ui_password
+
+        result = set_ui_password("newpass99")
+        assert result["status"] == "error"
+        assert "old password" in result["message"].lower()
+
+    def test_too_short_new_password(self, db_path, user):
+        """new_password shorter than 8 chars → error before any DB access."""
+        from server.main import set_ui_password
+
+        result = set_ui_password("short", old_password="password123")
+        assert result["status"] == "error"
+        assert "short" in result["message"].lower() or "8" in result["message"]
+
+    def test_no_active_user(self, db_path, monkeypatch):
+        """No active session / user → error."""
+        import ui.auth as _auth
+        from server.main import set_ui_password
+
+        monkeypatch.setattr(_auth, "get_active_user_id", lambda _: None)
+
+        # Also patch server.main's imported reference
+        import server.main as _main
+
+        monkeypatch.setattr(_main, "get_active_user_id", lambda _: None)
+
+        result = set_ui_password("newpass99", old_password="password123")
+        assert result["status"] == "error"
+        assert "logged in" in result["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# reset_ui_password
+# ---------------------------------------------------------------------------
+
+
+class TestResetUiPassword:
+    def test_recovery_txt_created(self, db_path, user, tmp_path):
+        """reset_ui_password creates recovery.txt with mode 0600."""
+        _clear_tokens()
+        from server.main import reset_ui_password
+
+        result = reset_ui_password()
+        assert result["status"] == "ok", f"Unexpected: {result}"
+        assert "recovery_url" in result
+
+        recovery_path = tmp_path / "recovery.txt"
+        assert recovery_path.exists(), "recovery.txt was not created"
+
+        mode = stat.S_IMODE(recovery_path.stat().st_mode)
+        assert mode == 0o600, f"Expected 0600, got {oct(mode)}"
+
+    def test_recovery_url_contains_token(self, db_path, user, tmp_path):
+        """The recovery_url must contain the written token."""
+        _clear_tokens()
+        from server.main import reset_ui_password
+
+        result = reset_ui_password()
+        recovery_path = tmp_path / "recovery.txt"
+        token = recovery_path.read_text().strip()
+
+        assert len(token) == 64, f"Token should be 64 hex chars, got {len(token)}"
+        assert token in result["recovery_url"]
+
+    def test_token_stored_in_memory(self, db_path, user, tmp_path):
+        """Token is stored in the shared _recovery_tokens dict."""
+        _clear_tokens()
+        from server.main import reset_ui_password
+        from ui.auth import _recovery_tokens
+
+        reset_ui_password()
+        recovery_path = tmp_path / "recovery.txt"
+        token = recovery_path.read_text().strip()
+        assert token in _recovery_tokens
+
+    def test_recovery_url_default_port(self, db_path, user, monkeypatch):
+        """recovery_url uses port 6789 when FRIDAY_BP_UI_PORT is not set."""
+        _clear_tokens()
+        import os
+
+        from server.main import reset_ui_password
+
+        monkeypatch.delitem(os.environ, "FRIDAY_BP_UI_PORT", raising=False)
+        result = reset_ui_password()
+        assert "127.0.0.1:6789" in result["recovery_url"]
+
+    def test_no_active_user(self, db_path, monkeypatch):
+        """No active session / user → error."""
+        _clear_tokens()
+        import server.main as _main
+
+        monkeypatch.setattr(_main, "get_active_user_id", lambda _: None)
+
+        result = _main.reset_ui_password()
+        assert result["status"] == "error"
+        assert "logged in" in result["message"].lower()

--- a/ui/auth.py
+++ b/ui/auth.py
@@ -322,6 +322,27 @@ def get_active_user_id(db_path) -> Optional[str]:
         conn.close()
 
 
+# ── Recovery token store (shared with MCP tools) ────────────────────────────
+# Maps token -> (user_id, expiry_float).  In-memory; tokens do not survive
+# daemon restarts, which is acceptable for a local single-user app.
+
+_recovery_tokens: dict[str, tuple[str, float]] = {}
+_RECOVERY_TOKEN_TTL: int = 600  # 10 minutes
+
+
+def add_recovery_token(token: str, user_id: str) -> None:
+    """Register *token* → *user_id* in the in-memory recovery-token store.
+
+    The token expires after ``_RECOVERY_TOKEN_TTL`` seconds.  This helper
+    is shared by the UI POST /forgot handler and the MCP
+    ``reset_ui_password`` tool so both operate on the same in-memory map.
+    """
+    import time as _time_mod
+
+    expiry = _time_mod.time() + _RECOVERY_TOKEN_TTL
+    _recovery_tokens[token] = (user_id, expiry)
+
+
 # ── Legacy app_config helpers (kept for backward compat) ─────────────────
 # These delegate to the users table when a user exists, otherwise fall back
 # to the app_config table.  New code should use the user-centric helpers

--- a/ui/server.py
+++ b/ui/server.py
@@ -44,8 +44,14 @@ from fastapi.templating import Jinja2Templates
 
 import server.paths as _paths
 from server.db import get_db
+
+# ── Recovery token store (in-memory, 10-min TTL) ──────────────────────────
+# Shared with the MCP tools (reset_ui_password) via ui.auth so both operate
+# on the same in-memory map.  Tokens do not survive daemon restarts.
 from ui.auth import (
     SESSION_COOKIE,
+    _recovery_tokens,
+    add_recovery_token,
     check_session,
     create_session,
     create_user,
@@ -62,12 +68,6 @@ from ui.auth import (
     update_user_password,
     verify_password,
 )
-
-# ── Recovery token store (in-memory, 10-min TTL) ──────────────────────────
-# Maps token -> (user_id, expiry_float).  In-memory is fine for a local app;
-# tokens survive daemon restart only if users don't restart between steps.
-_recovery_tokens: dict[str, tuple[str, float]] = {}
-_RECOVERY_TOKEN_TTL = 600  # 10 minutes
 
 # ── App setup ───────────────────────────────────────────────────────────────
 
@@ -612,8 +612,7 @@ async def forgot_post(request: Request):
 
     if user:
         token = secrets.token_hex(32)
-        expiry = time.time() + _RECOVERY_TOKEN_TTL
-        _recovery_tokens[token] = (user["id"], expiry)
+        add_recovery_token(token, user["id"])
 
         recovery_path = _paths.APP_DIR / "recovery.txt"
         try:


### PR DESCRIPTION
Closes #53

## Summary

Implements two MCP tools for password management — convenience wrappers over the existing auth helpers.

### Changes

**`ui/auth.py`** — DRY refactor:
- Extracted `_recovery_tokens` dict, `_RECOVERY_TOKEN_TTL`, and new `add_recovery_token(token, user_id)` helper from `ui/server.py` so both the UI `/forgot` handler and the new MCP `reset_ui_password` tool share the same in-memory token store.

**`ui/server.py`**:
- Replaced local `_recovery_tokens`/`_RECOVERY_TOKEN_TTL` definitions with imports from `ui.auth`.
- Simplified `forgot_post` to call `add_recovery_token(token, user["id"])`.

**`server/main.py`** — two new `@mcp.tool` functions:
- `set_ui_password(new_password, old_password=None)` — validates length ≥ 8, resolves active user via `get_active_user_id`, verifies old password, calls `update_user_password`.
- `reset_ui_password()` — generates a 32-byte hex token, registers it via `add_recovery_token`, writes `~/.friday-bp/recovery.txt` (mode 0600), returns `recovery_url`.

**`tests/test_password_mcp_tools.py`** — 10 new tests covering all specified cases.

## Tests

```
tests/test_password_mcp_tools.py::TestSetUiPassword::test_success_updates_password PASSED
tests/test_password_mcp_tools.py::TestSetUiPassword::test_wrong_old_password PASSED
tests/test_password_mcp_tools.py::TestSetUiPassword::test_missing_old_password PASSED
tests/test_password_mcp_tools.py::TestSetUiPassword::test_too_short_new_password PASSED
tests/test_password_mcp_tools.py::TestSetUiPassword::test_no_active_user PASSED
tests/test_password_mcp_tools.py::TestResetUiPassword::test_recovery_txt_created PASSED
tests/test_password_mcp_tools.py::TestResetUiPassword::test_recovery_url_contains_token PASSED
tests/test_password_mcp_tools.py::TestResetUiPassword::test_token_stored_in_memory PASSED
tests/test_password_mcp_tools.py::TestResetUiPassword::test_recovery_url_default_port PASSED
tests/test_password_mcp_tools.py::TestResetUiPassword::test_no_active_user PASSED

495 passed, 1 skipped (full suite)
```

## Interactive check

```python
from server.main import set_ui_password, reset_ui_password
print('set (wrong old):', set_ui_password('newpass12345', old_password='wrongpass'))
# {'status': 'error', 'message': 'Old password does not match'}
print('set (too short):', set_ui_password('short', old_password='wrongpass'))
# {'status': 'error', 'message': 'Password too short'}
print('set (no old pw):', set_ui_password('newpass12345'))
# {'status': 'error', 'message': 'Old password required'}
print('reset:', reset_ui_password())
# {'status': 'ok', 'recovery_url': 'http://127.0.0.1:6789/reset?t=b9e387f80988ba92816750e600877df24da649ba05d65d921735969ee21411d4'}
```