### PR TITLE
[P5] Proactive re-auth: get_connections_needing_attention MCP tool (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,26 @@ read it). Copy it into the reset page to set a new one.
 **"How do I uninstall?"** → `clawhub uninstall friday-budgeting-pro`.
 Your data file stays unless you delete it manually.
 
+### Proactive Re-Auth Alerts
+
+Friday will proactively notify you when a bank connection needs attention.
+During the daily 06:00 sync, it checks for connections in these states:
+
+- **`needs_reauth`** — Plaid login has expired (e.g. you changed your bank password).
+  > ⚠️ Your BMO Bank of Montreal connection needs re-authorization. Say 'reconnect BMO Bank of Montreal' to open the re-auth flow.
+
+- **`pending_expiration`** — Token is about to expire (some institutions rotate tokens).
+  > ⚠️ Your TD Bank connection expires soon. Say 'reconnect TD Bank' to refresh it.
+
+- **Never synced** — A connection was added but sync has never run.
+  > ⚠️ Your Scotiabank connection needs re-authorization. Say 'reconnect Scotiabank' to open the re-auth flow.
+
+Alerts are throttled to at most once every 24 hours per connection so you
+won't be spammed. You can also ask your agent directly:
+> "Do any of my bank connections need attention?"
+
+and it will call `get_connections_needing_attention` and report back.
+
 ---
 
 ## License

--- a/server/db.py
+++ b/server/db.py
@@ -60,6 +60,9 @@ def init_db(path: str | Path) -> None:
         _add_col_if_missing(
             conn, "bank_connections", "plaid_env", "TEXT NOT NULL DEFAULT 'sandbox'"
         )
+
+        # Migration: last_alerted_at (#35 — proactive re-auth alerts)
+        _add_col_if_missing(conn, "bank_connections", "last_alerted_at", "INTEGER")
         _add_col_if_missing(conn, "ledgers", "user_id", "TEXT")
         _add_col_if_missing(conn, "classification_hints", "user_id", "TEXT")
         _add_col_if_missing(conn, "sessions", "user_id", "TEXT")

--- a/server/main.py
+++ b/server/main.py
@@ -128,8 +128,12 @@ def _register_openclaw_cron() -> bool:
         "payload": {
             "kind": "agentTurn",
             "message": (
-                "Run friday-budgeting-pro sync: call the sync MCP tool, "
-                "then call get_needs_review and notify the user about any "
+                "Run friday-budgeting-pro daily tasks in order: "
+                "1) Call get_connections_needing_attention — if any connections "
+                "are returned, alert the user immediately with their suggested_message "
+                "(e.g. '\u26a0\ufe0f 1 connection needs attention: BMO Bank of Montreal'). "
+                "2) Call the sync MCP tool to pull new transactions. "
+                "3) Call get_needs_review and notify the user about any "
                 "transactions needing classification."
             ),
             "timeoutSeconds": 900,
@@ -448,6 +452,110 @@ def list_connections() -> dict:
         conn.close()
 
     return {"connections": connections}
+
+
+@mcp.tool
+def get_connections_needing_attention() -> dict:
+    """Return bank connections that need user action (re-auth or pending expiration).
+
+    A connection needs attention when:
+      - ``status = 'needs_reauth'``  — credentials have expired / login required.
+      - ``status = 'pending_expiration'`` — token will expire soon.
+      - ``last_synced_at IS NULL`` — connection was added but never synced.
+
+    For each connection returned, ``last_alerted_at`` is updated to the current
+    Unix timestamp so repeated cron calls do not spam the user more often than
+    once every 24 hours.
+
+    Returns
+    -------
+    dict
+        {"connections": [{"connection_id", "institution_name", "status",
+                          "days_until_expiry", "suggested_message",
+                          "last_alerted_at"}, ...]}
+    """
+    uid = get_active_user_id(server.paths.DB_PATH)
+    if uid is None:
+        return {"connections": []}
+
+    now = int(_time.time())
+    alert_cooldown = 24 * 60 * 60  # 24 hours in seconds
+
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        rows = conn.execute(
+            """
+            SELECT id, institution_name, status, last_synced_at,
+                   last_alerted_at
+            FROM bank_connections
+            WHERE user_id = ?
+              AND (
+                    status IN ('needs_reauth', 'pending_expiration')
+                    OR last_synced_at IS NULL
+              )
+            ORDER BY rowid
+            """,
+            (uid,),
+        ).fetchall()
+
+        result_connections = []
+        for row in rows:
+            connection_id = row["id"]
+            institution_name = row["institution_name"] or "Your bank"
+            status = row["status"]
+            last_alerted_at = row["last_alerted_at"]
+
+            # Throttle: skip if alerted within the last 24 hours.
+            if last_alerted_at is not None and (now - last_alerted_at) < alert_cooldown:
+                continue
+
+            # Determine days_until_expiry for pending_expiration connections.
+            # We don't have an explicit expiry date stored in the current schema;
+            # report as None until a dedicated expiry field is added.
+            days_until_expiry: Optional[int] = None
+
+            # Build suggested message.
+            if status == "pending_expiration":
+                if days_until_expiry is not None:
+                    suggested_message = (
+                        f"Your {institution_name} connection expires in "
+                        f"{days_until_expiry} days. "
+                        f"Say 'reconnect {institution_name}' to refresh it."
+                    )
+                else:
+                    suggested_message = (
+                        f"Your {institution_name} connection expires soon. "
+                        f"Say 'reconnect {institution_name}' to refresh it."
+                    )
+            else:
+                # needs_reauth or never-synced
+                suggested_message = (
+                    f"Your {institution_name} connection needs re-authorization. "
+                    f"Say 'reconnect {institution_name}' to open the re-auth flow."
+                )
+
+            # Update last_alerted_at to now.
+            conn.execute(
+                "UPDATE bank_connections SET last_alerted_at = ? WHERE id = ?",
+                (now, connection_id),
+            )
+
+            result_connections.append(
+                {
+                    "connection_id": connection_id,
+                    "institution_name": row["institution_name"],
+                    "status": status,
+                    "days_until_expiry": days_until_expiry,
+                    "suggested_message": suggested_message,
+                    "last_alerted_at": now,
+                }
+            )
+
+        conn.commit()
+    finally:
+        conn.close()
+
+    return {"connections": result_connections}
 
 
 @mcp.tool

--- a/tests/test_proactive_reauth.py
+++ b/tests/test_proactive_reauth.py
@@ -1,0 +1,255 @@
+"""
+tests/test_proactive_reauth.py — Tests for get_connections_needing_attention (#35).
+
+Covers:
+  - needs_reauth connection → returned with correct message
+  - pending_expiration connection → returned with expiry message
+  - active/healthy connection → NOT returned
+  - last_alerted_at is updated after call
+  - last_alerted_at within 24h → throttled (connection not returned again)
+  - no active user → returns empty list
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+
+import server.paths
+from server.db import get_db, init_db
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path, monkeypatch):
+    """Fresh temp DB with server.paths.DB_PATH monkeypatched."""
+    path = tmp_path / "test.db"
+    init_db(path)
+    monkeypatch.setattr(server.paths, "DB_PATH", path)
+    return path
+
+
+@pytest.fixture()
+def db_path_with_user(db_path):
+    """db_path that has a user inserted.
+
+    get_active_user_id() falls back to the first user in the DB when no
+    session exists, so we only need to insert a user row here.
+    """
+    conn = get_db(db_path)
+    user_id = str(uuid.uuid4())
+    now = int(time.time())
+    conn.execute(
+        "INSERT INTO users (id, username, password_hash, created_at) VALUES (?, ?, ?, ?)",
+        (user_id, "testuser", "fakehash", now),
+    )
+    conn.commit()
+    conn.close()
+    return db_path, user_id
+
+
+def _insert_connection(db_path, user_id, status, institution_name="Test Bank", last_synced_at=1):
+    """Helper: insert a bank_connections row and return its id."""
+    conn = get_db(db_path)
+    cid = str(uuid.uuid4())
+    conn.execute(
+        """
+        INSERT INTO bank_connections
+            (id, plaid_item_id, plaid_access_token_encrypted, status,
+             user_id, institution_name, last_synced_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (cid, f"item-{cid}", f"enc:tok-{cid}", status, user_id, institution_name, last_synced_at),
+    )
+    conn.commit()
+    conn.close()
+    return cid
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_needs_reauth_returned_with_correct_message(db_path_with_user):
+    db_path, user_id = db_path_with_user
+    cid = _insert_connection(db_path, user_id, "needs_reauth", "BMO Bank of Montreal")
+
+    from server.main import get_connections_needing_attention
+
+    result = get_connections_needing_attention()
+
+    assert isinstance(result, dict)
+    assert "connections" in result
+    connections = result["connections"]
+    assert len(connections) == 1
+
+    c = connections[0]
+    assert c["connection_id"] == cid
+    assert c["institution_name"] == "BMO Bank of Montreal"
+    assert c["status"] == "needs_reauth"
+    assert "re-authorization" in c["suggested_message"]
+    assert "BMO Bank of Montreal" in c["suggested_message"]
+    assert "reconnect BMO Bank of Montreal" in c["suggested_message"]
+
+
+def test_pending_expiration_returned_with_expiry_message(db_path_with_user):
+    db_path, user_id = db_path_with_user
+    cid = _insert_connection(db_path, user_id, "pending_expiration", "TD Bank")
+
+    from server.main import get_connections_needing_attention
+
+    result = get_connections_needing_attention()
+
+    connections = result["connections"]
+    assert len(connections) == 1
+    c = connections[0]
+    assert c["connection_id"] == cid
+    assert c["status"] == "pending_expiration"
+    assert "expires" in c["suggested_message"]
+    assert "TD Bank" in c["suggested_message"]
+    assert "reconnect TD Bank" in c["suggested_message"]
+
+
+def test_active_connection_not_returned(db_path_with_user):
+    db_path, user_id = db_path_with_user
+    # Healthy active connection — should NOT appear.
+    _insert_connection(db_path, user_id, "active", "RBC Royal Bank")
+
+    from server.main import get_connections_needing_attention
+
+    result = get_connections_needing_attention()
+    assert result["connections"] == []
+
+
+def test_never_synced_connection_returned(db_path_with_user):
+    db_path, user_id = db_path_with_user
+    # last_synced_at=None → never synced → needs attention
+    conn = get_db(db_path)
+    cid = str(uuid.uuid4())
+    conn.execute(
+        """
+        INSERT INTO bank_connections
+            (id, plaid_item_id, plaid_access_token_encrypted, status,
+             user_id, institution_name, last_synced_at)
+        VALUES (?, ?, ?, 'active', ?, ?, NULL)
+        """,
+        (cid, f"item-{cid}", f"enc:tok-{cid}", user_id, "Scotiabank"),
+    )
+    conn.commit()
+    conn.close()
+
+    from server.main import get_connections_needing_attention
+
+    result = get_connections_needing_attention()
+    assert len(result["connections"]) == 1
+    c = result["connections"][0]
+    assert c["connection_id"] == cid
+    assert "re-authorization" in c["suggested_message"]
+
+
+def test_last_alerted_at_updated_after_call(db_path_with_user):
+    db_path, user_id = db_path_with_user
+    cid = _insert_connection(db_path, user_id, "needs_reauth")
+
+    before = int(time.time())
+    from server.main import get_connections_needing_attention
+
+    get_connections_needing_attention()
+    after = int(time.time())
+
+    conn = get_db(db_path)
+    row = conn.execute(
+        "SELECT last_alerted_at FROM bank_connections WHERE id = ?", (cid,)
+    ).fetchone()
+    conn.close()
+
+    assert row["last_alerted_at"] is not None
+    assert before <= row["last_alerted_at"] <= after
+
+
+def test_throttle_within_24h(db_path_with_user):
+    """Connection alerted recently should NOT appear in a second call."""
+    db_path, user_id = db_path_with_user
+    cid = _insert_connection(db_path, user_id, "needs_reauth")
+
+    # Pre-set last_alerted_at to 1 hour ago (within 24h window).
+    one_hour_ago = int(time.time()) - 3600
+    conn = get_db(db_path)
+    conn.execute(
+        "UPDATE bank_connections SET last_alerted_at = ? WHERE id = ?",
+        (one_hour_ago, cid),
+    )
+    conn.commit()
+    conn.close()
+
+    from server.main import get_connections_needing_attention
+
+    result = get_connections_needing_attention()
+    assert result["connections"] == []
+
+
+def test_not_throttled_after_24h(db_path_with_user):
+    """Connection alerted >24h ago should appear again."""
+    db_path, user_id = db_path_with_user
+    cid = _insert_connection(db_path, user_id, "needs_reauth")
+
+    # Pre-set last_alerted_at to 25 hours ago (outside cooldown).
+    twenty_five_hours_ago = int(time.time()) - 25 * 3600
+    conn = get_db(db_path)
+    conn.execute(
+        "UPDATE bank_connections SET last_alerted_at = ? WHERE id = ?",
+        (twenty_five_hours_ago, cid),
+    )
+    conn.commit()
+    conn.close()
+
+    from server.main import get_connections_needing_attention
+
+    result = get_connections_needing_attention()
+    assert len(result["connections"]) == 1
+
+
+def test_no_active_user_returns_empty(db_path):
+    """When there is no active session/user, return empty list gracefully."""
+    from server.main import get_connections_needing_attention
+
+    result = get_connections_needing_attention()
+    assert result == {"connections": []}
+
+
+def test_only_current_user_connections_returned(db_path_with_user):
+    """Connections belonging to a different user are not returned."""
+    db_path, user_id = db_path_with_user
+
+    # Create a second user with a needs_reauth connection (no session).
+    other_user_id = str(uuid.uuid4())
+    conn = get_db(db_path)
+    now = int(time.time())
+    conn.execute(
+        "INSERT INTO users (id, username, password_hash, created_at) VALUES (?, ?, ?, ?)",
+        (other_user_id, "otheruser", "fakehash2", now),
+    )
+    other_cid = str(uuid.uuid4())
+    conn.execute(
+        """
+        INSERT INTO bank_connections
+            (id, plaid_item_id, plaid_access_token_encrypted, status,
+             user_id, institution_name, last_synced_at)
+        VALUES (?, ?, ?, 'needs_reauth', ?, ?, 1)
+        """,
+        (other_cid, f"item-{other_cid}", f"enc:tok-{other_cid}", other_user_id, "Other Bank"),
+    )
+    conn.commit()
+    conn.close()
+
+    from server.main import get_connections_needing_attention
+
+    result = get_connections_needing_attention()
+    returned_ids = [c["connection_id"] for c in result["connections"]]
+    assert other_cid not in returned_ids


### PR DESCRIPTION
Closes #35

## Summary

Implements proactive re-auth prompts so HAL can alert the user when a bank connection needs attention, without waiting for the user to ask.

### Changes

**`server/db.py`**
- Added `last_alerted_at INTEGER` column migration via `_add_col_if_missing` — idempotent, runs at startup.

**`server/main.py`**
- New `get_connections_needing_attention()` MCP tool: queries `bank_connections` for `needs_reauth`, `pending_expiration`, and never-synced (NULL `last_synced_at`) connections.
- Returns structured list with `suggested_message` per connection.
- Updates `last_alerted_at` on each returned connection to throttle alerts to at most once per 24 hours.
- Updated cron payload message to call `get_connections_needing_attention` **before** sync, and include a ⚠️ alert line if any connections need attention.

**`tests/test_proactive_reauth.py`** — 9 new tests covering all cases.

**`README.md`** — Added Proactive Re-Auth Alerts subsection under Troubleshooting.

### Interactive check

```
$ python3 -c "from server.main import get_connections_needing_attention; print(get_connections_needing_attention())"
{'connections': []}
```

### Test results

508 passed, 1 skipped — all green.