### PR TITLE
[P3] Implement ledger MCP tools: list/add/remove (#148)

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -644,26 +644,169 @@ def set_account_description(account_id: str, description: str) -> dict:
 
 @mcp.tool
 def list_ledgers() -> dict:
-    """List all ledgers and their line items."""
-    return {"status": "not_implemented"}
-
-
-@mcp.tool
-def add_line_item(ledger_id: str, name: str, item_type: str) -> dict:
-    """Add a new line item to a ledger."""
-    return {"status": "not_implemented"}
+    """List all ledgers and their line items for the active user."""
+    uid = get_active_user_id(server.paths.DB_PATH)
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        if uid:
+            ledger_rows = conn.execute(
+                "SELECT id, name FROM ledgers WHERE user_id = ? OR user_id IS NULL ORDER BY name",
+                (uid,),
+            ).fetchall()
+        else:
+            return {"ledgers": []}
+        ledgers = []
+        for lr in ledger_rows:
+            items = conn.execute(
+                "SELECT id, name, item_type FROM line_items WHERE ledger_id = ? ORDER BY name",
+                (lr["id"],),
+            ).fetchall()
+            ledgers.append(
+                {
+                    "id": lr["id"],
+                    "name": lr["name"],
+                    "items": [
+                        {"id": i["id"], "name": i["name"], "type": i["item_type"]} for i in items
+                    ],
+                }
+            )
+        return {"ledgers": ledgers}
+    finally:
+        conn.close()
 
 
 @mcp.tool
 def add_ledger(name: str) -> dict:
-    """Create a new ledger."""
-    return {"status": "not_implemented"}
+    """Create a new ledger for the active user.
+
+    Parameters
+    ----------
+    name : str
+        Non-empty ledger name.  Returns an error if a ledger with this name
+        already exists for the active user.
+    """
+    name = name.strip() if name else ""
+    if not name:
+        return {"status": "error", "message": "Ledger name must be non-empty"}
+
+    uid = get_active_user_id(server.paths.DB_PATH)
+    if uid is None:
+        return {"status": "error", "message": "No active user"}
+
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        existing = conn.execute(
+            "SELECT id FROM ledgers WHERE name = ? AND user_id = ?",
+            (name, uid),
+        ).fetchone()
+        if existing:
+            return {"status": "error", "message": f"Ledger '{name}' already exists"}
+        ledger_id = str(uuid.uuid4())
+        conn.execute(
+            "INSERT INTO ledgers (id, name, user_id) VALUES (?, ?, ?)",
+            (ledger_id, name, uid),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    return {"status": "ok", "ledger_id": ledger_id}
+
+
+@mcp.tool
+def add_line_item(ledger_id: str, name: str, item_type: str) -> dict:
+    """Add a new line item to a ledger owned by the active user.
+
+    Parameters
+    ----------
+    ledger_id : str
+        ID of the target ledger.
+    name : str
+        Non-empty display name for the line item.
+    item_type : str
+        Must be ``'income'`` or ``'expense'``.
+    """
+    name = name.strip() if name else ""
+    if not name:
+        return {"status": "error", "message": "Line item name must be non-empty"}
+    if item_type not in ("income", "expense"):
+        return {"status": "error", "message": "item_type must be 'income' or 'expense'"}
+
+    uid = get_active_user_id(server.paths.DB_PATH)
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        if uid:
+            ledger_row = conn.execute(
+                "SELECT id FROM ledgers WHERE id = ? AND (user_id = ? OR user_id IS NULL)",
+                (ledger_id, uid),
+            ).fetchone()
+        else:
+            ledger_row = conn.execute(
+                "SELECT id FROM ledgers WHERE id = ?",
+                (ledger_id,),
+            ).fetchone()
+        if ledger_row is None:
+            return {
+                "status": "error",
+                "message": f"Ledger '{ledger_id}' not found or not owned by active user",
+            }
+
+        item_id = str(uuid.uuid4())
+        conn.execute(
+            "INSERT INTO line_items (id, ledger_id, name, item_type) VALUES (?, ?, ?, ?)",
+            (item_id, ledger_id, name, item_type),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    return {"status": "ok", "item_id": item_id}
 
 
 @mcp.tool
 def remove_line_item(id: str) -> dict:
-    """Remove a line item from a ledger."""
-    return {"status": "not_implemented"}
+    """Remove a line item from a ledger.
+
+    The active user must own the ledger the item belongs to.  If any
+    ``transaction_entries`` reference this item the deletion is refused —
+    delete the entries first or re-route those transactions.
+    """
+    uid = get_active_user_id(server.paths.DB_PATH)
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        if uid:
+            row = conn.execute(
+                """
+                SELECT li.id FROM line_items li
+                JOIN ledgers l ON l.id = li.ledger_id
+                WHERE li.id = ? AND (l.user_id = ? OR l.user_id IS NULL)
+                """,
+                (id, uid),
+            ).fetchone()
+        else:
+            row = conn.execute("SELECT id FROM line_items WHERE id = ?", (id,)).fetchone()
+        if row is None:
+            return {
+                "status": "error",
+                "message": f"Line item '{id}' not found or not owned by active user",
+            }
+
+        entry_count = conn.execute(
+            "SELECT COUNT(*) FROM transaction_entries WHERE line_item_id = ?",
+            (id,),
+        ).fetchone()[0]
+        if entry_count > 0:
+            return {
+                "status": "error",
+                "message": "Line item has attached entries. Delete them first or re-route transactions.",
+            }
+
+        conn.execute("DELETE FROM line_items WHERE id = ?", (id,))
+        conn.commit()
+    finally:
+        conn.close()
+
+    return {"status": "ok"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -88,10 +88,11 @@ def test_setup_status_fresh(db_path, authed_user):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(strict=False, reason="list_ledgers not yet implemented (#121)")
-def test_list_ledgers(db_path, authed_user):
+def test_list_ledgers(db_path, authed_user, monkeypatch):
     """list_ledgers() returns a dict with a 'ledgers' key containing Personal."""
     from server.main import apply_initial_setup, list_ledgers
+
+    monkeypatch.setattr("server.main._register_openclaw_cron", lambda: False)
 
     # Seed the default Personal ledger via apply_initial_setup.
     apply_initial_setup(banks_to_link=[], extra_ledgers=[], hints=[])

--- a/tests/test_ledger_mcp_tools.py
+++ b/tests/test_ledger_mcp_tools.py
@@ -1,0 +1,274 @@
+"""
+tests/test_ledger_mcp_tools.py — Unit tests for ledger MCP tools.
+
+Tests:
+  - list_ledgers returns Personal ledger after setup
+  - add_ledger creates + appears in list_ledgers
+  - add_line_item adds to correct ledger with correct type
+  - remove_line_item works when no entries attached
+  - remove_line_item returns error when entries exist
+  - All tools return empty/error gracefully with no active user
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+
+import server.paths
+from server.db import get_db, init_db
+from ui.auth import create_session, create_user
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path, monkeypatch) -> Path:
+    """Fresh temp DB; monkeypatch server.paths.DB_PATH to point at it."""
+    path = tmp_path / "test_ledger.db"
+    init_db(path)
+    monkeypatch.setattr(server.paths, "DB_PATH", path)
+    return path
+
+
+@pytest.fixture()
+def authed_user(db_path: Path) -> dict:
+    """Create a test user + session so get_active_user_id() returns a real ID."""
+    user_id = create_user(db_path, "testuser", "testpass123")
+    token = create_session(db_path, user_id=user_id)
+    return {"user_id": user_id, "token": token}
+
+
+def _uid() -> str:
+    return str(uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# Helper: seed the Personal ledger via apply_initial_setup
+# ---------------------------------------------------------------------------
+
+
+def _seed_personal(monkeypatch):
+    """Call apply_initial_setup with a mocked _register_openclaw_cron."""
+    from server.main import apply_initial_setup
+
+    monkeypatch.setattr("server.main._register_openclaw_cron", lambda: False)
+    apply_initial_setup(banks_to_link=[], extra_ledgers=[], hints=[])
+
+
+# ---------------------------------------------------------------------------
+# Test: list_ledgers with no active user returns empty list
+# ---------------------------------------------------------------------------
+
+
+def test_list_ledgers_no_active_user(db_path):
+    """list_ledgers() with no session → {'ledgers': []}."""
+    from server.main import list_ledgers
+
+    result = list_ledgers()
+    assert isinstance(result, dict)
+    assert result == {"ledgers": []}
+
+
+# ---------------------------------------------------------------------------
+# Test: list_ledgers returns Personal ledger after setup
+# ---------------------------------------------------------------------------
+
+
+def test_list_ledgers_returns_personal(db_path, authed_user, monkeypatch):
+    """list_ledgers() returns a dict with Personal ledger + line items."""
+    from server.main import list_ledgers
+
+    _seed_personal(monkeypatch)
+
+    result = list_ledgers()
+    assert isinstance(result, dict)
+    assert "ledgers" in result
+
+    names = [lg["name"] for lg in result["ledgers"]]
+    assert "Personal" in names
+
+    personal = next(lg for lg in result["ledgers"] if lg["name"] == "Personal")
+    assert "id" in personal
+    assert "items" in personal
+    assert len(personal["items"]) > 0
+    # Each item should have id, name, type
+    item = personal["items"][0]
+    assert "id" in item
+    assert "name" in item
+    assert "type" in item
+
+
+# ---------------------------------------------------------------------------
+# Test: add_ledger creates + appears in list_ledgers
+# ---------------------------------------------------------------------------
+
+
+def test_add_ledger_and_list(db_path, authed_user):
+    """add_ledger() creates a ledger; list_ledgers() shows it."""
+    from server.main import add_ledger, list_ledgers
+
+    result = add_ledger("Business")
+    assert result["status"] == "ok"
+    assert "ledger_id" in result
+    ledger_id = result["ledger_id"]
+
+    ledgers = list_ledgers()["ledgers"]
+    ids = [lg["id"] for lg in ledgers]
+    assert ledger_id in ids
+
+    names = [lg["name"] for lg in ledgers]
+    assert "Business" in names
+
+
+def test_add_ledger_empty_name_returns_error(db_path, authed_user):
+    """add_ledger('') returns an error."""
+    from server.main import add_ledger
+
+    result = add_ledger("")
+    assert result["status"] == "error"
+
+
+def test_add_ledger_duplicate_returns_error(db_path, authed_user):
+    """add_ledger() twice with the same name returns error on second call."""
+    from server.main import add_ledger
+
+    add_ledger("Savings")
+    result = add_ledger("Savings")
+    assert result["status"] == "error"
+
+
+def test_add_ledger_no_active_user(db_path):
+    """add_ledger() with no active session returns an error."""
+    from server.main import add_ledger
+
+    result = add_ledger("NoUser")
+    assert result["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Test: add_line_item adds to correct ledger with correct type
+# ---------------------------------------------------------------------------
+
+
+def test_add_line_item_income(db_path, authed_user):
+    """add_line_item() with type='income' creates and returns item_id."""
+    from server.main import add_ledger, add_line_item, list_ledgers
+
+    add_result = add_ledger("Work")
+    ledger_id = add_result["ledger_id"]
+
+    result = add_line_item(ledger_id=ledger_id, name="Freelance", item_type="income")
+    assert result["status"] == "ok"
+    assert "item_id" in result
+
+    # Verify it appears in list_ledgers
+    ledgers = list_ledgers()["ledgers"]
+    work = next(lg for lg in ledgers if lg["id"] == ledger_id)
+    items = {i["name"]: i for i in work["items"]}
+    assert "Freelance" in items
+    assert items["Freelance"]["type"] == "income"
+
+
+def test_add_line_item_expense(db_path, authed_user):
+    """add_line_item() with type='expense' creates the item correctly."""
+    from server.main import add_ledger, add_line_item, list_ledgers
+
+    ledger_id = add_ledger("Personal2")["ledger_id"]
+    result = add_line_item(ledger_id=ledger_id, name="Rent", item_type="expense")
+    assert result["status"] == "ok"
+
+    ledgers = list_ledgers()["ledgers"]
+    ledger = next(lg for lg in ledgers if lg["id"] == ledger_id)
+    items = {i["name"]: i for i in ledger["items"]}
+    assert items["Rent"]["type"] == "expense"
+
+
+def test_add_line_item_invalid_type(db_path, authed_user):
+    """add_line_item() with invalid item_type returns error."""
+    from server.main import add_ledger, add_line_item
+
+    ledger_id = add_ledger("Test")["ledger_id"]
+    result = add_line_item(ledger_id=ledger_id, name="Misc", item_type="invalid")
+    assert result["status"] == "error"
+
+
+def test_add_line_item_wrong_ledger(db_path, authed_user):
+    """add_line_item() with unknown ledger_id returns error."""
+    from server.main import add_line_item
+
+    result = add_line_item(ledger_id=_uid(), name="Anything", item_type="expense")
+    assert result["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Test: remove_line_item works when no entries attached
+# ---------------------------------------------------------------------------
+
+
+def test_remove_line_item_no_entries(db_path, authed_user):
+    """remove_line_item() deletes item and returns ok when no entries attached."""
+    from server.main import add_ledger, add_line_item, list_ledgers, remove_line_item
+
+    ledger_id = add_ledger("Temp")["ledger_id"]
+    item_id = add_line_item(ledger_id=ledger_id, name="TempItem", item_type="expense")["item_id"]
+
+    result = remove_line_item(id=item_id)
+    assert result == {"status": "ok"}
+
+    # Verify it's gone from list_ledgers
+    ledgers = list_ledgers()["ledgers"]
+    temp = next((lg for lg in ledgers if lg["id"] == ledger_id), None)
+    if temp:
+        item_ids = [i["id"] for i in temp["items"]]
+        assert item_id not in item_ids
+
+
+# ---------------------------------------------------------------------------
+# Test: remove_line_item returns error when entries exist
+# ---------------------------------------------------------------------------
+
+
+def test_remove_line_item_with_entries(db_path, authed_user):
+    """remove_line_item() returns error when transaction_entries reference the item."""
+    from server.main import add_ledger, add_line_item, remove_line_item
+
+    ledger_id = add_ledger("WithEntries")["ledger_id"]
+    item_id = add_line_item(ledger_id=ledger_id, name="LinkedItem", item_type="expense")["item_id"]
+
+    # Manually attach a transaction entry referencing this item
+    conn = get_db(db_path)
+    txn_id = _uid()
+    conn.execute(
+        "INSERT INTO transactions (id, date, merchant, amount) VALUES (?, ?, ?, ?)",
+        (txn_id, "2026-01-01", "TestMerchant", 100.0),
+    )
+    conn.execute(
+        "INSERT INTO transaction_entries "
+        "(id, transaction_id, ledger_id, line_item_id, amount, source, reviewed) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (_uid(), txn_id, ledger_id, item_id, 100.0, "rule", 0),
+    )
+    conn.commit()
+    conn.close()
+
+    result = remove_line_item(id=item_id)
+    assert result["status"] == "error"
+    assert "attached entries" in result["message"].lower() or "entries" in result["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Test: remove_line_item with non-existent id
+# ---------------------------------------------------------------------------
+
+
+def test_remove_line_item_not_found(db_path, authed_user):
+    """remove_line_item() returns error for unknown item id."""
+    from server.main import remove_line_item
+
+    result = remove_line_item(id=_uid())
+    assert result["status"] == "error"


### PR DESCRIPTION
Closes #148

## Summary

Implements four previously-stubbed MCP ledger tools in `server/main.py`:

- **`list_ledgers()`** — returns all ledgers + line items for the active user, scoped to `get_active_user_id()`. Returns `{"ledgers": []}` when no active user.
- **`add_ledger(name)`** — creates a new ledger for the active user; validates non-empty name and uniqueness per user.
- **`add_line_item(ledger_id, name, item_type)`** — adds a line item to a ledger owned by the active user; validates `item_type` is `income` or `expense`.
- **`remove_line_item(id)`** — removes a line item; refuses if `transaction_entries` reference it (returns error with message to delete entries first).

Also:
- Added `tests/test_ledger_mcp_tools.py` with 13 unit tests covering all tools including edge cases (no active user, invalid types, duplicate names, attached entries, unknown IDs).
- Removed `@pytest.mark.xfail` from `tests/integration/test_mcp_tools.py::test_list_ledgers` — now passes normally.
- All 529 tests pass; black + ruff clean.

**Interactive check:**
```
python3 -c "from server.main import list_ledgers; print(list_ledgers())"
# => {'ledgers': [{'id': '...', 'name': 'Personal', 'items': [...]}]}
```
Returns `{"ledgers": [...]}`, not `{"status": "not_implemented"}`.