### PR TITLE
[Test] Playwright UI test suite (with skipif guard) (#119)

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,27 @@ threat model.
 
 ---
 
+## Testing
+
+The regular test suite runs with pytest and needs no extra deps:
+
+```bash
+python3 -m pytest -q
+```
+
+### Browser tests (optional)
+
+UI tests use Playwright and are **skipped automatically** when Playwright is not
+installed, so CI is never broken by a missing dep. To activate them locally:
+
+```bash
+pip install playwright
+playwright install chromium
+python3 -m pytest tests/ui/
+```
+
+---
+
 ## Troubleshooting
 
 **"Bank connection broken"** → Ask your OpenClaw agent (or any MCP client)

--- a/tests/ui/_server_runner.py
+++ b/tests/ui/_server_runner.py
@@ -1,0 +1,34 @@
+"""
+tests/ui/_server_runner.py — thin wrapper that starts ui.server via uvicorn
+while patching server.paths.DB_PATH from the FRIDAY_BP_DB_PATH env var.
+
+Called by the conftest server_url fixture as a subprocess so that each
+Playwright test session gets a fresh, isolated SQLite database.
+
+Usage (automated — do not call directly):
+    python -m tests.ui._server_runner --port <PORT>
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# ── Patch DB path BEFORE importing ui.server ───────────────────────────────
+_db_path_env = os.environ.get("FRIDAY_BP_DB_PATH")
+if _db_path_env:
+    import server.paths as _paths
+    from server.db import init_db
+
+    _db = Path(_db_path_env)
+    _db.parent.mkdir(parents=True, exist_ok=True)
+    init_db(_db)
+    _paths.DB_PATH = _db
+    _paths.APP_DIR = _db.parent
+
+# ── Start uvicorn ───────────────────────────────────────────────────────────
+if __name__ == "__main__":
+    import uvicorn
+
+    port = int(os.environ.get("FRIDAY_BP_UI_PORT", "6789"))
+    uvicorn.run("ui.server:app", host="127.0.0.1", port=port, log_level="warning")

--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -1,0 +1,195 @@
+"""
+tests/ui/conftest.py — Playwright fixtures + skip guard.
+
+All tests in this package are skipped cleanly when Playwright is not
+installed, and activate the moment you run:
+
+    pip install playwright
+    playwright install chromium
+
+Design notes
+────────────
+• Skip guards live in pytest_collection_modifyitems (not at module level) so
+  that conftest.py loads without error regardless of whether playwright or
+  chromium is available.  This is the correct pattern for pytest ≥ 7.
+• Fixtures raise pytest.skip() themselves when called without the runtime
+  deps, providing a belt-and-suspenders fallback.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from contextlib import closing
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Runtime availability probes (run once at import time — fast checks only)
+# ---------------------------------------------------------------------------
+
+try:
+    import playwright  # noqa: F401
+
+    _PLAYWRIGHT_INSTALLED = True
+except ImportError:
+    _PLAYWRIGHT_INSTALLED = False
+
+
+def _chromium_available() -> bool:
+    """Return True only when the chromium binary can actually be launched."""
+    if not _PLAYWRIGHT_INSTALLED:
+        return False
+    try:
+        from playwright.sync_api import sync_playwright
+
+        with sync_playwright() as p:
+            try:
+                browser = p.chromium.launch()
+                browser.close()
+                return True
+            except Exception:
+                return False
+    except Exception:
+        return False
+
+
+# Evaluated once; cached so collection is fast.
+_CHROMIUM_AVAILABLE: bool | None = None  # lazy
+
+
+def _ensure_chromium_checked() -> bool:
+    global _CHROMIUM_AVAILABLE
+    if _CHROMIUM_AVAILABLE is None:
+        _CHROMIUM_AVAILABLE = _chromium_available()
+    return _CHROMIUM_AVAILABLE
+
+
+def _skip_reason() -> str | None:
+    """Return a skip reason string, or None if tests should run."""
+    if not _PLAYWRIGHT_INSTALLED:
+        return (
+            "Playwright not installed. "
+            "Run: pip install playwright && playwright install chromium"
+        )
+    if not _ensure_chromium_checked():
+        return "Chromium binary not installed. Run: playwright install chromium"
+    return None
+
+
+# ---------------------------------------------------------------------------
+# pytest hook: add skip markers to all ui/ items when deps are absent
+# ---------------------------------------------------------------------------
+
+
+def pytest_collection_modifyitems(items: list) -> None:  # type: ignore[type-arg]
+    reason = _skip_reason()
+    if reason is None:
+        return
+    skip_mark = pytest.mark.skip(reason=reason)
+    for item in items:
+        # Only touch items that live under tests/ui/
+        if "tests/ui" in str(getattr(item, "fspath", "")):
+            item.add_marker(skip_mark)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_free_port() -> int:
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+# ---------------------------------------------------------------------------
+# Session-scoped server fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def server_url(tmp_path_factory):
+    """Start the UI server in a subprocess on a free port, yield URL, clean up.
+
+    Uses tests/ui/_server_runner.py so that server.paths.DB_PATH is patched
+    to a fresh temp database before ui.server is imported in the subprocess.
+    """
+    reason = _skip_reason()
+    if reason:
+        pytest.skip(reason)
+
+    port = _find_free_port()
+    db_path = tmp_path_factory.mktemp("ui_db") / "test.db"
+
+    env = os.environ.copy()
+    env["FRIDAY_BP_DB_PATH"] = str(db_path)
+    env["FRIDAY_BP_UI_PORT"] = str(port)
+    env.setdefault("PLAID_CLIENT_ID", "test-client-id")
+    env.setdefault("PLAID_SECRET", "test-secret")
+
+    repo_root = Path(__file__).parent.parent.parent
+    runner_module = "tests.ui._server_runner"
+
+    proc = subprocess.Popen(
+        [sys.executable, "-m", runner_module],
+        env=env,
+        cwd=str(repo_root),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    url = f"http://127.0.0.1:{port}"
+    deadline = time.time() + 15
+    while time.time() < deadline:
+        try:
+            urllib.request.urlopen(f"{url}/healthz", timeout=0.5)
+            break
+        except Exception:
+            if proc.poll() is not None:
+                _, err = proc.communicate()
+                raise RuntimeError(f"Server process exited early:\n{err.decode()[:1000]}")
+            time.sleep(0.25)
+    else:
+        proc.kill()
+        _, err = proc.communicate()
+        raise RuntimeError(f"Server failed to start within 15s: {err.decode()[:500]}")
+
+    yield url
+
+    proc.kill()
+    proc.wait(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Per-test browser fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def browser_context(server_url):  # noqa: ARG001 — ensures server is up
+    reason = _skip_reason()
+    if reason:
+        pytest.skip(reason)
+
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        context = browser.new_context()
+        yield context
+        context.close()
+        browser.close()
+
+
+@pytest.fixture
+def page(browser_context):
+    pg = browser_context.new_page()
+    yield pg
+    pg.close()

--- a/tests/ui/test_login.py
+++ b/tests/ui/test_login.py
@@ -1,0 +1,113 @@
+"""
+tests/ui/test_login.py — Playwright tests for the login / logout flow.
+
+Prerequisites (handled by conftest):
+  - Server running with a fresh DB.
+  - The session-scoped `server_url` fixture is shared — tests run after
+    test_setup_flow has already completed setup (same server process).
+    If tests run in isolation the fixture boots a fresh server, so we
+    create a user via the setup wizard before testing login.
+
+Tests skip cleanly when Playwright / Chromium are not installed (see conftest).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module-level helper: ensure the server has a user we can log in with.
+# We use a session-scoped fixture so the wizard runs only once per session.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def registered_user(server_url):
+    """Ensure a test user exists by completing the setup wizard if needed.
+
+    Returns (username, password).
+    """
+    from playwright.sync_api import sync_playwright
+
+    username = "logintest"
+    password = "hunter2abc"
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        ctx = browser.new_context()
+        pg = ctx.new_page()
+
+        pg.goto(server_url + "/")
+        if "/setup" in pg.url:
+            # Complete the wizard
+            pg.fill("input#username", username)
+            pg.fill("input#password", password)
+            pg.fill("input#password_confirm", password)
+            pg.click("button[type=submit]")
+            # Step 2 — submit defaults
+            pg.click("button[type=submit]")
+            # Step 3 — skip bank
+            pg.locator("button[type=submit]", has_text="Skip").first.click()
+            # Step 4 — finish
+            pg.click("button[type=submit]")
+            pg.wait_for_url("**/profile", timeout=5000)
+
+        ctx.close()
+        browser.close()
+
+    return username, password
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_login_page_renders(page, server_url, registered_user):
+    """GET /login shows username and password fields."""
+    page.goto(server_url + "/login")
+    assert page.locator("input#username").is_visible()
+    assert page.locator("input#password").is_visible()
+
+
+def test_login_wrong_password_shows_error(page, server_url, registered_user):
+    """Wrong password keeps the user on /login and shows an error."""
+    username, _ = registered_user
+    page.goto(server_url + "/login")
+    page.fill("input#username", username)
+    page.fill("input#password", "wrongpassword!")
+    page.click("button[type=submit]")
+
+    # Still on /login
+    assert "/login" in page.url
+    # Error message visible somewhere on the page
+    assert page.locator(".alert-error").is_visible()
+
+
+def test_login_correct_password_redirects_to_profile(page, server_url, registered_user):
+    """Correct credentials redirect to /profile."""
+    username, password = registered_user
+    page.goto(server_url + "/login")
+    page.fill("input#username", username)
+    page.fill("input#password", password)
+    page.click("button[type=submit]")
+
+    page.wait_for_url("**/profile", timeout=5000)
+    assert "/profile" in page.url
+
+
+def test_logout_redirects_to_login(page, server_url, registered_user):
+    """Clicking Sign out lands back on /login."""
+    username, password = registered_user
+
+    # Log in first
+    page.goto(server_url + "/login")
+    page.fill("input#username", username)
+    page.fill("input#password", password)
+    page.click("button[type=submit]")
+    page.wait_for_url("**/profile", timeout=5000)
+
+    # Submit logout form (POST /logout)
+    page.click("button[type=submit]:has-text('Sign out')")
+    page.wait_for_url("**/login", timeout=5000)
+    assert "/login" in page.url

--- a/tests/ui/test_profile.py
+++ b/tests/ui/test_profile.py
@@ -1,0 +1,90 @@
+"""
+tests/ui/test_profile.py — Playwright tests for the /profile page.
+
+Route shape (from ui/server.py and ui/templates/profile.html):
+  GET /profile    → settings + Linked Accounts section (auth required)
+  /link/start     → Plaid Link initiation (linked via "+ Connect a bank" button)
+
+Tests skip cleanly when Playwright / Chromium are not installed (see conftest).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _login(page, server_url: str, username: str, password: str) -> None:
+    """Log in via the /login form."""
+    page.goto(server_url + "/login")
+    page.fill("input#username", username)
+    page.fill("input#password", password)
+    page.click("button[type=submit]")
+    page.wait_for_url("**/profile", timeout=5000)
+
+
+# ---------------------------------------------------------------------------
+# Module-scoped fixture: ensure a user exists for this test module.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def profile_user(server_url):
+    """Create a user via setup wizard (if the server is fresh) and return creds."""
+    from playwright.sync_api import sync_playwright
+
+    username = "profiletest"
+    password = "profile_pw_99"
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        ctx = browser.new_context()
+        pg = ctx.new_page()
+
+        pg.goto(server_url + "/")
+        if "/setup" in pg.url:
+            pg.fill("input#username", username)
+            pg.fill("input#password", password)
+            pg.fill("input#password_confirm", password)
+            pg.click("button[type=submit]")
+            # Step 2
+            pg.click("button[type=submit]")
+            # Step 3 — skip
+            pg.locator("button[type=submit]", has_text="Skip").first.click()
+            # Step 4 — finish
+            pg.click("button[type=submit]")
+            pg.wait_for_url("**/profile", timeout=5000)
+
+        ctx.close()
+        browser.close()
+
+    return username, password
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_profile_shows_linked_accounts_section(page, server_url, profile_user):
+    """Authenticated /profile includes the 'Linked Accounts' section."""
+    username, password = profile_user
+    _login(page, server_url, username, password)
+
+    # The <section id="linked-accounts"> is present and has a heading.
+    heading = page.locator("#linked-accounts h2")
+    assert heading.count() > 0
+    assert "Linked Accounts" in heading.first.inner_text()
+
+
+def test_profile_has_connect_bank_button(page, server_url, profile_user):
+    """Profile page shows a '+ Connect a bank' button."""
+    username, password = profile_user
+    _login(page, server_url, username, password)
+
+    btn = page.locator("a", has_text="Connect a bank")
+    assert btn.count() > 0, "Expected '+ Connect a bank' link on /profile"
+    assert btn.first.is_visible()

--- a/tests/ui/test_setup_flow.py
+++ b/tests/ui/test_setup_flow.py
@@ -1,0 +1,68 @@
+"""
+tests/ui/test_setup_flow.py — Playwright tests for the first-run setup wizard.
+
+Route shape (from ui/server.py):
+  GET  /setup        → shows step 1 (password)
+  POST /setup/1      → validates & creates user, renders step 2 (notifications)
+  POST /setup/2      → saves notification pref, renders step 3 (bank)
+  POST /setup/3      → bank or skip (action=skip), renders step 4 (done)
+  POST /setup/4      → finalises setup, redirects to /profile
+
+Tests skip cleanly when Playwright / Chromium are not installed (see conftest).
+"""
+
+from __future__ import annotations
+
+
+def test_root_redirects_to_setup(page, server_url):
+    """GET / → /setup when no user exists yet."""
+    response = page.goto(server_url + "/")
+    # After redirect chain we should land on /setup
+    assert "/setup" in page.url
+
+
+def test_setup_step1_form_visible(page, server_url):
+    """Setup page shows username and password fields."""
+    page.goto(server_url + "/setup")
+    assert page.locator("input#username").is_visible()
+    assert page.locator("input#password").is_visible()
+    assert page.locator("input#password_confirm").is_visible()
+
+
+def test_setup_wizard_full_flow(page, server_url):
+    """Walk through all four steps of the setup wizard and land on /profile."""
+    # ── Step 1: username + password ─────────────────────────────────────────
+    page.goto(server_url + "/setup")
+    page.fill("input#username", "testuser")
+    page.fill("input#password", "supersecret1")
+    page.fill("input#password_confirm", "supersecret1")
+    page.click("button[type=submit]")
+
+    # Should now show step 2 (notification preference)
+    assert (
+        page.locator("input[name=notification_channel]").count() > 0
+    ), "Expected notification channel radio buttons on step 2"
+
+    # ── Step 2: pick default notification channel ────────────────────────────
+    # The first radio is already checked; just submit.
+    page.click("button[type=submit]")
+
+    # Should now show step 3 (connect bank / skip)
+    skip_btn = page.locator("button[type=submit]", has_text="Skip")
+    assert skip_btn.count() > 0, "Expected a Skip button on step 3"
+
+    # ── Step 3: skip bank ────────────────────────────────────────────────────
+    skip_btn.first.click()
+
+    # Should now show step 4 (finish)
+    finish_btn = page.locator("button[type=submit]")
+    assert finish_btn.count() > 0, "Expected a finish button on step 4"
+    # Step 4 heading should mention "all set" or similar
+    assert page.locator("h2").count() > 0
+
+    # ── Step 4: complete setup ───────────────────────────────────────────────
+    finish_btn.first.click()
+
+    # Should redirect to /profile
+    page.wait_for_url("**/profile", timeout=5000)
+    assert "/profile" in page.url


### PR DESCRIPTION
Closes #119

Scaffolding for browser-level UI tests. Tests skip cleanly when Playwright isn't installed, activate when:

    pip install playwright
    playwright install chromium

**Interactive check:** (pytest output showing tests skip)
```
tests/ui/test_login.py::test_login_page_renders SKIPPED (Chromium bi...)
tests/ui/test_login.py::test_login_wrong_password_shows_error SKIPPED
tests/ui/test_login.py::test_login_correct_password_redirects_to_profile SKIPPED
tests/ui/test_login.py::test_logout_redirects_to_login SKIPPED (Chro...)
tests/ui/test_profile.py::test_profile_shows_linked_accounts_section SKIPPED
tests/ui/test_profile.py::test_profile_has_connect_bank_button SKIPPED
tests/ui/test_setup_flow.py::test_root_redirects_to_setup SKIPPED (C...)
tests/ui/test_setup_flow.py::test_setup_step1_form_visible SKIPPED (...)
tests/ui/test_setup_flow.py::test_setup_wizard_full_flow SKIPPED (Ch...)

9 skipped in 0.70s ✅
```

Full suite (537 passed, 16 skipped, 0 failed):
```
537 passed, 16 skipped, 3 warnings in 37.91s ✅
```

**To activate locally:** see README "Browser tests" section.
**To activate in CI:** add `playwright install chromium` step + `playwright` to requirements (separate ticket).

## Files added
- `tests/ui/__init__.py` — package marker
- `tests/ui/_server_runner.py` — subprocess wrapper that patches DB path before uvicorn starts
- `tests/ui/conftest.py` — skip guards (via `pytest_collection_modifyitems`) + session-scoped server + browser fixtures
- `tests/ui/test_setup_flow.py` — 3 tests covering the full 4-step setup wizard
- `tests/ui/test_login.py` — 4 tests: render, wrong password, correct login, logout
- `tests/ui/test_profile.py` — 2 tests: Linked Accounts section, + Connect a bank button
- `README.md` — added "Browser tests (optional)" section under Testing