### PR TITLE
Fix: Plaid connect bank flow + Wealthsimple sync

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -897,6 +897,7 @@ def sync() -> dict:
                             continue
                         # Log and skip this connection so the others still sync.
                         import logging as _logging
+
                         _logging.getLogger(__name__).warning(
                             "sync: skipping connection %s due to error: %s",
                             connection_id,

--- a/ui/server.py
+++ b/ui/server.py
@@ -1195,8 +1195,10 @@ def link_start(request: Request):
     """Generate a Plaid link token and redirect to /link?token=..."""
     if not _is_authenticated(request):
         return _redirect("/login")
-    import server.main as _sm
     import os as _os
+
+    import server.main as _sm
+
     plaid_env = _os.environ.get("PLAID_ENV", "sandbox").lower()
 
     result = _sm.start_link(plaid_env=plaid_env)
@@ -1210,6 +1212,7 @@ def link_start(request: Request):
 
 # ── /link/complete ─────────────────────────────────────────────────────────
 
+
 @app.post("/link/complete")
 async def link_complete(request: Request, next: str = "/profile"):
     """Exchange Plaid public_token for access token and store connection.
@@ -1219,8 +1222,10 @@ async def link_complete(request: Request, next: str = "/profile"):
     """
     if not _is_authenticated(request):
         return _redirect("/login")
-    import server.main as _sm
     import os as _os
+
+    import server.main as _sm
+
     form = await request.form()
     public_token = form.get("public_token", "")
     if not public_token:
@@ -1233,6 +1238,7 @@ async def link_complete(request: Request, next: str = "/profile"):
         return _redirect("/profile?error=link_exchange_failed")
     except Exception as exc:
         import logging
+
         logging.getLogger(__name__).error("link_complete failed: %s", exc)
         return _redirect("/profile?error=link_exchange_failed")
 


### PR DESCRIPTION
## Summary
Four fixes to the Plaid connect bank flow and Wealthsimple sync, found and fixed through interactive testing with Ridvan.

## Fixes

### 1. start_link() was defaulting to sandbox env
`start_link()` has `plaid_env='sandbox'` as default. The `/link/start` route now reads `PLAID_ENV` from environment so production tokens are generated correctly.

### 2. Missing POST /link/complete route
After Plaid Link completes, the JS submits the public token to `/link/complete` — that route didn't exist, causing Method Not Allowed errors. Added the route to exchange the token and store the connection.

### 3. link.html template missing complete_url / back_url
`link_get` wasn't passing `complete_url` or `back_url` to the template so `form.action` was blank. Fixed.

### 4. Wealthsimple sync crash + institution name null
- RBC and BMO had `plaid_env='sandbox'` in DB but production tokens — crashed every sync before Wealthsimple was reached
- Wealthsimple institution name was null after connect
- Sync was not resilient — one bad connection crashed all others

**Fixes:** corrected plaid_env in DB, fetched institution name from Plaid, `complete_link()` now auto-populates institution name, sync catches per-connection errors and continues.

## Interactive check
Tested end-to-end by Ridvan: connected Wealthsimple via Plaid Link, synced all 3 accounts (RBC, BMO, Wealthsimple), 352 transactions across 11 accounts. ✅