### PR TITLE
[P4] Classification rules: schema + 6 default rules + 7 MCP tools (#169)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,24 @@ Every transaction goes through a three-tier classifier:
 After 3 successful classifications of the same merchant, it becomes a
 Tier 1 rule automatically. The longer you use it, the less it asks.
 
+### Classification Rules
+
+Friday ships with **6 built-in (default) classification rules** that run before
+the LLM sees a transaction.  They handle the most common patterns automatically:
+
+| Priority | Rule | What it does |
+|----------|------|--------------|
+| 1 | **Pending skip** | Skips any transaction still marked pending |
+| 10 | **Internal transfer** | Flags same-amount cross-account moves within 3 days as Transfer |
+| 20 | **Investment contribution** | Marks outflows to Wealthsimple, Questrade, etc. as Transfer/Savings |
+| 30 | **Credit card payment** | Identifies chequing→credit payments as Transfer (charges already tracked) |
+| 40 | **Salary / payroll** | Marks bank-tagged payroll transactions as Income |
+| 50 | **Bank fees** | Marks monthly account fees as Bank Fees (spending) |
+
+Default rules can be **disabled** but not deleted.  You can add your own rules
+(priority 100+) and reorder them via MCP tools: `list_rules`, `add_rule`,
+`update_rule`, `reorder_rules`, `disable_rule`, `enable_rule`, `delete_rule`.
+
 ---
 
 ## With OpenClaw (and any other MCP client)

--- a/server/db.py
+++ b/server/db.py
@@ -46,6 +46,61 @@ def init_db(path: str | Path) -> None:
         conn.executescript(sql)
         conn.commit()
 
+        # Seed default classification_rules if none exist yet
+        default_count = conn.execute(
+            "SELECT COUNT(*) FROM classification_rules WHERE is_default = 1"
+        ).fetchone()[0]
+        if default_count == 0:
+            import uuid as _uuid
+
+            now = int(_time.time())
+            _DEFAULT_RULES = [
+                (
+                    1,
+                    "Pending skip",
+                    "Skip any transaction that is still pending",
+                    "skip",
+                ),
+                (
+                    10,
+                    "Internal transfer",
+                    "If the same amount leaves one account and arrives at another of mine within 3 days, mark both as Transfer",
+                    "transfer",
+                ),
+                (
+                    20,
+                    "Investment contribution",
+                    "Outflows to Wealthsimple, Questrade, or any investment platform are Transfer/Savings, not spending",
+                    "transfer",
+                ),
+                (
+                    30,
+                    "Credit card payment",
+                    "A payment from chequing that matches a credit card balance is a Transfer — the individual charges are already tracked",
+                    "transfer",
+                ),
+                (
+                    40,
+                    "Salary/payroll",
+                    "Transactions tagged as payroll or salary by the bank are Income",
+                    "income",
+                ),
+                (
+                    50,
+                    "Bank fees",
+                    "Monthly account fees and bank charges are Bank Fees",
+                    "spending",
+                ),
+            ]
+            for priority, name, description, rule_type in _DEFAULT_RULES:
+                conn.execute(
+                    "INSERT INTO classification_rules "
+                    "(id, name, description, rule_type, line_item_id, priority, is_default, enabled, created_at) "
+                    "VALUES (?, ?, ?, ?, NULL, ?, 1, 1, ?)",
+                    (str(_uuid.uuid4()), name, description, rule_type, priority, now),
+                )
+            conn.commit()
+
         # Migration: bank_accounts.description (added in #127)
         ba_cols = {row[1] for row in conn.execute("PRAGMA table_info(bank_accounts)")}
         if "description" not in ba_cols:

--- a/server/main.py
+++ b/server/main.py
@@ -1623,6 +1623,254 @@ def reset_ui_password() -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Classification rules tools
+# ---------------------------------------------------------------------------
+
+_VALID_RULE_TYPES = {"transfer", "savings", "spending", "income", "skip"}
+
+
+@mcp.tool
+def list_rules() -> dict:
+    """Return all classification rules sorted by priority ascending.
+
+    Returns
+    -------
+    dict
+        ``{"rules": [{id, name, description, rule_type, line_item_id,
+        priority, is_default, enabled, created_at}, ...]}``
+    """
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        rows = conn.execute(
+            "SELECT id, name, description, rule_type, line_item_id, "
+            "priority, is_default, enabled, created_at "
+            "FROM classification_rules ORDER BY priority ASC"
+        ).fetchall()
+        return {
+            "rules": [
+                {
+                    "id": row["id"],
+                    "name": row["name"],
+                    "description": row["description"],
+                    "rule_type": row["rule_type"],
+                    "line_item_id": row["line_item_id"],
+                    "priority": row["priority"],
+                    "is_default": bool(row["is_default"]),
+                    "enabled": bool(row["enabled"]),
+                    "created_at": row["created_at"],
+                }
+                for row in rows
+            ]
+        }
+    finally:
+        conn.close()
+
+
+@mcp.tool
+def add_rule(
+    name: str,
+    description: str,
+    rule_type: str,
+    line_item_id: str = None,
+    priority: int = 100,
+) -> dict:
+    """Create a new classification rule.
+
+    Parameters
+    ----------
+    name : str
+        Short display name for the rule.
+    description : str
+        Natural language description of what this rule matches and does.
+    rule_type : str
+        One of ``'transfer'``, ``'savings'``, ``'spending'``, ``'income'``,
+        or ``'skip'``.
+    line_item_id : str, optional
+        Target line item ID (optional).
+    priority : int, optional
+        Evaluation order — lower numbers run first.  Defaults to 100.
+
+    Returns
+    -------
+    dict
+        ``{"status": "ok", "rule_id": "<uuid>"}``
+    """
+    if rule_type not in _VALID_RULE_TYPES:
+        raise ValueError(
+            f"rule_type must be one of {sorted(_VALID_RULE_TYPES)!r}, got {rule_type!r}"
+        )
+    rule_id = str(uuid.uuid4())
+    now = int(_time.time())
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        conn.execute(
+            "INSERT INTO classification_rules "
+            "(id, name, description, rule_type, line_item_id, priority, is_default, enabled, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, 0, 1, ?)",
+            (rule_id, name.strip(), description.strip(), rule_type, line_item_id, priority, now),
+        )
+        conn.commit()
+        return {"status": "ok", "rule_id": rule_id}
+    finally:
+        conn.close()
+
+
+@mcp.tool
+def update_rule(
+    id: str,
+    name: str = None,
+    description: str = None,
+    rule_type: str = None,
+    priority: int = None,
+    enabled: bool = None,
+    line_item_id: str = None,
+) -> dict:
+    """Update one or more fields on an existing classification rule.
+
+    Only the fields that are explicitly provided are changed.  Any field
+    left as ``None`` is untouched.
+
+    Returns
+    -------
+    dict
+        ``{"status": "ok"}`` or ``{"status": "error", "message": "..."}``
+    """
+    if rule_type is not None and rule_type not in _VALID_RULE_TYPES:
+        raise ValueError(
+            f"rule_type must be one of {sorted(_VALID_RULE_TYPES)!r}, got {rule_type!r}"
+        )
+    updates = []
+    params = []
+    if name is not None:
+        updates.append("name = ?")
+        params.append(name.strip())
+    if description is not None:
+        updates.append("description = ?")
+        params.append(description.strip())
+    if rule_type is not None:
+        updates.append("rule_type = ?")
+        params.append(rule_type)
+    if priority is not None:
+        updates.append("priority = ?")
+        params.append(priority)
+    if enabled is not None:
+        updates.append("enabled = ?")
+        params.append(1 if enabled else 0)
+    if line_item_id is not None:
+        updates.append("line_item_id = ?")
+        params.append(line_item_id)
+    if not updates:
+        return {"status": "ok"}  # nothing to do
+    params.append(id)
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        cursor = conn.execute(
+            f"UPDATE classification_rules SET {', '.join(updates)} WHERE id = ?",
+            params,
+        )
+        conn.commit()
+        if cursor.rowcount == 0:
+            return {"status": "error", "message": f"Rule not found: {id}"}
+        return {"status": "ok"}
+    finally:
+        conn.close()
+
+
+@mcp.tool
+def reorder_rules(rule_ids: list) -> dict:
+    """Assign sequential priorities (10, 20, 30, …) to the supplied rule IDs.
+
+    The first ID in the list gets priority 10, second gets 20, etc.  Any
+    rules **not** in the list are left unchanged.
+
+    Returns
+    -------
+    dict
+        ``{"status": "ok"}``
+    """
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        with db_txn(conn):
+            for i, rule_id in enumerate(rule_ids):
+                conn.execute(
+                    "UPDATE classification_rules SET priority = ? WHERE id = ?",
+                    ((i + 1) * 10, rule_id),
+                )
+        return {"status": "ok"}
+    finally:
+        conn.close()
+
+
+@mcp.tool
+def disable_rule(id: str) -> dict:
+    """Disable a classification rule so it is skipped during evaluation.
+
+    Returns
+    -------
+    dict
+        ``{"status": "ok"}`` or ``{"status": "error", "message": "..."}``
+    """
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        cursor = conn.execute("UPDATE classification_rules SET enabled = 0 WHERE id = ?", (id,))
+        conn.commit()
+        if cursor.rowcount == 0:
+            return {"status": "error", "message": f"Rule not found: {id}"}
+        return {"status": "ok"}
+    finally:
+        conn.close()
+
+
+@mcp.tool
+def enable_rule(id: str) -> dict:
+    """Re-enable a previously disabled classification rule.
+
+    Returns
+    -------
+    dict
+        ``{"status": "ok"}`` or ``{"status": "error", "message": "..."}``
+    """
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        cursor = conn.execute("UPDATE classification_rules SET enabled = 1 WHERE id = ?", (id,))
+        conn.commit()
+        if cursor.rowcount == 0:
+            return {"status": "error", "message": f"Rule not found: {id}"}
+        return {"status": "ok"}
+    finally:
+        conn.close()
+
+
+@mcp.tool
+def delete_rule(id: str) -> dict:
+    """Delete a user-created classification rule.
+
+    Default rules (``is_default=1``) cannot be deleted — use
+    :func:`disable_rule` to suppress them instead.
+
+    Returns
+    -------
+    dict
+        ``{"status": "ok"}`` or
+        ``{"status": "error", "message": "Cannot delete default rule"}``
+    """
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        row = conn.execute(
+            "SELECT is_default FROM classification_rules WHERE id = ?", (id,)
+        ).fetchone()
+        if row is None:
+            return {"status": "error", "message": f"Rule not found: {id}"}
+        if row["is_default"]:
+            return {"status": "error", "message": "Cannot delete default rule"}
+        conn.execute("DELETE FROM classification_rules WHERE id = ?", (id,))
+        conn.commit()
+        return {"status": "ok"}
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
 # UI URL tool
 # ---------------------------------------------------------------------------
 

--- a/tests/test_classification_rules.py
+++ b/tests/test_classification_rules.py
@@ -1,0 +1,273 @@
+"""
+tests/test_classification_rules.py — Tests for classification rules schema,
+default seeding, and MCP tools.
+
+Covers:
+- Migration: fresh DB seeds exactly 6 default rules with correct priorities
+- Migration is idempotent (running init_db again does not duplicate)
+- list_rules() returns rules in priority order, all metadata present
+- add_rule() creates a new rule, appears in list
+- update_rule() updates specified fields, leaves others unchanged
+- reorder_rules() assigns priorities 10, 20, 30 ... in supplied order
+- disable_rule() / enable_rule() toggle the enabled column
+- delete_rule() on default rule → error; on user rule → ok
+- Invalid rule_type in add_rule → ValueError
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from server.db import init_db
+from server.main import (
+    add_rule,
+    delete_rule,
+    disable_rule,
+    enable_rule,
+    list_rules,
+    reorder_rules,
+    update_rule,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    """Create a fresh DB at tmp_path and monkeypatch server.paths.DB_PATH."""
+    import server.paths
+
+    db_file = tmp_path / "test.db"
+    monkeypatch.setattr(server.paths, "DB_PATH", db_file)
+    init_db(db_file)
+    return db_file
+
+
+# ---------------------------------------------------------------------------
+# Migration / seeding tests
+# ---------------------------------------------------------------------------
+
+
+def test_default_rules_seeded(tmp_db):
+    """Fresh DB must have exactly 6 default rules seeded."""
+    result = list_rules()
+    defaults = [r for r in result["rules"] if r["is_default"]]
+    assert len(defaults) == 6
+
+
+def test_default_rules_priorities(tmp_db):
+    """Default rules must have priorities 1, 10, 20, 30, 40, 50."""
+    result = list_rules()
+    defaults = sorted([r for r in result["rules"] if r["is_default"]], key=lambda r: r["priority"])
+    assert [r["priority"] for r in defaults] == [1, 10, 20, 30, 40, 50]
+
+
+def test_default_rules_is_default_flag(tmp_db):
+    """All seeded default rules must have is_default=True."""
+    result = list_rules()
+    defaults = [r for r in result["rules"] if r["is_default"]]
+    assert all(r["is_default"] is True for r in defaults)
+
+
+def test_migration_idempotent(tmp_db):
+    """Calling init_db a second time must not duplicate default rules."""
+
+    init_db(tmp_db)  # second call
+    result = list_rules()
+    defaults = [r for r in result["rules"] if r["is_default"]]
+    assert len(defaults) == 6
+
+
+# ---------------------------------------------------------------------------
+# list_rules tests
+# ---------------------------------------------------------------------------
+
+
+def test_list_rules_sorted_by_priority(tmp_db):
+    """list_rules must return rules in ascending priority order."""
+    result = list_rules()
+    priorities = [r["priority"] for r in result["rules"]]
+    assert priorities == sorted(priorities)
+
+
+def test_list_rules_metadata_fields(tmp_db):
+    """Every rule dict must contain all expected metadata fields."""
+    result = list_rules()
+    required_fields = {
+        "id",
+        "name",
+        "description",
+        "rule_type",
+        "line_item_id",
+        "priority",
+        "is_default",
+        "enabled",
+        "created_at",
+    }
+    for rule in result["rules"]:
+        assert required_fields.issubset(rule.keys()), (
+            f"Missing fields in rule {rule.get('id')}: " f"{required_fields - set(rule.keys())}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# add_rule tests
+# ---------------------------------------------------------------------------
+
+
+def test_add_rule_creates_rule(tmp_db):
+    """add_rule must return status ok with a rule_id, and rule must appear in list."""
+    result = add_rule(
+        name="Test rule",
+        description="Purchases at test merchant are spending",
+        rule_type="spending",
+    )
+    assert result["status"] == "ok"
+    rule_id = result["rule_id"]
+    assert isinstance(rule_id, str) and len(rule_id) > 0
+
+    rules = list_rules()["rules"]
+    ids = [r["id"] for r in rules]
+    assert rule_id in ids
+
+
+def test_add_rule_custom_priority(tmp_db):
+    """add_rule with explicit priority must honour it."""
+    result = add_rule(
+        name="High-priority test",
+        description="desc",
+        rule_type="income",
+        priority=5,
+    )
+    rule_id = result["rule_id"]
+    rule = next(r for r in list_rules()["rules"] if r["id"] == rule_id)
+    assert rule["priority"] == 5
+
+
+def test_add_rule_invalid_type_raises(tmp_db):
+    """add_rule with an unrecognised rule_type must raise ValueError."""
+    with pytest.raises(ValueError, match="rule_type"):
+        add_rule(name="Bad", description="bad", rule_type="garbage")
+
+
+# ---------------------------------------------------------------------------
+# update_rule tests
+# ---------------------------------------------------------------------------
+
+
+def test_update_rule_changes_fields(tmp_db):
+    """update_rule must update only the supplied fields."""
+    r = add_rule(name="Before", description="original desc", rule_type="spending")
+    rule_id = r["rule_id"]
+
+    result = update_rule(id=rule_id, name="After", priority=200)
+    assert result["status"] == "ok"
+
+    rule = next(r for r in list_rules()["rules"] if r["id"] == rule_id)
+    assert rule["name"] == "After"
+    assert rule["priority"] == 200
+    assert rule["description"] == "original desc"  # unchanged
+
+
+def test_update_rule_no_fields_is_noop(tmp_db):
+    """update_rule with no fields provided must return ok without error."""
+    r = add_rule(name="Noop test", description="desc", rule_type="skip")
+    result = update_rule(id=r["rule_id"])
+    assert result["status"] == "ok"
+
+
+def test_update_rule_invalid_type_raises(tmp_db):
+    """update_rule with an invalid rule_type must raise ValueError."""
+    r = add_rule(name="Type test", description="desc", rule_type="spending")
+    with pytest.raises(ValueError, match="rule_type"):
+        update_rule(id=r["rule_id"], rule_type="nonsense")
+
+
+# ---------------------------------------------------------------------------
+# reorder_rules tests
+# ---------------------------------------------------------------------------
+
+
+def test_reorder_rules(tmp_db):
+    """reorder_rules must assign priorities 10, 20, 30 ... in supplied order."""
+    r1 = add_rule(name="R1", description="d1", rule_type="spending", priority=300)["rule_id"]
+    r2 = add_rule(name="R2", description="d2", rule_type="income", priority=200)["rule_id"]
+    r3 = add_rule(name="R3", description="d3", rule_type="skip", priority=100)["rule_id"]
+
+    result = reorder_rules(rule_ids=[r3, r1, r2])
+    assert result["status"] == "ok"
+
+    by_id = {r["id"]: r for r in list_rules()["rules"]}
+    assert by_id[r3]["priority"] == 10
+    assert by_id[r1]["priority"] == 20
+    assert by_id[r2]["priority"] == 30
+
+
+# ---------------------------------------------------------------------------
+# disable_rule / enable_rule tests
+# ---------------------------------------------------------------------------
+
+
+def test_disable_enable_rule(tmp_db):
+    """disable_rule and enable_rule must toggle the enabled field."""
+    r = add_rule(name="Toggle me", description="d", rule_type="transfer")
+    rule_id = r["rule_id"]
+
+    # starts enabled
+    rule = next(x for x in list_rules()["rules"] if x["id"] == rule_id)
+    assert rule["enabled"] is True
+
+    assert disable_rule(id=rule_id)["status"] == "ok"
+    rule = next(x for x in list_rules()["rules"] if x["id"] == rule_id)
+    assert rule["enabled"] is False
+
+    assert enable_rule(id=rule_id)["status"] == "ok"
+    rule = next(x for x in list_rules()["rules"] if x["id"] == rule_id)
+    assert rule["enabled"] is True
+
+
+def test_disable_default_rule(tmp_db):
+    """Default rules can be disabled (they just can't be deleted)."""
+    default_rule = next(r for r in list_rules()["rules"] if r["is_default"])
+    result = disable_rule(id=default_rule["id"])
+    assert result["status"] == "ok"
+
+    rule = next(r for r in list_rules()["rules"] if r["id"] == default_rule["id"])
+    assert rule["enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# delete_rule tests
+# ---------------------------------------------------------------------------
+
+
+def test_delete_user_rule(tmp_db):
+    """delete_rule on a user-created rule must succeed."""
+    r = add_rule(name="Deletable", description="d", rule_type="spending")
+    rule_id = r["rule_id"]
+
+    result = delete_rule(id=rule_id)
+    assert result["status"] == "ok"
+
+    ids = [r["id"] for r in list_rules()["rules"]]
+    assert rule_id not in ids
+
+
+def test_delete_default_rule_refused(tmp_db):
+    """delete_rule on a default rule must return an error."""
+    default_rule = next(r for r in list_rules()["rules"] if r["is_default"])
+    result = delete_rule(id=default_rule["id"])
+    assert result["status"] == "error"
+    assert "Cannot delete default rule" in result["message"]
+
+    # Rule must still exist
+    ids = [r["id"] for r in list_rules()["rules"]]
+    assert default_rule["id"] in ids
+
+
+def test_delete_nonexistent_rule(tmp_db):
+    """delete_rule on an unknown ID must return an error."""
+    result = delete_rule(id="nonexistent-id-xyz")
+    assert result["status"] == "error"


### PR DESCRIPTION
Closes #169

Adds the `classification_rules` table migration with 6 seeded default rules, 7 MCP tools for managing rules, a full test suite (18 tests), and README docs.

**Interactive check:**
```
initial: 6 default rules (priorities 1,10,20,30,40,50, all is_default=True, enabled=True)
added:   {'status': 'ok', 'rule_id': '170ea2ec-...'}
rules after add (count): 7
after disable: [{'id': '170ea2ec-...', 'name': 'Test', 'rule_type': 'spending', 'is_default': False, 'enabled': False, ...}]
after delete (count): 6
```

**Docs updated:** ARCHITECTURE.md (confirmed schema + default rules already present), README.md (Classification Rules subsection added under "What AI Does for You").