### PR TITLE
[P2] Ledger types + account-to-ledger mapping (#174)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -265,10 +265,13 @@ Only what HAL actually needs to call. Grouped:
 - `disconnect(id)`
 
 ### Ledgers (rarely used after setup)
-- `list_ledgers()`
-- `add_line_item(ledger_id, name, item_type)`
-- `add_ledger(name)`
+- `list_ledgers()` — returns `id`, `name`, `type`, `description`, and `items` for each ledger
+- `add_ledger(name)` — creates a generic personal ledger
+- `create_property_ledger(name, description?)` — creates a `property` ledger seeded with 6 default line items (Rent income, Mortgage, Property tax, Maintenance & repairs, Insurance, Utilities)
+- `create_investment_ledger(name)` — creates an `investment` ledger seeded with 2 default line items (Contributions, Dividends & Returns)
+- `add_line_item(ledger_id, name, item_type)` — `item_type` is `income` or `expense`
 - `remove_line_item(id)`
+- `set_account_ledger(account_id, ledger_id)` — routes transactions from a bank account to a specific ledger by default
 
 ### Transactions
 - `sync()` → pull from Plaid, classify, return summary

--- a/README.md
+++ b/README.md
@@ -139,6 +139,14 @@ Three things, kept minimal:
 Personal), click into one to add/rename/remove line items, add new
 ledgers when you need them (e.g. for a rental property).
 
+Ledgers come in three types:
+- **Personal** (default) — standard household budget with line items like Salary, Groceries, Dining, etc.
+- **Property** — rental/investment property ledger with pre-seeded items: Rent income, Mortgage, Property tax, Maintenance & repairs, Insurance, Utilities.
+- **Investment** — tracks investment accounts with Contributions and Dividends & Returns.
+
+Create typed ledgers via MCP: `create_property_ledger('123 Main St')` or `create_investment_ledger('TFSA')`.
+Link a bank account to a ledger so its transactions route there by default: `set_account_ledger(account_id, ledger_id)`.
+
 Reviewing classifications, running queries, anything beyond the basics -
 those still happen through the MCP adapter (your OpenClaw agent or any
 other MCP client).

--- a/server/db.py
+++ b/server/db.py
@@ -122,6 +122,16 @@ def init_db(path: str | Path) -> None:
         _add_col_if_missing(conn, "classification_hints", "user_id", "TEXT")
         _add_col_if_missing(conn, "sessions", "user_id", "TEXT")
 
+        # Migration: ledger types + description (#174)
+        _add_col_if_missing(conn, "ledgers", "type", "TEXT NOT NULL DEFAULT 'personal'")
+        _add_col_if_missing(conn, "ledgers", "description", "TEXT")
+
+        # Migration: bank_accounts default_ledger_id (#174)
+        _add_col_if_missing(conn, "bank_accounts", "default_ledger_id", "TEXT")
+
+        # Migration: line_items item_type (#174)
+        _add_col_if_missing(conn, "line_items", "item_type", "TEXT NOT NULL DEFAULT 'expense'")
+
         # Migration: create default user only when there is existing data to migrate
         # (i.e. rows exist that need a user_id) but no users have been created yet.
         # On truly fresh DBs, we leave users empty so the setup wizard can create

--- a/server/main.py
+++ b/server/main.py
@@ -650,7 +650,8 @@ def list_ledgers() -> dict:
     try:
         if uid:
             ledger_rows = conn.execute(
-                "SELECT id, name FROM ledgers WHERE user_id = ? OR user_id IS NULL ORDER BY name",
+                "SELECT id, name, type, description FROM ledgers "
+                "WHERE user_id = ? OR user_id IS NULL ORDER BY name",
                 (uid,),
             ).fetchall()
         else:
@@ -665,6 +666,8 @@ def list_ledgers() -> dict:
                 {
                     "id": lr["id"],
                     "name": lr["name"],
+                    "type": lr["type"],
+                    "description": lr["description"],
                     "items": [
                         {"id": i["id"], "name": i["name"], "type": i["item_type"]} for i in items
                     ],
@@ -807,6 +810,184 @@ def remove_line_item(id: str) -> dict:
         conn.close()
 
     return {"status": "ok"}
+
+
+@mcp.tool
+def set_account_ledger(account_id: str, ledger_id: str) -> dict:
+    """Link a bank account to a default ledger for transaction routing.
+
+    Transactions from this account will be routed to the specified ledger by
+    default during classification.
+
+    Parameters
+    ----------
+    account_id : str
+        Internal bank_account id.
+    ledger_id : str
+        ID of the target ledger (must belong to the active user).
+
+    Returns
+    -------
+    dict
+        ``{"status": "ok"}`` on success or ``{"status": "error", ...}``.
+    """
+    uid = get_active_user_id(server.paths.DB_PATH)
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        # Verify account belongs to active user (via bank_connections.user_id)
+        if uid:
+            acct_row = conn.execute(
+                """
+                SELECT ba.id FROM bank_accounts ba
+                JOIN bank_connections bc ON bc.id = ba.connection_id
+                WHERE ba.id = ? AND bc.user_id = ?
+                """,
+                (account_id, uid),
+            ).fetchone()
+        else:
+            acct_row = conn.execute(
+                "SELECT id FROM bank_accounts WHERE id = ?", (account_id,)
+            ).fetchone()
+
+        if acct_row is None:
+            return {
+                "status": "error",
+                "message": f"account_id {account_id!r} not found or not owned by active user",
+            }
+
+        # Verify ledger belongs to active user
+        if uid:
+            ledger_row = conn.execute(
+                "SELECT id FROM ledgers WHERE id = ? AND (user_id = ? OR user_id IS NULL)",
+                (ledger_id, uid),
+            ).fetchone()
+        else:
+            ledger_row = conn.execute(
+                "SELECT id FROM ledgers WHERE id = ?", (ledger_id,)
+            ).fetchone()
+
+        if ledger_row is None:
+            return {
+                "status": "error",
+                "message": f"ledger_id {ledger_id!r} not found or not owned by active user",
+            }
+
+        conn.execute(
+            "UPDATE bank_accounts SET default_ledger_id = ? WHERE id = ?",
+            (ledger_id, account_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    return {"status": "ok"}
+
+
+@mcp.tool
+def create_property_ledger(name: str, description: str = None) -> dict:
+    """Create a ledger for a rental/investment property with default line items.
+
+    Seeds 6 standard line items:
+      Income: ``Rent income``
+      Expenses: ``Mortgage``, ``Property tax``, ``Maintenance & repairs``,
+                ``Insurance``, ``Utilities``
+
+    Parameters
+    ----------
+    name : str
+        Ledger name (e.g. "123 Main St").
+    description : str, optional
+        Optional address or label (e.g. "2-bed condo, downtown").
+
+    Returns
+    -------
+    dict
+        ``{"status": "ok", "ledger_id": "<uuid>"}``
+    """
+    name = name.strip() if name else ""
+    if not name:
+        return {"status": "error", "message": "Ledger name must be non-empty"}
+
+    uid = get_active_user_id(server.paths.DB_PATH)
+    if uid is None:
+        return {"status": "error", "message": "No active user"}
+
+    _PROPERTY_LINE_ITEMS = [
+        ("Rent income", "income"),
+        ("Mortgage", "expense"),
+        ("Property tax", "expense"),
+        ("Maintenance & repairs", "expense"),
+        ("Insurance", "expense"),
+        ("Utilities", "expense"),
+    ]
+
+    ledger_id = str(uuid.uuid4())
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        with db_txn(conn):
+            conn.execute(
+                "INSERT INTO ledgers (id, name, user_id, type, description) "
+                "VALUES (?, ?, ?, 'property', ?)",
+                (ledger_id, name, uid, description),
+            )
+            for item_name, item_type in _PROPERTY_LINE_ITEMS:
+                conn.execute(
+                    "INSERT INTO line_items (id, ledger_id, name, item_type) VALUES (?, ?, ?, ?)",
+                    (str(uuid.uuid4()), ledger_id, item_name, item_type),
+                )
+    finally:
+        conn.close()
+
+    return {"status": "ok", "ledger_id": ledger_id}
+
+
+@mcp.tool
+def create_investment_ledger(name: str) -> dict:
+    """Create a ledger for tracking investments with default line items.
+
+    Seeds 2 standard line items:
+      ``Contributions`` (expense), ``Dividends & Returns`` (income)
+
+    Parameters
+    ----------
+    name : str
+        Ledger name (e.g. "TFSA", "RRSP").
+
+    Returns
+    -------
+    dict
+        ``{"status": "ok", "ledger_id": "<uuid>"}``
+    """
+    name = name.strip() if name else ""
+    if not name:
+        return {"status": "error", "message": "Ledger name must be non-empty"}
+
+    uid = get_active_user_id(server.paths.DB_PATH)
+    if uid is None:
+        return {"status": "error", "message": "No active user"}
+
+    _INVESTMENT_LINE_ITEMS = [
+        ("Contributions", "expense"),
+        ("Dividends & Returns", "income"),
+    ]
+
+    ledger_id = str(uuid.uuid4())
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        with db_txn(conn):
+            conn.execute(
+                "INSERT INTO ledgers (id, name, user_id, type) VALUES (?, ?, ?, 'investment')",
+                (ledger_id, name, uid),
+            )
+            for item_name, item_type in _INVESTMENT_LINE_ITEMS:
+                conn.execute(
+                    "INSERT INTO line_items (id, ledger_id, name, item_type) VALUES (?, ?, ?, ?)",
+                    (str(uuid.uuid4()), ledger_id, item_name, item_type),
+                )
+    finally:
+        conn.close()
+
+    return {"status": "ok", "ledger_id": ledger_id}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ledger_types.py
+++ b/tests/test_ledger_types.py
@@ -1,0 +1,344 @@
+"""
+tests/test_ledger_types.py — Unit tests for ledger type support (#174).
+
+Tests:
+  - Migrations: fresh DB has type/description on ledgers, default_ledger_id
+    on bank_accounts, item_type on line_items
+  - list_ledgers() returns type and description fields
+  - create_property_ledger() creates ledger with type=property and 6 line items
+  - create_investment_ledger() creates ledger with type=investment and 2 line items
+  - set_account_ledger() links account to ledger correctly
+  - Invalid account or ledger → error response
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+
+import server.paths
+from server.db import get_db, init_db
+from ui.auth import create_session, create_user
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path, monkeypatch) -> Path:
+    """Fresh temp DB; monkeypatch server.paths.DB_PATH to point at it."""
+    path = tmp_path / "test_ledger_types.db"
+    init_db(path)
+    monkeypatch.setattr(server.paths, "DB_PATH", path)
+    return path
+
+
+@pytest.fixture()
+def authed_user(db_path: Path) -> dict:
+    """Create a test user + session so get_active_user_id() returns a real ID."""
+    user_id = create_user(db_path, "testuser", "testpass123")
+    token = create_session(db_path, user_id=user_id)
+    return {"user_id": user_id, "token": token}
+
+
+# ---------------------------------------------------------------------------
+# Migration tests: schema columns exist on fresh DB
+# ---------------------------------------------------------------------------
+
+
+def test_ledgers_has_type_column(db_path: Path):
+    """Fresh DB: ledgers table has a 'type' column."""
+    conn = get_db(db_path)
+    try:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(ledgers)")}
+    finally:
+        conn.close()
+    assert "type" in cols, "ledgers.type column missing"
+
+
+def test_ledgers_has_description_column(db_path: Path):
+    """Fresh DB: ledgers table has a 'description' column."""
+    conn = get_db(db_path)
+    try:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(ledgers)")}
+    finally:
+        conn.close()
+    assert "description" in cols, "ledgers.description column missing"
+
+
+def test_bank_accounts_has_default_ledger_id(db_path: Path):
+    """Fresh DB: bank_accounts table has a 'default_ledger_id' column."""
+    conn = get_db(db_path)
+    try:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(bank_accounts)")}
+    finally:
+        conn.close()
+    assert "default_ledger_id" in cols, "bank_accounts.default_ledger_id column missing"
+
+
+def test_line_items_has_item_type_column(db_path: Path):
+    """Fresh DB: line_items table has an 'item_type' column."""
+    conn = get_db(db_path)
+    try:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(line_items)")}
+    finally:
+        conn.close()
+    assert "item_type" in cols, "line_items.item_type column missing"
+
+
+# ---------------------------------------------------------------------------
+# list_ledgers returns type and description
+# ---------------------------------------------------------------------------
+
+
+def test_list_ledgers_returns_type_and_description(db_path: Path, authed_user, monkeypatch):
+    """list_ledgers() returns 'type' and 'description' fields for each ledger."""
+    from server.main import list_ledgers
+
+    # Seed a personal ledger directly
+    uid = authed_user["user_id"]
+    ledger_id = str(uuid.uuid4())
+    conn = get_db(db_path)
+    try:
+        conn.execute(
+            "INSERT INTO ledgers (id, name, user_id, type, description) VALUES (?, ?, ?, ?, ?)",
+            (ledger_id, "Personal", uid, "personal", None),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    result = list_ledgers()
+    assert "ledgers" in result
+    assert len(result["ledgers"]) >= 1
+
+    personal = next((lg for lg in result["ledgers"] if lg["name"] == "Personal"), None)
+    assert personal is not None
+    assert "type" in personal, "list_ledgers response missing 'type' field"
+    assert "description" in personal, "list_ledgers response missing 'description' field"
+    assert personal["type"] == "personal"
+
+
+# ---------------------------------------------------------------------------
+# create_property_ledger
+# ---------------------------------------------------------------------------
+
+
+def test_create_property_ledger(db_path: Path, authed_user):
+    """create_property_ledger creates a ledger with type=property and 6 line items."""
+    from server.main import create_property_ledger
+
+    result = create_property_ledger("Test Property", description="123 Main St")
+    assert result["status"] == "ok"
+    ledger_id = result["ledger_id"]
+
+    conn = get_db(db_path)
+    try:
+        ledger = conn.execute(
+            "SELECT id, name, type, description FROM ledgers WHERE id = ?", (ledger_id,)
+        ).fetchone()
+        assert ledger is not None
+        assert ledger["type"] == "property"
+        assert ledger["description"] == "123 Main St"
+
+        items = conn.execute(
+            "SELECT name, item_type FROM line_items WHERE ledger_id = ?", (ledger_id,)
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert len(items) == 6, f"Expected 6 line items, got {len(items)}: {[i['name'] for i in items]}"
+
+    names = [i["name"] for i in items]
+    item_types = {i["name"]: i["item_type"] for i in items}
+
+    assert "Rent income" in names
+    assert "Mortgage" in names
+    assert "Property tax" in names
+    assert "Maintenance & repairs" in names
+    assert "Insurance" in names
+    assert "Utilities" in names
+
+    assert item_types["Rent income"] == "income"
+    for expense_name in (
+        "Mortgage",
+        "Property tax",
+        "Maintenance & repairs",
+        "Insurance",
+        "Utilities",
+    ):
+        assert item_types[expense_name] == "expense", f"{expense_name} should be expense"
+
+
+def test_create_property_ledger_no_description(db_path: Path, authed_user):
+    """create_property_ledger works without a description."""
+    from server.main import create_property_ledger
+
+    result = create_property_ledger("Prop B")
+    assert result["status"] == "ok"
+
+    conn = get_db(db_path)
+    try:
+        ledger = conn.execute(
+            "SELECT type, description FROM ledgers WHERE id = ?", (result["ledger_id"],)
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert ledger["type"] == "property"
+    assert ledger["description"] is None
+
+
+def test_create_property_ledger_no_active_user(db_path: Path):
+    """create_property_ledger returns error when no user is logged in."""
+    from server.main import create_property_ledger
+
+    result = create_property_ledger("Should Fail")
+    assert result["status"] == "error"
+    assert "No active user" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# create_investment_ledger
+# ---------------------------------------------------------------------------
+
+
+def test_create_investment_ledger(db_path: Path, authed_user):
+    """create_investment_ledger creates a ledger with type=investment and 2 line items."""
+    from server.main import create_investment_ledger
+
+    result = create_investment_ledger("TFSA")
+    assert result["status"] == "ok"
+    ledger_id = result["ledger_id"]
+
+    conn = get_db(db_path)
+    try:
+        ledger = conn.execute(
+            "SELECT id, name, type FROM ledgers WHERE id = ?", (ledger_id,)
+        ).fetchone()
+        assert ledger is not None
+        assert ledger["type"] == "investment"
+        assert ledger["name"] == "TFSA"
+
+        items = conn.execute(
+            "SELECT name, item_type FROM line_items WHERE ledger_id = ?", (ledger_id,)
+        ).fetchall()
+    finally:
+        conn.close()
+
+    assert len(items) == 2, f"Expected 2 line items, got {len(items)}"
+
+    item_types = {i["name"]: i["item_type"] for i in items}
+    assert "Contributions" in item_types
+    assert "Dividends & Returns" in item_types
+    assert item_types["Contributions"] == "expense"
+    assert item_types["Dividends & Returns"] == "income"
+
+
+def test_create_investment_ledger_no_active_user(db_path: Path):
+    """create_investment_ledger returns error when no user is logged in."""
+    from server.main import create_investment_ledger
+
+    result = create_investment_ledger("Should Fail")
+    assert result["status"] == "error"
+    assert "No active user" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# set_account_ledger
+# ---------------------------------------------------------------------------
+
+
+def _seed_account_and_ledger(db_path: Path, user_id: str) -> tuple[str, str]:
+    """Insert a bank connection + bank account + ledger for testing. Returns (account_id, ledger_id)."""
+    conn = get_db(db_path)
+    try:
+        connection_id = str(uuid.uuid4())
+        conn.execute(
+            "INSERT INTO bank_connections "
+            "(id, plaid_item_id, plaid_access_token_encrypted, status, user_id, plaid_env) "
+            "VALUES (?, ?, ?, 'active', ?, 'sandbox')",
+            (connection_id, f"item-{uuid.uuid4()}", "encrypted-token", user_id),
+        )
+
+        account_id = str(uuid.uuid4())
+        conn.execute(
+            "INSERT INTO bank_accounts (id, connection_id, plaid_account_id, name) "
+            "VALUES (?, ?, ?, ?)",
+            (account_id, connection_id, f"plaid-acct-{uuid.uuid4()}", "Test Account"),
+        )
+
+        ledger_id = str(uuid.uuid4())
+        conn.execute(
+            "INSERT INTO ledgers (id, name, user_id, type) VALUES (?, ?, ?, 'personal')",
+            (ledger_id, "Test Ledger", user_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    return account_id, ledger_id
+
+
+def test_set_account_ledger(db_path: Path, authed_user):
+    """set_account_ledger links account to ledger correctly."""
+    from server.main import set_account_ledger
+
+    uid = authed_user["user_id"]
+    account_id, ledger_id = _seed_account_and_ledger(db_path, uid)
+
+    result = set_account_ledger(account_id, ledger_id)
+    assert result == {"status": "ok"}, f"Unexpected result: {result}"
+
+    conn = get_db(db_path)
+    try:
+        row = conn.execute(
+            "SELECT default_ledger_id FROM bank_accounts WHERE id = ?", (account_id,)
+        ).fetchone()
+    finally:
+        conn.close()
+
+    assert row["default_ledger_id"] == ledger_id
+
+
+def test_set_account_ledger_invalid_account(db_path: Path, authed_user):
+    """set_account_ledger returns error for non-existent account."""
+    from server.main import set_account_ledger
+
+    uid = authed_user["user_id"]
+    _, ledger_id = _seed_account_and_ledger(db_path, uid)
+
+    result = set_account_ledger("nonexistent-account-id", ledger_id)
+    assert result["status"] == "error"
+
+
+def test_set_account_ledger_invalid_ledger(db_path: Path, authed_user):
+    """set_account_ledger returns error for non-existent ledger."""
+    from server.main import set_account_ledger
+
+    uid = authed_user["user_id"]
+    account_id, _ = _seed_account_and_ledger(db_path, uid)
+
+    result = set_account_ledger(account_id, "nonexistent-ledger-id")
+    assert result["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# list_ledgers includes property and investment types
+# ---------------------------------------------------------------------------
+
+
+def test_list_ledgers_shows_all_types(db_path: Path, authed_user):
+    """list_ledgers() returns all three ledger types when created."""
+    from server.main import create_investment_ledger, create_property_ledger, list_ledgers
+
+    create_property_ledger("Property A")
+    create_investment_ledger("Investments")
+
+    result = list_ledgers()
+    types = [lg["type"] for lg in result["ledgers"]]
+    assert "property" in types, f"Expected 'property' in types, got: {types}"
+    assert "investment" in types, f"Expected 'investment' in types, got: {types}"


### PR DESCRIPTION
Closes #174

Adds `type` (personal/property/investment) + `description` to ledgers, `default_ledger_id` to bank_accounts, `item_type` (income/expense) to line_items. Three new MCP tools: `create_property_ledger`, `create_investment_ledger`, `set_account_ledger`. Property ledger seeds 6 default line items; investment ledger seeds 2.

**Interactive check:**
```
{'status': 'ok', 'ledger_id': 'b1bfc60e-b9b8-4a1d-b05a-4f08d1b09bc1'}
{'status': 'ok', 'ledger_id': '9b8c88f2-f894-484b-a645-c6cd933da8e1'}
['investment', 'property']
```

**MCP sanity check:**
- list_ledgers() → each ledger has `type` and `description` fields
- create_property_ledger(name='Property A') → type=property, 6 line items (Rent income [income], Mortgage/Property tax/Maintenance & repairs/Insurance/Utilities [expense])
- create_investment_ledger(name='Investments') → type=investment, 2 line items (Contributions [expense], Dividends & Returns [income])
- set_account_ledger(account_id=..., ledger_id=...) → links correctly; invalid account/ledger → error response

**Test suite:** 573 passed, 16 skipped (including 14 new tests in test_ledger_types.py)

**Docs updated:** ARCHITECTURE.md (Ledgers section updated with new tools), README.md (ledger types mentioned with usage examples).