### PR TITLE
[P6] Excel export: browser stream download at /export/excel (#156)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -447,6 +447,7 @@ system working while you're not looking.
   /setup         →  first-run wizard (one-time, locked after completion)
   /login         →  password login
   /profile       →  settings, password, sync/export actions, Linked Accounts list
+  /export/excel  →  GET — stream .xlsx workbook as browser download (auth required)
   /ledgers       →  minimal ledger / line-item editor
   /link          →  Plaid Link flow (used by setup wizard, profile, MCP links)
 ```

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Three things, kept minimal:
 - Log out
 - Read-only system info (Plaid env, last sync time, daemon uptime)
 - **Sync now** button
-- **Export to Excel** button
+- **Export to Excel** button — available as a browser download at `/export/excel` (streams the workbook directly to your browser without saving to disk)
 - **Linked Accounts** - compact list of connected banks with status pills
   and **Reconnect / Disconnect / + Connect a bank** buttons. No fancy
   cards, just a list.

--- a/server/excel_export.py
+++ b/server/excel_export.py
@@ -327,6 +327,31 @@ def build_workbook(
     return wb
 
 
+def export_excel_bytes(
+    conn: sqlite3.Connection,
+    years: list[int] | None = None,
+) -> bytes:
+    """Generate an Excel export and return as bytes (for browser streaming).
+
+    Parameters
+    ----------
+    conn:
+        An open sqlite3 connection.
+    years:
+        Passed through to build_workbook.  If None, all years are included.
+
+    Returns
+    -------
+    Raw bytes of the .xlsx file (suitable for streaming to a browser).
+    """
+    import io
+
+    wb = build_workbook(conn, years)
+    buffer = io.BytesIO()
+    wb.save(buffer)
+    return buffer.getvalue()
+
+
 def export_to_file(
     conn: sqlite3.Connection,
     path: str | Path,

--- a/tests/test_excel_download.py
+++ b/tests/test_excel_download.py
@@ -1,0 +1,104 @@
+"""
+tests/test_excel_download.py — Tests for the /export/excel browser-download route (#156).
+
+Verifies that:
+  - Authenticated GET /export/excel returns 200 with correct Content-Type and
+    Content-Disposition headers and non-empty body.
+  - Unauthenticated GET /export/excel returns 302 redirect to /login.
+  - Response body is a valid openpyxl workbook with at least one sheet.
+"""
+
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# Re-use auth helpers from test_ui_routes
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path, monkeypatch) -> Path:
+    import server.paths as paths
+    from server.db import init_db
+
+    db = tmp_path / "test.db"
+    init_db(db)
+
+    monkeypatch.setattr(paths, "DB_PATH", db)
+    monkeypatch.setattr(paths, "APP_DIR", tmp_path)
+    return db
+
+
+@pytest.fixture()
+def client(db_path: Path) -> TestClient:
+    from ui.server import app
+
+    return TestClient(app, follow_redirects=False)
+
+
+@pytest.fixture()
+def authed_client(db_path: Path) -> TestClient:
+    from ui.server import app
+
+    c = TestClient(app, follow_redirects=False)
+    _complete_setup(c)
+    return _login(c)
+
+
+def _complete_setup(client: TestClient, password: str = "testpassword123") -> None:
+    r = client.post("/setup/1", data={"password": password, "password_confirm": password})
+    assert r.status_code == 200
+    r = client.post("/setup/2", data={"notification_pref": "openclaw"})
+    # Accept any 2xx or redirect — wizard may have more steps
+    assert r.status_code in (200, 302, 303)
+
+
+def _login(client: TestClient, password: str = "testpassword123") -> TestClient:
+    r = client.post("/login", data={"password": password})
+    # Should redirect on success
+    assert r.status_code in (200, 302, 303)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestExcelDownloadAuthenticated:
+    def test_status_200(self, authed_client: TestClient) -> None:
+        r = authed_client.get("/export/excel")
+        assert r.status_code == 200
+
+    def test_content_type_xlsx(self, authed_client: TestClient) -> None:
+        r = authed_client.get("/export/excel")
+        assert "spreadsheetml" in r.headers["content-type"]
+
+    def test_content_disposition_attachment(self, authed_client: TestClient) -> None:
+        r = authed_client.get("/export/excel")
+        cd = r.headers.get("content-disposition", "")
+        assert "attachment" in cd
+        assert ".xlsx" in cd
+
+    def test_body_non_empty(self, authed_client: TestClient) -> None:
+        r = authed_client.get("/export/excel")
+        assert len(r.content) > 0
+
+    def test_valid_workbook_with_sheets(self, authed_client: TestClient) -> None:
+        import openpyxl
+
+        r = authed_client.get("/export/excel")
+        wb = openpyxl.load_workbook(BytesIO(r.content))
+        assert len(wb.sheetnames) >= 1
+
+
+class TestExcelDownloadUnauthenticated:
+    def test_redirects_to_login(self, client: TestClient) -> None:
+        r = client.get("/export/excel")
+        assert r.status_code == 302
+        assert "/login" in r.headers.get("location", "")

--- a/ui/server.py
+++ b/ui/server.py
@@ -1009,6 +1009,29 @@ async def account_description_patch(request: Request, account_id: str):
 # ── /ledgers ─────────────────────────────────────────────────────────────────
 
 
+@app.get("/export/excel")
+def export_excel_download(request: Request):
+    """Stream an Excel export as a browser download."""
+    if not _is_authenticated(request):
+        return _redirect("/login")
+
+    import datetime
+
+    from fastapi.responses import Response as _Response
+
+    from server.excel_export import export_excel_bytes
+
+    with get_db(_db_path()) as conn:
+        data = export_excel_bytes(conn)
+
+    filename = f"friday-budget-{datetime.date.today().strftime('%Y-%m')}.xlsx"
+    return _Response(
+        content=data,
+        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        headers={"Content-Disposition": f"attachment; filename={filename}"},
+    )
+
+
 @app.get("/ledgers", response_class=HTMLResponse)
 def ledgers_get(request: Request):
     """Read-only ledger tree.  Requires authentication.

--- a/ui/templates/profile.html
+++ b/ui/templates/profile.html
@@ -62,10 +62,7 @@
         <input type="hidden" name="action" value="sync_now">
         <button type="submit" class="btn-secondary" id="btn-sync-now">Sync Now</button>
       </form>
-      <form method="post" action="/profile" style="display:inline">
-        <input type="hidden" name="action" value="export_now">
-        <button type="submit" class="btn-secondary">Export Excel</button>
-      </form>
+      <a href="/export/excel" class="btn-secondary">Export Excel</a>
     </div>
   </section>
 


### PR DESCRIPTION
Closes #156

## Summary

Implements in-memory (BytesIO) Excel generation and streams the workbook directly to the browser as a file download — no disk writes needed.

### Changes

- **** — Added `export_excel_bytes(conn, years=None) -> bytes` that builds the workbook via the existing `build_workbook()` and returns raw bytes from a `BytesIO` buffer.
- **** — Added `GET /export/excel` route (auth-guarded) that calls `export_excel_bytes` and returns a `Response` with `Content-Disposition: attachment` and the xlsx MIME type.
- **`ui/templates/profile.html`** — Replaced the old POST form (`action=export_now`) with a simple `<a href="/export/excel">` link.
- **`tests/test_excel_download.py`** — 6 tests: authenticated 200 + correct Content-Type + Content-Disposition + non-empty body + valid openpyxl workbook; unauthenticated 302 → /login.
- **`README.md`** / **`ARCHITECTURE.md`** — Documented the new route.

### Interactive check

Verified via `TestClient` (all 6 tests pass):
```
tests/test_excel_download.py::TestExcelDownloadAuthenticated::test_status_200 PASSED
tests/test_excel_download.py::TestExcelDownloadAuthenticated::test_content_type_xlsx PASSED
tests/test_excel_download.py::TestExcelDownloadAuthenticated::test_content_disposition_attachment PASSED
tests/test_excel_download.py::TestExcelDownloadAuthenticated::test_body_non_empty PASSED
tests/test_excel_download.py::TestExcelDownloadAuthenticated::test_valid_workbook_with_sheets PASSED
tests/test_excel_download.py::TestExcelDownloadUnauthenticated::test_redirects_to_login PASSED

579 passed, 16 skipped in full suite
```