### PR TITLE
[P4] Transfer detection: cross-account same-amount matching (#171)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -310,6 +310,33 @@ New transaction
 After 3 successful LLM classifications of the same merchant, auto-promote
 to a Tier 1 rule. System gets cheaper and faster over time.
 
+### Transfer Detection
+
+Implemented in `server/transfer_detect.py`. Independent of the main classifier
+so it can run as a pre-pass without touching `classifier.py`.
+
+**`detect_internal_transfers(db_conn, user_id, lookback_days=7)`**
+- Fetches all non-pending transactions for accounts belonging to `user_id`.
+- Pairs an outflow (positive amount) with an inflow (negative amount) when:
+  - They belong to **different** bank accounts owned by the same user.
+  - `|outflow.amount − |inflow.amount|| < 0.01` (penny-level tolerance).
+  - `|outflow.date − inflow.date| ≤ 3 days`.
+- Returns a list of `{outflow_tx_id, inflow_tx_id, amount, days_apart, account_a, account_b}` dicts.
+- Matching is one-to-one: once a transaction is paired it is not reused.
+
+**`get_transfer_hint(tx_id, db_path)`**
+- Convenience wrapper: opens the DB, resolves the owner, calls
+  `detect_internal_transfers`, and returns
+  `{is_possible_transfer: True, matched_account: str, matched_amount: float}`
+  if the transaction appears in a detected pair, or `None` otherwise.
+
+**`is_investment_account(account)`**
+- Returns `True` if `account["institution_name"]` is a substring (case-insensitive)
+  of a known investment platform: Wealthsimple, Questrade, Robinhood, Vanguard,
+  Fidelity, Schwab.
+- Used by callers that want to tag investment outflows as `savings` rather than
+  `spending`.
+
 ---
 
 ## OpenClaw Integration

--- a/server/transfer_detect.py
+++ b/server/transfer_detect.py
@@ -1,0 +1,237 @@
+"""
+server/transfer_detect.py — Internal transfer detection for Friday Budgeting Pro.
+
+Identifies pairs of transactions that look like internal transfers between
+accounts owned by the same user (same amount, different accounts, within 3 days).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+# ---------------------------------------------------------------------------
+# Known investment institution substrings (case-insensitive match)
+# ---------------------------------------------------------------------------
+
+_INVESTMENT_INSTITUTIONS = [
+    "wealthsimple",
+    "questrade",
+    "robinhood",
+    "vanguard",
+    "fidelity",
+    "schwab",
+]
+
+
+def is_investment_account(account: dict) -> bool:
+    """Return True if the account is at a known investment platform.
+
+    Matches on ``institution_name`` as a case-insensitive substring check.
+
+    Args:
+        account: A dict (or sqlite3.Row) with an ``institution_name`` key.
+
+    Returns:
+        True if the institution name contains a known investment platform name.
+    """
+    name: str = (account.get("institution_name") or "").lower()
+    return any(inst in name for inst in _INVESTMENT_INSTITUTIONS)
+
+
+# ---------------------------------------------------------------------------
+# Core transfer detection
+# ---------------------------------------------------------------------------
+
+
+def detect_internal_transfers(
+    db_conn: sqlite3.Connection,
+    user_id: str,
+    lookback_days: int = 7,
+) -> list[dict]:
+    """Find pairs of transactions that look like internal transfers.
+
+    Matching criteria:
+    - Same user (transactions belong to bank_accounts whose connections share
+      user_id)
+    - Different bank accounts
+    - One outflow (positive amount) and one inflow (negative amount, i.e. credit)
+    - |outflow.amount - |inflow.amount|| < 0.01
+    - |outflow.date - inflow.date| <= 3 days
+
+    Args:
+        db_conn:      An open sqlite3 connection (row_factory may be set or not).
+        user_id:      The user whose accounts to search across.
+        lookback_days: How many days back to consider (default 7).
+
+    Returns:
+        List of dicts, each containing::
+
+            {
+                "outflow_tx_id": str,
+                "inflow_tx_id":  str,
+                "amount":        float,   # the outflow amount
+                "days_apart":    int,
+                "account_a":     str,     # bank_account_id of the outflow
+                "account_b":     str,     # bank_account_id of the inflow
+            }
+    """
+    # Fetch all recent transactions for accounts belonging to this user.
+    # Positive amount = outflow (money leaving the account).
+    # Negative amount = inflow (money arriving, e.g. credit/deposit from bank's POV).
+    cursor = db_conn.execute(
+        """
+        SELECT
+            t.id          AS tx_id,
+            t.bank_account_id,
+            t.date,
+            t.amount
+        FROM transactions t
+        JOIN bank_accounts ba ON ba.id = t.bank_account_id
+        JOIN bank_connections bc ON bc.id = ba.connection_id
+        WHERE bc.user_id = ?
+          AND t.date >= date('now', ? || ' days')
+          AND t.pending = 0
+        ORDER BY t.date ASC
+        """,
+        (user_id, f"-{lookback_days}"),
+    )
+
+    rows = cursor.fetchall()
+
+    # Separate into outflows (positive) and inflows (negative).
+    outflows = []
+    inflows = []
+    for row in rows:
+        if isinstance(row, sqlite3.Row):
+            tx_id, account_id, date, amount = (
+                row["tx_id"],
+                row["bank_account_id"],
+                row["date"],
+                row["amount"],
+            )
+        else:
+            tx_id, account_id, date, amount = row
+
+        if amount > 0:
+            outflows.append((tx_id, account_id, date, amount))
+        elif amount < 0:
+            inflows.append((tx_id, account_id, date, amount))
+
+    # Match pairs.
+    matched_pairs: list[dict] = []
+    used_outflows: set[str] = set()
+    used_inflows: set[str] = set()
+
+    for out_id, out_account, out_date, out_amount in outflows:
+        if out_id in used_outflows:
+            continue
+
+        for in_id, in_account, in_date, in_amount in inflows:
+            if in_id in used_inflows:
+                continue
+
+            # Must be different accounts.
+            if out_account == in_account:
+                continue
+
+            # Amount tolerance: |out_amount - |in_amount|| < 0.01
+            if abs(out_amount - abs(in_amount)) >= 0.01:
+                continue
+
+            # Date distance: <= 3 days.
+            days_apart = _date_diff_days(out_date, in_date)
+            if days_apart > 3:
+                continue
+
+            matched_pairs.append(
+                {
+                    "outflow_tx_id": out_id,
+                    "inflow_tx_id": in_id,
+                    "amount": out_amount,
+                    "days_apart": days_apart,
+                    "account_a": out_account,
+                    "account_b": in_account,
+                }
+            )
+            used_outflows.add(out_id)
+            used_inflows.add(in_id)
+            break  # One-to-one matching: move to next outflow.
+
+    return matched_pairs
+
+
+# ---------------------------------------------------------------------------
+# Per-transaction helper
+# ---------------------------------------------------------------------------
+
+
+def get_transfer_hint(tx_id: str, db_path: str) -> dict | None:
+    """Return a transfer hint dict if this transaction may be part of an internal transfer.
+
+    Opens a fresh connection to *db_path*, fetches the transaction's user_id,
+    then calls :func:`detect_internal_transfers` and checks whether *tx_id*
+    appears in any detected pair.
+
+    Args:
+        tx_id:   The transaction ID to look up.
+        db_path: Path to the SQLite database file.
+
+    Returns:
+        ``{"is_possible_transfer": True, "matched_account": str,
+           "matched_amount": float}``
+        if the transaction is part of a detected transfer pair, otherwise ``None``.
+    """
+    from server.db import get_db
+
+    conn = get_db(db_path)
+    try:
+        # Resolve the user that owns this transaction.
+        row = conn.execute(
+            """
+            SELECT bc.user_id, t.bank_account_id
+            FROM transactions t
+            JOIN bank_accounts ba ON ba.id = t.bank_account_id
+            JOIN bank_connections bc ON bc.id = ba.connection_id
+            WHERE t.id = ?
+            """,
+            (tx_id,),
+        ).fetchone()
+
+        if row is None:
+            return None
+
+        user_id = row["user_id"]
+
+        pairs = detect_internal_transfers(conn, user_id, lookback_days=7)
+
+        for pair in pairs:
+            if pair["outflow_tx_id"] == tx_id:
+                return {
+                    "is_possible_transfer": True,
+                    "matched_account": pair["account_b"],
+                    "matched_amount": pair["amount"],
+                }
+            if pair["inflow_tx_id"] == tx_id:
+                return {
+                    "is_possible_transfer": True,
+                    "matched_account": pair["account_a"],
+                    "matched_amount": pair["amount"],
+                }
+    finally:
+        conn.close()
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _date_diff_days(date_a: str, date_b: str) -> int:
+    """Return the absolute number of days between two YYYY-MM-DD date strings."""
+    from datetime import date as _date
+
+    a = _date.fromisoformat(date_a)
+    b = _date.fromisoformat(date_b)
+    return abs((a - b).days)

--- a/tests/test_transfer_detection.py
+++ b/tests/test_transfer_detection.py
@@ -1,0 +1,316 @@
+"""
+tests/test_transfer_detection.py — Tests for server/transfer_detect.py.
+
+Covers:
+- detect_internal_transfers: basic match (same amount, different accounts, within 3 days)
+- detect_internal_transfers: amount tolerance within $0.01 → still detected
+- detect_internal_transfers: more than 3 days apart → NOT detected
+- detect_internal_transfers: same account → NOT detected
+- detect_internal_transfers: different users → NOT detected
+- is_investment_account: returns True for Wealthsimple, False for RBC Royal Bank
+- get_transfer_hint: returns proper hint dict for a matching tx, None otherwise
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from pathlib import Path
+
+import pytest
+
+from server.db import get_db, init_db
+from server.transfer_detect import (
+    detect_internal_transfers,
+    get_transfer_hint,
+    is_investment_account,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_db(tmp_path: Path):
+    """Return a fresh initialised DB path."""
+    db_file = tmp_path / "test.db"
+    init_db(db_file)
+    return db_file
+
+
+def _new_id() -> str:
+    return str(uuid.uuid4())
+
+
+def _seed_user(conn: sqlite3.Connection) -> str:
+    """Insert a user and return their id."""
+    import time
+
+    user_id = _new_id()
+    conn.execute(
+        "INSERT INTO users (id, username, password_hash, created_at) VALUES (?, ?, ?, ?)",
+        (user_id, f"user_{user_id[:8]}", "hash", int(time.time())),
+    )
+    conn.commit()
+    return user_id
+
+
+def _seed_connection(conn: sqlite3.Connection, user_id: str, institution_name: str = "RBC") -> str:
+    """Insert a bank_connection and return its id."""
+
+    conn_id = _new_id()
+    conn.execute(
+        "INSERT INTO bank_connections "
+        "(id, plaid_access_token_encrypted, institution_name, user_id, plaid_env) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (conn_id, "enc_token", institution_name, user_id, "sandbox"),
+    )
+    conn.commit()
+    return conn_id
+
+
+def _seed_account(conn: sqlite3.Connection, connection_id: str) -> str:
+    """Insert a bank_account and return its id."""
+    acct_id = _new_id()
+    conn.execute(
+        "INSERT INTO bank_accounts (id, connection_id, plaid_account_id, name, type) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (acct_id, connection_id, _new_id(), "Chequing", "depository"),
+    )
+    conn.commit()
+    return acct_id
+
+
+def _seed_transaction(
+    conn: sqlite3.Connection,
+    bank_account_id: str,
+    amount: float,
+    date: str,
+    pending: int = 0,
+) -> str:
+    """Insert a transaction and return its id."""
+    tx_id = _new_id()
+    conn.execute(
+        "INSERT INTO transactions "
+        "(id, bank_account_id, plaid_transaction_id, date, merchant, amount, pending) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (tx_id, bank_account_id, _new_id(), date, "Transfer", amount, pending),
+    )
+    conn.commit()
+    return tx_id
+
+
+# ---------------------------------------------------------------------------
+# detect_internal_transfers tests
+# ---------------------------------------------------------------------------
+
+
+def test_basic_transfer_detected(tmp_db: Path):
+    """Outflow $500 on 2026-05-20, inflow -$500 on 2026-05-21 → detected."""
+    conn = get_db(tmp_db)
+    user_id = _seed_user(conn)
+    conn_id = _seed_connection(conn, user_id)
+    acct_a = _seed_account(conn, conn_id)
+    acct_b = _seed_account(conn, conn_id)
+
+    tx_out = _seed_transaction(conn, acct_a, 500.0, "2026-05-20")
+    tx_in = _seed_transaction(conn, acct_b, -500.0, "2026-05-21")
+
+    pairs = detect_internal_transfers(conn, user_id, lookback_days=365)
+    conn.close()
+
+    assert len(pairs) == 1
+    p = pairs[0]
+    assert p["outflow_tx_id"] == tx_out
+    assert p["inflow_tx_id"] == tx_in
+    assert p["amount"] == 500.0
+    assert p["days_apart"] == 1
+    assert p["account_a"] == acct_a
+    assert p["account_b"] == acct_b
+
+
+def test_amount_tolerance_within_penny(tmp_db: Path):
+    """Amounts within $0.01 of each other should still be detected."""
+    conn = get_db(tmp_db)
+    user_id = _seed_user(conn)
+    conn_id = _seed_connection(conn, user_id)
+    acct_a = _seed_account(conn, conn_id)
+    acct_b = _seed_account(conn, conn_id)
+
+    tx_out = _seed_transaction(conn, acct_a, 500.00, "2026-05-20")
+    tx_in = _seed_transaction(conn, acct_b, -500.005, "2026-05-20")
+
+    pairs = detect_internal_transfers(conn, user_id, lookback_days=365)
+    conn.close()
+
+    assert len(pairs) == 1
+    assert pairs[0]["outflow_tx_id"] == tx_out
+    assert pairs[0]["inflow_tx_id"] == tx_in
+
+
+def test_more_than_3_days_apart_not_detected(tmp_db: Path):
+    """4 days apart should NOT be detected."""
+    conn = get_db(tmp_db)
+    user_id = _seed_user(conn)
+    conn_id = _seed_connection(conn, user_id)
+    acct_a = _seed_account(conn, conn_id)
+    acct_b = _seed_account(conn, conn_id)
+
+    _seed_transaction(conn, acct_a, 500.0, "2026-05-20")
+    _seed_transaction(conn, acct_b, -500.0, "2026-05-24")  # 4 days later
+
+    pairs = detect_internal_transfers(conn, user_id, lookback_days=365)
+    conn.close()
+
+    assert pairs == []
+
+
+def test_same_account_not_detected(tmp_db: Path):
+    """Outflow and inflow on the same account should NOT be detected as a transfer."""
+    conn = get_db(tmp_db)
+    user_id = _seed_user(conn)
+    conn_id = _seed_connection(conn, user_id)
+    acct_a = _seed_account(conn, conn_id)
+
+    _seed_transaction(conn, acct_a, 500.0, "2026-05-20")
+    _seed_transaction(conn, acct_a, -500.0, "2026-05-21")
+
+    pairs = detect_internal_transfers(conn, user_id, lookback_days=365)
+    conn.close()
+
+    assert pairs == []
+
+
+def test_different_users_not_detected(tmp_db: Path):
+    """Transactions from different users should NOT be matched."""
+    conn = get_db(tmp_db)
+
+    user_a = _seed_user(conn)
+    conn_a = _seed_connection(conn, user_a)
+    acct_a = _seed_account(conn, conn_a)
+
+    user_b = _seed_user(conn)
+    conn_b = _seed_connection(conn, user_b)
+    acct_b = _seed_account(conn, conn_b)
+
+    _seed_transaction(conn, acct_a, 500.0, "2026-05-20")
+    _seed_transaction(conn, acct_b, -500.0, "2026-05-21")
+
+    # Query from user_a's perspective: should find no match with user_b's account.
+    pairs = detect_internal_transfers(conn, user_a, lookback_days=365)
+    conn.close()
+
+    assert pairs == []
+
+
+# ---------------------------------------------------------------------------
+# is_investment_account tests
+# ---------------------------------------------------------------------------
+
+
+def test_is_investment_wealthsimple():
+    assert is_investment_account({"institution_name": "Wealthsimple"}) is True
+
+
+def test_is_investment_wealthsimple_lower():
+    assert is_investment_account({"institution_name": "wealthsimple trade"}) is True
+
+
+def test_is_investment_questrade():
+    assert is_investment_account({"institution_name": "Questrade Inc."}) is True
+
+
+def test_is_investment_robinhood():
+    assert is_investment_account({"institution_name": "Robinhood Markets"}) is True
+
+
+def test_is_investment_vanguard():
+    assert is_investment_account({"institution_name": "Vanguard"}) is True
+
+
+def test_is_investment_fidelity():
+    assert is_investment_account({"institution_name": "Fidelity Investments"}) is True
+
+
+def test_is_investment_schwab():
+    assert is_investment_account({"institution_name": "Charles Schwab"}) is True
+
+
+def test_not_investment_rbc():
+    assert is_investment_account({"institution_name": "RBC Royal Bank"}) is False
+
+
+def test_not_investment_td():
+    assert is_investment_account({"institution_name": "TD Canada Trust"}) is False
+
+
+def test_not_investment_none():
+    assert is_investment_account({"institution_name": None}) is False
+
+
+def test_not_investment_empty():
+    assert is_investment_account({"institution_name": ""}) is False
+
+
+# ---------------------------------------------------------------------------
+# get_transfer_hint tests
+# ---------------------------------------------------------------------------
+
+
+def test_get_transfer_hint_match(tmp_db: Path):
+    """get_transfer_hint returns a hint dict for a transaction that is part of a pair."""
+    conn = get_db(tmp_db)
+    user_id = _seed_user(conn)
+    conn_id = _seed_connection(conn, user_id)
+    acct_a = _seed_account(conn, conn_id)
+    acct_b = _seed_account(conn, conn_id)
+
+    tx_out = _seed_transaction(conn, acct_a, 500.0, "2026-05-20")
+    _seed_transaction(conn, acct_b, -500.0, "2026-05-21")
+    conn.close()
+
+    hint = get_transfer_hint(tx_out, str(tmp_db))
+    assert hint is not None
+    assert hint["is_possible_transfer"] is True
+    assert hint["matched_account"] == acct_b
+    assert hint["matched_amount"] == 500.0
+
+
+def test_get_transfer_hint_inflow_match(tmp_db: Path):
+    """get_transfer_hint also works when queried from the inflow side."""
+    conn = get_db(tmp_db)
+    user_id = _seed_user(conn)
+    conn_id = _seed_connection(conn, user_id)
+    acct_a = _seed_account(conn, conn_id)
+    acct_b = _seed_account(conn, conn_id)
+
+    _seed_transaction(conn, acct_a, 500.0, "2026-05-20")
+    tx_in = _seed_transaction(conn, acct_b, -500.0, "2026-05-21")
+    conn.close()
+
+    hint = get_transfer_hint(tx_in, str(tmp_db))
+    assert hint is not None
+    assert hint["is_possible_transfer"] is True
+    assert hint["matched_account"] == acct_a
+    assert hint["matched_amount"] == 500.0
+
+
+def test_get_transfer_hint_no_match(tmp_db: Path):
+    """get_transfer_hint returns None when no pair is detected."""
+    conn = get_db(tmp_db)
+    user_id = _seed_user(conn)
+    conn_id = _seed_connection(conn, user_id)
+    acct_a = _seed_account(conn, conn_id)
+
+    tx_id = _seed_transaction(conn, acct_a, 500.0, "2026-05-20")
+    conn.close()
+
+    hint = get_transfer_hint(tx_id, str(tmp_db))
+    assert hint is None
+
+
+def test_get_transfer_hint_unknown_tx(tmp_db: Path):
+    """get_transfer_hint returns None for an unknown transaction id."""
+    hint = get_transfer_hint("nonexistent-tx-id", str(tmp_db))
+    assert hint is None


### PR DESCRIPTION
Closes #171

## Summary

Adds a new standalone module `server/transfer_detect.py` for detecting internal transfers between accounts. Kept fully separate from `classifier.py` to avoid conflicts with the classifier overhaul (#170).

### What's included

**`server/transfer_detect.py`**
- `detect_internal_transfers(db_conn, user_id, lookback_days=7)` — finds pairs of transactions (outflow + inflow, same amount ±$0.01, different accounts, ≤3 days apart) across all accounts owned by the same user
- `get_transfer_hint(tx_id, db_path)` — per-transaction convenience wrapper; returns `{is_possible_transfer, matched_account, matched_amount}` or `None`
- `is_investment_account(account)` — returns `True` if `institution_name` matches a known investment platform (Wealthsimple, Questrade, Robinhood, Vanguard, Fidelity, Schwab)

**`tests/test_transfer_detection.py`** — 20 tests covering all matching/exclusion criteria and both helpers

**`ARCHITECTURE.md`** — "Transfer detection" subsection added under Classification Engine

**Interactive check:**
```
detect_internal_transfers result:
  outflow_tx_id=62fb92e4...
  inflow_tx_id =c8f700e9...
  amount       =500.0
  days_apart   =1
  account_a    =35b2b747...
  account_b    =72891efd...
```

All 664 tests pass (16 skipped).