### PR TITLE
[P4] LLM classifier v2: rule-based prompt + classify_with_rules (#170)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -288,27 +288,43 @@ That's the whole API. ~15 tools.
 
 ---
 
-## Classification Engine (Unchanged — This Is the Value)
+## Classification Engine
 
 ```
 New transaction
    │
-   ├─▶ Tier 1: Rules
-   │     If merchant matches a saved rule → auto-route. Done.
+   ├─▶ Tier 1 v2: classify_with_rules()  (LLM-first, #170)
+   │     Passes the full priority-ordered classification_rules list to the
+   │     LLM.  First matching rule wins.  Returns:
+   │       { rule_id, line_item_id, classification_type, confidence,
+   │         uncertain, reasoning }
+   │     Optional context: possible_internal_transfer hint (#171),
+   │     recent_corrections.
+   │     Results available for #165 to write to transaction_entries.
    │
-   ├─▶ Tier 2: LLM
-   │     Prompt: hints + ledger tree + recent similar txns + this txn
-   │     LLM picks ledger/line item with confidence score
-   │     If confidence >= 0.75 → auto-route + flag for casual review
+   ├─▶ Tier 1 legacy: apply_rules() (substring matching, routing_rules)
+   │     Still runs for backward-compat; new writes use classify_with_rules.
+   │
+   ├─▶ Tier 2: classify_with_llm()
+   │     Prompt: hints + full ledger tree + recent similar txns + this txn.
+   │     LLM picks ledger/line item with confidence score.
+   │     If confidence >= 0.75 → auto-route + flag for casual review.
    │
    └─▶ Tier 3: Ask user
          HAL sends: "Got a $X charge at Y — my guess is Z (62% sure).
                      Correct, or should it be something else?"
-         User replies → save as a new rule for next time
+         User replies → save as a new rule for next time.
 ```
 
 After 3 successful LLM classifications of the same merchant, auto-promote
-to a Tier 1 rule. System gets cheaper and faster over time.
+to a legacy Tier-1 routing_rule. System gets cheaper and faster over time.
+
+### classify_with_rules — key design notes
+- Disabled rules (`enabled=0`) are excluded from the LLM prompt.
+- `uncertain=True` when `confidence < 0.7`.
+- Does NOT write to `transaction_entries` — that is #165's responsibility.
+- The sync loop (`server/main.py`) calls it as a read-only integration point
+  and logs the result at DEBUG level for now.
 
 ### Transfer Detection
 

--- a/README.md
+++ b/README.md
@@ -157,15 +157,19 @@ other MCP client).
 
 Every transaction goes through a three-tier classifier:
 
-1. **Rules** - exact merchant matches you've already confirmed. Free, instant.
-2. **LLM** - for new merchants, the LLM reasons about the transaction
-   using your hints and recent similar transactions, and auto-routes if
-   confident enough.
+1. **Rules (LLM-first)** - the LLM evaluates your priority-ordered
+   `classification_rules` in order and applies the first matching rule.
+   Returns `rule_id`, `classification_type`, `confidence`, and `reasoning`.
+   Disabled rules are skipped.  When confidence < 0.7 the result is
+   flagged as `uncertain`.  _(Introduced in v2, issue #170.)_
+2. **LLM (free-form)** - for transactions with no matching rule, the LLM
+   reasons about the transaction using your hints, full ledger tree, and
+   recent similar transactions, and auto-routes if confident enough.
 3. **Review queue** - if it's unsure, the transaction lands in a review
    queue. You'll get a notification through your chosen channel.
 
 After 3 successful classifications of the same merchant, it becomes a
-Tier 1 rule automatically. The longer you use it, the less it asks.
+Tier 1 legacy rule automatically. The longer you use it, the less it asks.
 
 ### Classification Rules
 

--- a/server/classifier.py
+++ b/server/classifier.py
@@ -1,19 +1,226 @@
 """
-server/classifier.py — Tier 1 deterministic rules-based classifier.
+server/classifier.py — Classifier tiers for Friday Budgeting Pro.
 
-Given a transaction, checks routing_rules for a matching merchant_pattern
-and returns a ready-to-insert transaction_entry dict, or None if no rule fires.
+Classification pipeline:
+  Tier 1 (classify_with_rules): LLM-first approach using priority-ordered
+      classification_rules — evaluates natural language rules in order via the
+      LLM and returns a structured result.  This is the primary entry point.
+  Tier 2 (classify_with_llm): LLM classification using the full ledger tree,
+      hints, and recent similar transactions.  Coexists with Tier 1.
+  Tier 3 (auto-promotion): flag_for_review + maybe_promote_to_rule.
 
-This is the first tier in the three-tier classification pipeline:
-  Tier 1 (this file): deterministic merchant-pattern rules
-  Tier 2: LLM-based classification
-  Tier 3: auto-promotion of confident results
+Legacy (apply_rules): deterministic substring matching against routing_rules.
+  Kept for backward-compat; new code should prefer classify_with_rules.
 """
 
 from __future__ import annotations
 
 import json
 import sqlite3
+
+# ---------------------------------------------------------------------------
+# Tier 1 — LLM-first classify_with_rules
+# ---------------------------------------------------------------------------
+
+
+def classify_with_rules(
+    transaction: dict,
+    rules: list[dict],
+    context: dict | None = None,
+) -> dict:
+    """Classify a single transaction using priority-ordered rules via the LLM.
+
+    This is the primary Tier-1 entry point.  It passes the full ordered
+    ``classification_rules`` list to the LLM and asks it to find the first
+    matching rule.  The LLM is also given optional context such as a
+    transfer-detection hint from issue #171 and recent manual corrections.
+
+    Args:
+        transaction: dict with any of the following keys (all optional except
+            those needed for meaningful classification):
+
+            - merchant             (str)  display name from the bank
+            - amount               (real) signed transaction amount
+            - date                 (str)  ISO-format date
+            - account_name         (str)  human name of the bank account
+            - account_description  (str)  user-set context for the account
+            - plaid_category       (str)  Plaid category string
+
+        rules: list of rule dicts as returned by
+            ``list_rules()["rules"]``.  Expected keys per rule:
+            ``id``, ``name``, ``description``, ``rule_type``,
+            ``line_item_id``, ``priority``, ``enabled``.
+            Pre-sorted by priority ASC; disabled rules are skipped.
+
+        context: optional dict with any of:
+            - ``possible_internal_transfer`` (bool)  hint from transfer
+              detection (#171) — included in the prompt when True.
+            - ``recent_corrections`` (list[dict])  recent manual overrides
+              for this merchant; each dict should have ``from_line_item``,
+              ``to_line_item``, and ``date``.
+
+    Returns:
+        A classification result dict::
+
+            {
+                "rule_id":             str | None,
+                "line_item_id":        str | None,
+                "classification_type": "transfer" | "savings" | "spending"
+                                        | "income" | "skip",
+                "confidence":          float,
+                "uncertain":           bool,
+                "reasoning":           str,
+            }
+
+        ``rule_id`` is the ID of the first matching rule, or ``None`` when no
+        rule clearly applies.  ``uncertain`` is ``True`` when confidence < 0.7.
+
+    Raises:
+        ValueError: If the LLM returns invalid JSON or a response that is
+            missing required fields.
+    """
+    from server.llm import chat  # local import keeps chat patchable in tests
+
+    UNCERTAIN_THRESHOLD = 0.7
+
+    # ------------------------------------------------------------------
+    # 1. Build the rules section (enabled rules only, priority order)
+    # ------------------------------------------------------------------
+    enabled_rules = [r for r in rules if r.get("enabled", True)]
+
+    if enabled_rules:
+        rules_lines: list[str] = []
+        for r in enabled_rules:
+            li_note = f" → line_item_id={r['line_item_id']}" if r.get("line_item_id") else ""
+            rules_lines.append(
+                f"  [{r['priority']:>3}] id={r['id']}  type={r['rule_type']}"
+                f"  name=\"{r['name']}\""
+                f"  desc=\"{r['description']}\"{li_note}"
+            )
+        rules_text = "\n".join(rules_lines)
+    else:
+        rules_text = "  (no enabled rules)"
+
+    # ------------------------------------------------------------------
+    # 2. Build the transaction section
+    # ------------------------------------------------------------------
+    merchant = transaction.get("merchant") or "(unknown)"
+    amount = transaction.get("amount", 0.0)
+    date = transaction.get("date", "unknown")
+    account_name = transaction.get("account_name", "")
+    account_description = transaction.get("account_description", "")
+    plaid_category = transaction.get("plaid_category", "")
+
+    txn_lines = [
+        f"  Merchant            : {merchant}",
+        f"  Amount              : ${amount:.2f}",
+        f"  Date                : {date}",
+    ]
+    if account_name:
+        txn_lines.append(f"  Account             : {account_name}")
+    if account_description:
+        txn_lines.append(f"  Account description : {account_description}")
+    if plaid_category:
+        txn_lines.append(f"  Plaid category      : {plaid_category}")
+    txn_text = "\n".join(txn_lines)
+
+    # ------------------------------------------------------------------
+    # 3. Build the optional context section
+    # ------------------------------------------------------------------
+    context_parts: list[str] = []
+    if context:
+        if context.get("possible_internal_transfer"):
+            context_parts.append(
+                "  ⚠️  Transfer detector flagged this transaction as a "
+                "possible internal transfer (same amount moved between accounts)."
+            )
+        corrections = context.get("recent_corrections") or []
+        if corrections:
+            corr_lines = [
+                f"  - {c.get('date','?')}  "
+                f"{c.get('from_line_item','?')} → {c.get('to_line_item','?')}"
+                for c in corrections
+            ]
+            context_parts.append(
+                "  Recent manual corrections for this merchant:\n" + "\n".join(corr_lines)
+            )
+    context_text = "\n".join(context_parts) if context_parts else "  (none)"
+
+    # ------------------------------------------------------------------
+    # 4. Compose the prompt
+    # ------------------------------------------------------------------
+    system_msg = (
+        "You are a personal finance classifier.  Your job is to evaluate "
+        "priority-ordered classification rules and find the FIRST rule that "
+        "clearly applies to the given transaction.  The FIRST match wins — "
+        "stop evaluating after the first match.\n\n"
+        "Reply with ONLY a JSON object — no markdown, no text outside the JSON — "
+        "with these keys:\n"
+        '{"rule_id": "<id or null>", "line_item_id": "<id or null>", '
+        '"classification_type": "<transfer|savings|spending|income|skip>", '
+        '"confidence": <0.0-1.0>, "reasoning": "<one sentence>"}\n\n'
+        "Rules for null fields:\n"
+        "- Set rule_id=null when no rule clearly applies.\n"
+        "- Set line_item_id=null when the matched rule has no line_item_id, "
+        "or when no rule matched.\n"
+        "- When no rule matches, infer classification_type from the Plaid "
+        "category and amount sign (negative = outflow = spending/transfer).\n"
+        "- Set confidence < 0.7 (and the caller will set uncertain=true) when "
+        "you are not confident."
+    )
+
+    user_msg = (
+        f"## Classification Rules (priority ASC — first match wins)\n{rules_text}\n\n"
+        f"## Transaction\n{txn_text}\n\n"
+        f"## Additional Context\n{context_text}\n\n"
+        "Reply with the JSON object only."
+    )
+
+    messages = [
+        {"role": "system", "content": system_msg},
+        {"role": "user", "content": user_msg},
+    ]
+
+    # ------------------------------------------------------------------
+    # 5. Call the LLM and parse the response
+    # ------------------------------------------------------------------
+    raw = chat(messages, temperature=0.0)
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"LLM returned non-JSON response: {raw!r}") from exc
+
+    # Validate required keys
+    required_keys = {"rule_id", "classification_type", "confidence", "reasoning"}
+    missing = required_keys - parsed.keys()
+    if missing:
+        raise ValueError(f"LLM JSON missing required keys {sorted(missing)!r}: {parsed!r}")
+
+    confidence = float(parsed.get("confidence", 0.0))
+
+    # Validate classification_type
+    valid_types = {"transfer", "savings", "spending", "income", "skip"}
+    classification_type = parsed.get("classification_type", "")
+    if classification_type not in valid_types:
+        raise ValueError(
+            f"LLM returned unknown classification_type={classification_type!r}. "
+            f"Expected one of {sorted(valid_types)!r}."
+        )
+
+    return {
+        "rule_id": parsed.get("rule_id"),
+        "line_item_id": parsed.get("line_item_id"),
+        "classification_type": classification_type,
+        "confidence": confidence,
+        "uncertain": confidence < UNCERTAIN_THRESHOLD,
+        "reasoning": str(parsed.get("reasoning", "")),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Legacy Tier 1 — deterministic substring rules (routing_rules table)
+# ---------------------------------------------------------------------------
 
 
 def apply_rules(

--- a/server/main.py
+++ b/server/main.py
@@ -25,7 +25,7 @@ import server.crypto
 import server.excel_export as excel_export
 import server.health_monitor
 import server.paths
-from server.classifier import apply_rules
+from server.classifier import apply_rules, classify_with_rules
 from server.db import get_db
 from server.db import transaction as db_txn
 from server.providers.plaid import PlaidProvider
@@ -1186,6 +1186,54 @@ def sync() -> dict:
                                         ),
                                     )
                                     conn_classified += 1
+
+                                # --- Tier-1 v2: classify_with_rules integration point ---
+                                # Evaluate priority-ordered classification_rules via LLM.
+                                # Results are NOT written to transaction_entries here —
+                                # that is #165's responsibility.  This block runs when
+                                # rules exist and the legacy apply_rules produced no match
+                                # (or as an additional signal when it did).
+                                # Only runs when at least one classification_rule exists.
+                                try:
+                                    _rules_result = list_rules()
+                                    _cr_rules = _rules_result.get("rules", [])
+                                    if _cr_rules:
+                                        _plaid_cat = None
+                                        # Enrich txn_dict for classify_with_rules
+                                        _v2_txn = {
+                                            "merchant": merchant,
+                                            "amount": amount,
+                                            "date": str(date) if date is not None else None,
+                                            "account_name": None,
+                                            "account_description": None,
+                                            "plaid_category": _plaid_cat,
+                                        }
+                                        # Attach account name/description if available
+                                        _ba_row = db_conn.execute(
+                                            "SELECT name, description FROM bank_accounts WHERE id = ?",
+                                            (bank_account_id,),
+                                        ).fetchone()
+                                        if _ba_row:
+                                            _v2_txn["account_name"] = _ba_row["name"]
+                                            _v2_txn["account_description"] = _ba_row["description"]
+                                        _v2_result = classify_with_rules(_v2_txn, _cr_rules)
+                                        import logging as _logging
+
+                                        _logging.getLogger(__name__).debug(
+                                            "classify_with_rules txn_id=%s result=%r",
+                                            txn_id,
+                                            _v2_result,
+                                        )
+                                        # Result available for #165 to consume
+                                        # (auto-write to transaction_entries is out of scope here)
+                                except Exception as _exc:
+                                    import logging as _logging
+
+                                    _logging.getLogger(__name__).debug(
+                                        "classify_with_rules skipped for txn_id=%s: %s",
+                                        txn_id,
+                                        _exc,
+                                    )
 
                         # --- Modified transactions ---
                         for txn in modified_txns:

--- a/tests/test_classifier_v2.py
+++ b/tests/test_classifier_v2.py
@@ -1,0 +1,406 @@
+"""
+tests/test_classifier_v2.py — Tests for the Tier-1 v2 LLM classifier.
+
+Covers classify_with_rules() from server.classifier (issue #170).
+
+All tests mock server.llm.chat so no real API calls are made.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from server.classifier import classify_with_rules
+
+# ---------------------------------------------------------------------------
+# Helpers — canned LLM responses
+# ---------------------------------------------------------------------------
+
+INVESTMENT_RULE_ID = "rule-investment"
+INVESTMENT_LINE_ITEM_ID = "li-invest"
+
+PENDING_RULE_ID = "rule-pending"
+
+SALARY_RULE_ID = "rule-salary"
+
+
+def _llm_response(**kwargs) -> str:
+    """Build a JSON string suitable as a mocked chat() return value."""
+    defaults = {
+        "rule_id": None,
+        "line_item_id": None,
+        "classification_type": "spending",
+        "confidence": 0.9,
+        "reasoning": "Test reasoning.",
+    }
+    defaults.update(kwargs)
+    return json.dumps(defaults)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — sample rule list
+# ---------------------------------------------------------------------------
+
+DEFAULT_RULES = [
+    {
+        "id": PENDING_RULE_ID,
+        "name": "Pending skip",
+        "description": "Skip any transaction that is still pending",
+        "rule_type": "skip",
+        "line_item_id": None,
+        "priority": 1,
+        "is_default": True,
+        "enabled": True,
+    },
+    {
+        "id": "rule-transfer",
+        "name": "Internal transfer",
+        "description": "Same amount leaving one account and arriving at another within 3 days",
+        "rule_type": "transfer",
+        "line_item_id": None,
+        "priority": 10,
+        "is_default": True,
+        "enabled": True,
+    },
+    {
+        "id": INVESTMENT_RULE_ID,
+        "name": "Investment contribution",
+        "description": "Outflows to Wealthsimple, Questrade, or any investment platform",
+        "rule_type": "transfer",
+        "line_item_id": INVESTMENT_LINE_ITEM_ID,
+        "priority": 20,
+        "is_default": True,
+        "enabled": True,
+    },
+    {
+        "id": "rule-cc",
+        "name": "Credit card payment",
+        "description": "Payment from chequing that matches a credit card balance",
+        "rule_type": "transfer",
+        "line_item_id": None,
+        "priority": 30,
+        "is_default": True,
+        "enabled": True,
+    },
+    {
+        "id": SALARY_RULE_ID,
+        "name": "Salary/payroll",
+        "description": "Transactions tagged as payroll or salary by the bank",
+        "rule_type": "income",
+        "line_item_id": None,
+        "priority": 40,
+        "is_default": True,
+        "enabled": True,
+    },
+    {
+        "id": "rule-fees",
+        "name": "Bank fees",
+        "description": "Monthly account fees and bank charges",
+        "rule_type": "spending",
+        "line_item_id": None,
+        "priority": 50,
+        "is_default": True,
+        "enabled": True,
+    },
+]
+
+WEALTHSIMPLE_TXN = {
+    "merchant": "Wealthsimple",
+    "amount": 500.0,
+    "date": "2026-05-20",
+    "account_name": "RBC Chequing",
+    "account_description": "Day-to-day chequing account",
+    "plaid_category": "TRANSFER_OUT",
+}
+
+
+# ---------------------------------------------------------------------------
+# Tests: basic matching
+# ---------------------------------------------------------------------------
+
+
+def test_classify_returns_correct_rule_id_for_match():
+    """LLM returns a rule_id that matches → result carries that rule_id."""
+    response = _llm_response(
+        rule_id=INVESTMENT_RULE_ID,
+        line_item_id=INVESTMENT_LINE_ITEM_ID,
+        classification_type="transfer",
+        confidence=0.95,
+        reasoning="Wealthsimple is an investment platform.",
+    )
+    mock_chat = MagicMock(return_value=response)
+
+    with patch("server.llm.chat", mock_chat):
+        result = classify_with_rules(WEALTHSIMPLE_TXN, DEFAULT_RULES)
+
+    assert result["rule_id"] == INVESTMENT_RULE_ID
+    assert result["line_item_id"] == INVESTMENT_LINE_ITEM_ID
+    assert result["classification_type"] == "transfer"
+    assert result["confidence"] == pytest.approx(0.95)
+    assert result["uncertain"] is False
+    assert "Wealthsimple" in result["reasoning"] or result["reasoning"]
+
+
+def test_classify_with_6_default_rules_matches_investment():
+    """classify_with_rules with the default 6 rules picks Investment contribution."""
+    response = _llm_response(
+        rule_id=INVESTMENT_RULE_ID,
+        line_item_id=INVESTMENT_LINE_ITEM_ID,
+        classification_type="transfer",
+        confidence=0.92,
+        reasoning="Outflow to Wealthsimple is an investment contribution.",
+    )
+    mock_chat = MagicMock(return_value=response)
+
+    with patch("server.llm.chat", mock_chat):
+        result = classify_with_rules(WEALTHSIMPLE_TXN, DEFAULT_RULES)
+
+    assert result["rule_id"] == INVESTMENT_RULE_ID
+    assert result["classification_type"] == "transfer"
+    assert result["uncertain"] is False
+
+
+def test_prompt_contains_all_rules():
+    """The prompt sent to the LLM includes all enabled rules by name."""
+    mock_chat = MagicMock(return_value=_llm_response())
+
+    with patch("server.llm.chat", mock_chat):
+        classify_with_rules(WEALTHSIMPLE_TXN, DEFAULT_RULES)
+
+    messages = mock_chat.call_args[0][0]
+    full_prompt = " ".join(m["content"] for m in messages)
+
+    for rule in DEFAULT_RULES:
+        assert rule["name"] in full_prompt, f"Rule '{rule['name']}' missing from prompt"
+
+
+def test_prompt_contains_transaction_details():
+    """Merchant, amount, and date appear in the LLM prompt."""
+    mock_chat = MagicMock(return_value=_llm_response())
+
+    with patch("server.llm.chat", mock_chat):
+        classify_with_rules(WEALTHSIMPLE_TXN, DEFAULT_RULES)
+
+    messages = mock_chat.call_args[0][0]
+    full_prompt = " ".join(m["content"] for m in messages)
+
+    assert "Wealthsimple" in full_prompt
+    assert "2026-05-20" in full_prompt
+    assert "500" in full_prompt
+
+
+# ---------------------------------------------------------------------------
+# Tests: disabled / skip rules
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_rule_excluded_from_prompt():
+    """A rule with enabled=False must not appear in the prompt."""
+    rules_with_disabled = [dict(r, enabled=(r["id"] != INVESTMENT_RULE_ID)) for r in DEFAULT_RULES]
+    mock_chat = MagicMock(return_value=_llm_response())
+
+    with patch("server.llm.chat", mock_chat):
+        classify_with_rules(WEALTHSIMPLE_TXN, rules_with_disabled)
+
+    messages = mock_chat.call_args[0][0]
+    full_prompt = " ".join(m["content"] for m in messages)
+    # The rule id should not appear in the prompt since it was disabled
+    assert INVESTMENT_RULE_ID not in full_prompt
+
+
+def test_pending_rule_returns_skip_classification_type():
+    """When the LLM matches the pending-skip rule, classification_type is 'skip'."""
+    response = _llm_response(
+        rule_id=PENDING_RULE_ID,
+        line_item_id=None,
+        classification_type="skip",
+        confidence=0.99,
+        reasoning="Transaction is still pending.",
+    )
+    mock_chat = MagicMock(return_value=response)
+
+    pending_txn = {
+        "merchant": "Amazon",
+        "amount": 29.99,
+        "date": "2026-05-20",
+        "plaid_category": "PENDING",
+    }
+
+    with patch("server.llm.chat", mock_chat):
+        result = classify_with_rules(pending_txn, DEFAULT_RULES)
+
+    assert result["rule_id"] == PENDING_RULE_ID
+    assert result["classification_type"] == "skip"
+
+
+# ---------------------------------------------------------------------------
+# Tests: no rule matches
+# ---------------------------------------------------------------------------
+
+
+def test_no_match_returns_none_rule_id():
+    """When LLM finds no matching rule, rule_id is None and type is inferred."""
+    response = _llm_response(
+        rule_id=None,
+        line_item_id=None,
+        classification_type="spending",
+        confidence=0.65,
+        reasoning="No rule matched; inferred spending from negative amount.",
+    )
+    mock_chat = MagicMock(return_value=response)
+
+    txn = {
+        "merchant": "Tim Hortons",
+        "amount": -4.50,
+        "date": "2026-05-20",
+        "plaid_category": "FOOD_AND_DRINK",
+    }
+
+    with patch("server.llm.chat", mock_chat):
+        result = classify_with_rules(txn, DEFAULT_RULES)
+
+    assert result["rule_id"] is None
+    assert result["classification_type"] == "spending"
+
+
+# ---------------------------------------------------------------------------
+# Tests: uncertain flag
+# ---------------------------------------------------------------------------
+
+
+def test_uncertain_true_when_confidence_below_threshold():
+    """uncertain=True when LLM confidence < 0.7."""
+    response = _llm_response(
+        rule_id=None,
+        line_item_id=None,
+        classification_type="spending",
+        confidence=0.5,
+        reasoning="Not sure.",
+    )
+    mock_chat = MagicMock(return_value=response)
+
+    with patch("server.llm.chat", mock_chat):
+        result = classify_with_rules(WEALTHSIMPLE_TXN, DEFAULT_RULES)
+
+    assert result["uncertain"] is True
+    assert result["confidence"] == pytest.approx(0.5)
+
+
+def test_uncertain_false_when_confidence_at_threshold():
+    """uncertain=False when LLM confidence == 0.7 (boundary — not below)."""
+    response = _llm_response(
+        rule_id=INVESTMENT_RULE_ID,
+        classification_type="transfer",
+        confidence=0.7,
+        reasoning="Boundary confidence.",
+    )
+    mock_chat = MagicMock(return_value=response)
+
+    with patch("server.llm.chat", mock_chat):
+        result = classify_with_rules(WEALTHSIMPLE_TXN, DEFAULT_RULES)
+
+    assert result["uncertain"] is False
+
+
+# ---------------------------------------------------------------------------
+# Tests: context injection
+# ---------------------------------------------------------------------------
+
+
+def test_context_transfer_hint_appears_in_prompt():
+    """possible_internal_transfer=True hint shows up in the LLM prompt."""
+    mock_chat = MagicMock(return_value=_llm_response())
+
+    with patch("server.llm.chat", mock_chat):
+        classify_with_rules(
+            WEALTHSIMPLE_TXN,
+            DEFAULT_RULES,
+            context={"possible_internal_transfer": True},
+        )
+
+    messages = mock_chat.call_args[0][0]
+    full_prompt = " ".join(m["content"] for m in messages)
+    assert "transfer" in full_prompt.lower() or "internal" in full_prompt.lower()
+
+
+def test_context_recent_corrections_appear_in_prompt():
+    """recent_corrections are included in the prompt."""
+    corrections = [
+        {
+            "date": "2026-05-01",
+            "from_line_item": "Groceries",
+            "to_line_item": "Dining Out",
+        }
+    ]
+    mock_chat = MagicMock(return_value=_llm_response())
+
+    with patch("server.llm.chat", mock_chat):
+        classify_with_rules(
+            WEALTHSIMPLE_TXN,
+            DEFAULT_RULES,
+            context={"recent_corrections": corrections},
+        )
+
+    messages = mock_chat.call_args[0][0]
+    full_prompt = " ".join(m["content"] for m in messages)
+    assert "Groceries" in full_prompt or "Dining Out" in full_prompt
+
+
+# ---------------------------------------------------------------------------
+# Tests: error handling
+# ---------------------------------------------------------------------------
+
+
+def test_raises_on_non_json_response():
+    """ValueError raised when LLM returns non-JSON."""
+    mock_chat = MagicMock(return_value="not json at all")
+
+    with patch("server.llm.chat", mock_chat):
+        with pytest.raises(ValueError, match="non-JSON"):
+            classify_with_rules(WEALTHSIMPLE_TXN, DEFAULT_RULES)
+
+
+def test_raises_on_missing_required_keys():
+    """ValueError raised when LLM JSON is missing required keys."""
+    bad_response = json.dumps({"confidence": 0.9})
+    mock_chat = MagicMock(return_value=bad_response)
+
+    with patch("server.llm.chat", mock_chat):
+        with pytest.raises(ValueError, match="missing required keys"):
+            classify_with_rules(WEALTHSIMPLE_TXN, DEFAULT_RULES)
+
+
+def test_raises_on_invalid_classification_type():
+    """ValueError raised when LLM returns an unrecognised classification_type."""
+    bad_response = _llm_response(classification_type="unknown_type")
+    mock_chat = MagicMock(return_value=bad_response)
+
+    with patch("server.llm.chat", mock_chat):
+        with pytest.raises(ValueError, match="unknown classification_type"):
+            classify_with_rules(WEALTHSIMPLE_TXN, DEFAULT_RULES)
+
+
+# ---------------------------------------------------------------------------
+# Tests: empty rules list
+# ---------------------------------------------------------------------------
+
+
+def test_empty_rules_list_still_calls_llm():
+    """classify_with_rules works with an empty rules list (no rules enabled)."""
+    response = _llm_response(
+        rule_id=None,
+        classification_type="spending",
+        confidence=0.6,
+        reasoning="No rules defined; inferred from context.",
+    )
+    mock_chat = MagicMock(return_value=response)
+
+    with patch("server.llm.chat", mock_chat):
+        result = classify_with_rules(WEALTHSIMPLE_TXN, [])
+
+    assert mock_chat.called
+    assert result["rule_id"] is None
+    assert result["classification_type"] == "spending"


### PR DESCRIPTION
Closes #170

## Summary

Introduces **Tier-1 v2 classification** via `classify_with_rules()` in `server/classifier.py`. Instead of substring matching against `routing_rules`, this LLM-first approach passes the full priority-ordered `classification_rules` list to the LLM and asks it to find the first matching rule.

### What changed

**`server/classifier.py`**
- New `classify_with_rules(transaction, rules, context) -> dict` function.
- Builds a priority-ordered rules prompt (enabled rules only), transaction details, and optional context (transfer hint from #171, recent corrections).
- Returns `{rule_id, line_item_id, classification_type, confidence, uncertain, reasoning}`.
- `uncertain=True` when `confidence < 0.7`.
- Reuses `server.llm.chat` (same provider abstraction as existing classifiers).
- Existing `apply_rules` / `classify_with_llm` / `safe_classify` / `flag_for_review` / `maybe_promote_to_rule` untouched.

**`server/main.py`**
- Imports `classify_with_rules`.
- Sync loop calls it as a read-only integration point after each newly-inserted transaction when `classification_rules` exist.
- Results are NOT written to `transaction_entries` (that is #165's responsibility).
- Errors are caught and logged at DEBUG level so sync never breaks.

**`tests/test_classifier_v2.py`** — 15 new tests:
- Correct `rule_id` returned for matching cases with default 6 rules
- Disabled rule excluded from prompt
- Pending-skip rule → `classification_type='skip'`
- Investment contribution matches Wealthsimple outflow
- No rule matches → `rule_id=None` with inferred classification
- `uncertain=True` when confidence < 0.7 (and boundary at 0.7 is False)
- Context: transfer hint and recent corrections appear in prompt
- Error handling: non-JSON, missing keys, invalid classification_type
- Empty rules list still calls LLM

**`ARCHITECTURE.md`** — classifier section updated with Tier-1 v2 flow  
**`README.md`** — classifier description updated

### Interactive check

```python
from server.classifier import classify_with_rules
from server.main import list_rules
rules = list_rules()['rules']
tx = {"merchant": "Wealthsimple", "amount": 500, "date": "2026-05-20",
      "account_name": "RBC Chequing", "plaid_category": "TRANSFER_OUT"}
result = classify_with_rules(tx, rules)
# => rule_id matches 'Investment contribution', classification_type='transfer',
#    confidence=0.95, uncertain=False
```

**Output:** matched `Investment contribution` rule ✓

### CI
`black` ✓ · `ruff` ✓ · `pytest` 659 passed, 16 skipped ✓
