### PR TITLE
[P4] Ledger drilldown: get_ledger MCP tool + expandable UI (#175)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -266,6 +266,7 @@ Only what HAL actually needs to call. Grouped:
 
 ### Ledgers (rarely used after setup)
 - `list_ledgers()` — returns `id`, `name`, `type`, `description`, and `items` for each ledger
+- `get_ledger(ledger_id, period?)` — returns full ledger tree: metadata, all line items with per-item totals, and the transactions classified to each item; `period` is `"this_month"` (default), `"last_month"`, `"this_year"`, or `None` for all time
 - `add_ledger(name)` — creates a generic personal ledger
 - `create_property_ledger(name, description?)` — creates a `property` ledger seeded with 6 default line items (Rent income, Mortgage, Property tax, Maintenance & repairs, Insurance, Utilities)
 - `create_investment_ledger(name)` — creates an `investment` ledger seeded with 2 default line items (Contributions, Dividends & Returns)

--- a/README.md
+++ b/README.md
@@ -135,9 +135,11 @@ Three things, kept minimal:
   and **Reconnect / Disconnect / + Connect a bank** buttons. No fancy
   cards, just a list.
 
-**Ledgers page** - minimal structure editor. List your ledgers (default:
+**Ledgers page** - structure editor with drilldown. List your ledgers (default:
 Personal), click into one to add/rename/remove line items, add new
-ledgers when you need them (e.g. for a rental property).
+ledgers when you need them (e.g. for a rental property). Each line item shows
+its running total and transaction count; click to expand and see the individual
+transactions classified to it (populated once auto-categorisation is active).
 
 Ledgers come in three types:
 - **Personal** (default) — standard household budget with line items like Salary, Groceries, Dining, etc.

--- a/server/main.py
+++ b/server/main.py
@@ -678,6 +678,179 @@ def list_ledgers() -> dict:
         conn.close()
 
 
+# ---------------------------------------------------------------------------
+# Shared helper: fetch a ledger + line items + classified transactions
+# ---------------------------------------------------------------------------
+
+
+def _build_ledger_drilldown(
+    conn,
+    ledger_row: dict,
+    period: str | None = "this_month",
+) -> dict:
+    """Return a ledger dict with line_items + transactions per item and totals.
+
+    Parameters
+    ----------
+    conn :
+        Open DB connection (caller is responsible for closing).
+    ledger_row :
+        Row from the ``ledgers`` table with at least ``id``, ``name``,
+        ``type``, and ``description``.
+    period : str | None
+        Date filter applied to ``transactions.date``:
+        - ``"this_month"``  — current calendar month (default)
+        - ``"last_month"``  — previous calendar month
+        - ``"this_year"``   — current calendar year
+        - ``None``          — all time
+    """
+    from datetime import datetime as _dt
+
+    # Build date-range filter -------------------------------------------
+    date_filter_sql = ""
+    date_params: list = []
+
+    if period is not None:
+        now = _dt.now()
+        if period == "this_month":
+            start = _dt(now.year, now.month, 1).strftime("%Y-%m-%d")
+            if now.month == 12:
+                end = _dt(now.year + 1, 1, 1).strftime("%Y-%m-%d")
+            else:
+                end = _dt(now.year, now.month + 1, 1).strftime("%Y-%m-%d")
+            date_filter_sql = " AND t.date >= ? AND t.date < ?"
+            date_params = [start, end]
+        elif period == "last_month":
+            if now.month == 1:
+                s_year, s_month = now.year - 1, 12
+            else:
+                s_year, s_month = now.year, now.month - 1
+            start = _dt(s_year, s_month, 1).strftime("%Y-%m-%d")
+            if s_month == 12:
+                end = _dt(s_year + 1, 1, 1).strftime("%Y-%m-%d")
+            else:
+                end = _dt(s_year, s_month + 1, 1).strftime("%Y-%m-%d")
+            date_filter_sql = " AND t.date >= ? AND t.date < ?"
+            date_params = [start, end]
+        elif period == "this_year":
+            start = _dt(now.year, 1, 1).strftime("%Y-%m-%d")
+            end = _dt(now.year + 1, 1, 1).strftime("%Y-%m-%d")
+            date_filter_sql = " AND t.date >= ? AND t.date < ?"
+            date_params = [start, end]
+        # unknown period values → no filter (treat as None)
+
+    # Fetch line items --------------------------------------------------
+    item_rows = conn.execute(
+        "SELECT id, name, item_type FROM line_items WHERE ledger_id = ? ORDER BY name",
+        (ledger_row["id"],),
+    ).fetchall()
+
+    total_income = 0.0
+    total_expenses = 0.0
+    line_items_out = []
+
+    for item in item_rows:
+        txn_sql = (
+            "SELECT t.id, t.date, t.merchant, te.amount_home, te.amount, "
+            "       b.name AS account_name, t.pending "
+            "FROM transaction_entries te "
+            "JOIN transactions t ON te.transaction_id = t.id "
+            "LEFT JOIN bank_accounts b ON t.bank_account_id = b.id "
+            "WHERE te.line_item_id = ?" + date_filter_sql + " ORDER BY t.date DESC"
+        )
+        txn_rows = conn.execute(txn_sql, [item["id"]] + date_params).fetchall()
+
+        transactions_out = []
+        item_total = 0.0
+        for tx in txn_rows:
+            amt = tx["amount_home"] if tx["amount_home"] is not None else tx["amount"]
+            item_total += amt
+            transactions_out.append(
+                {
+                    "id": tx["id"],
+                    "date": tx["date"],
+                    "merchant": tx["merchant"] or "",
+                    "amount": round(amt, 2),
+                    "account_name": tx["account_name"] or "",
+                    "pending": bool(tx["pending"]),
+                }
+            )
+
+        item_total = round(item_total, 2)
+        if item["item_type"] == "income":
+            total_income += item_total
+        else:
+            total_expenses += item_total
+
+        line_items_out.append(
+            {
+                "id": item["id"],
+                "name": item["name"],
+                "item_type": item["item_type"],
+                "total": item_total,
+                "transactions": transactions_out,
+            }
+        )
+
+    return {
+        "ledger": {
+            "id": ledger_row["id"],
+            "name": ledger_row["name"],
+            "type": ledger_row["type"],
+        },
+        "line_items": line_items_out,
+        "totals": {
+            "income": round(total_income, 2),
+            "expenses": round(total_expenses, 2),
+            "net": round(total_income - total_expenses, 2),
+        },
+    }
+
+
+@mcp.tool
+def get_ledger(ledger_id: str, period: str = "this_month") -> dict:
+    """Get a ledger with all line items and the transactions classified to each.
+
+    Parameters
+    ----------
+    ledger_id : str
+        ID of the ledger to retrieve.
+    period : str | None
+        Optional date filter:
+        - ``"this_month"`` (default)
+        - ``"last_month"``
+        - ``"this_year"``
+        - ``None`` / empty string → all time
+
+    Returns
+    -------
+    dict
+        ``{"ledger": {...}, "line_items": [...], "totals": {...}}`` on
+        success, or ``{"status": "error", "message": ...}`` on failure.
+    """
+    uid = get_active_user_id(server.paths.DB_PATH)
+    if uid is None:
+        return {"status": "error", "message": "No active user found"}
+
+    # Normalise period
+    if not period:
+        period = None
+
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        ledger_row = conn.execute(
+            "SELECT id, name, type, description FROM ledgers "
+            "WHERE id = ? AND (user_id = ? OR user_id IS NULL)",
+            (ledger_id, uid),
+        ).fetchone()
+        if ledger_row is None:
+            return {"status": "error", "message": f"Ledger '{ledger_id}' not found"}
+
+        return _build_ledger_drilldown(conn, ledger_row, period=period)
+    finally:
+        conn.close()
+
+
 @mcp.tool
 def add_ledger(name: str) -> dict:
     """Create a new ledger for the active user.

--- a/tests/test_ledger_drilldown.py
+++ b/tests/test_ledger_drilldown.py
@@ -1,0 +1,397 @@
+"""
+tests/test_ledger_drilldown.py — Tests for the ledger drilldown (#175).
+
+Covers:
+  - get_ledger() returns proper structure for a ledger with no entries
+  - With seeded transaction_entries, transactions appear under correct line items
+  - period='this_month' filters correctly
+  - Invalid ledger_id → error
+  - Not authenticated → error
+  - UI: GET /ledgers renders line items with data-line-item-id attrs and totals
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+import server.paths
+from server.db import get_db, init_db
+from ui.auth import create_session, create_user
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path, monkeypatch) -> Path:
+    """Fresh temp DB; monkeypatch server.paths.DB_PATH to point at it."""
+    path = tmp_path / "test_drilldown.db"
+    init_db(path)
+    monkeypatch.setattr(server.paths, "DB_PATH", path)
+    return path
+
+
+@pytest.fixture()
+def authed_user(db_path: Path) -> dict:
+    """Create a test user + session so get_active_user_id() returns a real ID."""
+    user_id = create_user(db_path, "testuser", "testpass123")
+    token = create_session(db_path, user_id=user_id)
+    return {"user_id": user_id, "token": token}
+
+
+def _uid() -> str:
+    return str(uuid.uuid4())
+
+
+def _seed_ledger(db_path: Path, user_id: str) -> tuple[str, str, str]:
+    """Insert a ledger with one income and one expense line item.
+
+    Returns (ledger_id, income_item_id, expense_item_id).
+    """
+    conn = get_db(db_path)
+    try:
+        ledger_id = _uid()
+        income_id = _uid()
+        expense_id = _uid()
+        conn.execute(
+            "INSERT INTO ledgers (id, name, user_id) VALUES (?, ?, ?)",
+            (ledger_id, "TestLedger", user_id),
+        )
+        conn.execute(
+            "INSERT INTO line_items (id, ledger_id, name, item_type) VALUES (?, ?, ?, ?)",
+            (income_id, ledger_id, "Salary", "income"),
+        )
+        conn.execute(
+            "INSERT INTO line_items (id, ledger_id, name, item_type) VALUES (?, ?, ?, ?)",
+            (expense_id, ledger_id, "Groceries", "expense"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return ledger_id, income_id, expense_id
+
+
+def _seed_transaction(
+    db_path: Path,
+    ledger_id: str,
+    line_item_id: str,
+    date: str,
+    amount: float,
+    merchant: str = "Test Merchant",
+) -> str:
+    """Insert a transaction + transaction_entry. Returns transaction id."""
+    conn = get_db(db_path)
+    try:
+        txn_id = _uid()
+        entry_id = _uid()
+        conn.execute(
+            "INSERT INTO transactions (id, date, merchant, amount) VALUES (?, ?, ?, ?)",
+            (txn_id, date, merchant, amount),
+        )
+        conn.execute(
+            "INSERT INTO transaction_entries "
+            "(id, transaction_id, ledger_id, line_item_id, amount, amount_home, entry_type, source) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (entry_id, txn_id, ledger_id, line_item_id, amount, amount, "spending", "rule"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return txn_id
+
+
+# ---------------------------------------------------------------------------
+# Test: get_ledger structure with no entries
+# ---------------------------------------------------------------------------
+
+
+class TestGetLedgerNoEntries:
+    def test_returns_ledger_metadata(self, db_path, authed_user):
+        """get_ledger() returns ledger dict with id/name/type."""
+        from server.main import get_ledger
+
+        ledger_id, _, _ = _seed_ledger(db_path, authed_user["user_id"])
+        result = get_ledger(ledger_id)
+
+        assert "ledger" in result
+        assert result["ledger"]["id"] == ledger_id
+        assert result["ledger"]["name"] == "TestLedger"
+
+    def test_returns_line_items(self, db_path, authed_user):
+        """get_ledger() returns line_items list."""
+        from server.main import get_ledger
+
+        ledger_id, income_id, expense_id = _seed_ledger(db_path, authed_user["user_id"])
+        result = get_ledger(ledger_id)
+
+        assert "line_items" in result
+        item_ids = {li["id"] for li in result["line_items"]}
+        assert income_id in item_ids
+        assert expense_id in item_ids
+
+    def test_line_item_has_required_keys(self, db_path, authed_user):
+        """Each line item has id, name, item_type, total, transactions."""
+        from server.main import get_ledger
+
+        ledger_id, _, _ = _seed_ledger(db_path, authed_user["user_id"])
+        result = get_ledger(ledger_id)
+
+        for item in result["line_items"]:
+            assert "id" in item
+            assert "name" in item
+            assert "item_type" in item
+            assert "total" in item
+            assert "transactions" in item
+
+    def test_empty_transactions_list(self, db_path, authed_user):
+        """With no entries, transactions list is empty."""
+        from server.main import get_ledger
+
+        ledger_id, _, _ = _seed_ledger(db_path, authed_user["user_id"])
+        result = get_ledger(ledger_id)
+
+        for item in result["line_items"]:
+            assert item["transactions"] == []
+            assert item["total"] == 0.0
+
+    def test_returns_totals(self, db_path, authed_user):
+        """get_ledger() returns totals dict with income/expenses/net."""
+        from server.main import get_ledger
+
+        ledger_id, _, _ = _seed_ledger(db_path, authed_user["user_id"])
+        result = get_ledger(ledger_id)
+
+        assert "totals" in result
+        totals = result["totals"]
+        assert "income" in totals
+        assert "expenses" in totals
+        assert "net" in totals
+        assert totals["income"] == 0.0
+        assert totals["expenses"] == 0.0
+        assert totals["net"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Test: with seeded transaction_entries, transactions appear under correct items
+# ---------------------------------------------------------------------------
+
+
+class TestGetLedgerWithEntries:
+    def test_transaction_appears_under_correct_item(self, db_path, authed_user):
+        """Seeded transaction_entry appears in the correct line item."""
+        from server.main import get_ledger
+
+        ledger_id, income_id, expense_id = _seed_ledger(db_path, authed_user["user_id"])
+        _seed_transaction(db_path, ledger_id, expense_id, "2026-01-15", 99.99, "Superstore")
+
+        result = get_ledger(ledger_id, period=None)
+        expense_item = next(li for li in result["line_items"] if li["id"] == expense_id)
+        income_item = next(li for li in result["line_items"] if li["id"] == income_id)
+
+        assert len(expense_item["transactions"]) == 1
+        assert expense_item["transactions"][0]["merchant"] == "Superstore"
+        assert expense_item["transactions"][0]["amount"] == 99.99
+        assert len(income_item["transactions"]) == 0
+
+    def test_transaction_has_required_keys(self, db_path, authed_user):
+        """Each transaction dict has id, date, merchant, amount, account_name, pending."""
+        from server.main import get_ledger
+
+        ledger_id, _, expense_id = _seed_ledger(db_path, authed_user["user_id"])
+        _seed_transaction(db_path, ledger_id, expense_id, "2026-01-15", 50.0)
+
+        result = get_ledger(ledger_id, period=None)
+        expense_item = next(li for li in result["line_items"] if li["id"] == expense_id)
+        tx = expense_item["transactions"][0]
+
+        for key in ("id", "date", "merchant", "amount", "account_name", "pending"):
+            assert key in tx, f"Missing key: {key}"
+
+    def test_totals_computed_correctly(self, db_path, authed_user):
+        """Totals reflect the sum of transaction_entries amounts."""
+        from server.main import get_ledger
+
+        ledger_id, income_id, expense_id = _seed_ledger(db_path, authed_user["user_id"])
+        _seed_transaction(db_path, ledger_id, expense_id, "2026-01-10", 200.0)
+        _seed_transaction(db_path, ledger_id, expense_id, "2026-01-20", 150.0)
+        _seed_transaction(db_path, ledger_id, income_id, "2026-01-05", 3000.0)
+
+        result = get_ledger(ledger_id, period=None)
+        assert result["totals"]["expenses"] == pytest.approx(350.0)
+        assert result["totals"]["income"] == pytest.approx(3000.0)
+        assert result["totals"]["net"] == pytest.approx(2650.0)
+
+
+# ---------------------------------------------------------------------------
+# Test: period='this_month' filters correctly
+# ---------------------------------------------------------------------------
+
+
+class TestGetLedgerPeriodFilter:
+    def test_this_month_includes_current_month(self, db_path, authed_user):
+        """period='this_month' includes transactions dated in the current month."""
+        from server.main import get_ledger
+
+        ledger_id, _, expense_id = _seed_ledger(db_path, authed_user["user_id"])
+        today = datetime.now()
+        current_date = f"{today.year}-{today.month:02d}-15"
+        _seed_transaction(db_path, ledger_id, expense_id, current_date, 75.0, "InMonth")
+
+        result = get_ledger(ledger_id, period="this_month")
+        expense_item = next(li for li in result["line_items"] if li["id"] == expense_id)
+        merchants = [tx["merchant"] for tx in expense_item["transactions"]]
+        assert "InMonth" in merchants
+
+    def test_this_month_excludes_other_months(self, db_path, authed_user):
+        """period='this_month' excludes transactions from other months."""
+        from server.main import get_ledger
+
+        ledger_id, _, expense_id = _seed_ledger(db_path, authed_user["user_id"])
+        # Use a date far in the past — guaranteed to be out of this month
+        _seed_transaction(db_path, ledger_id, expense_id, "2020-01-15", 99.0, "OldTxn")
+
+        result = get_ledger(ledger_id, period="this_month")
+        expense_item = next(li for li in result["line_items"] if li["id"] == expense_id)
+        merchants = [tx["merchant"] for tx in expense_item["transactions"]]
+        assert "OldTxn" not in merchants
+
+    def test_none_period_returns_all(self, db_path, authed_user):
+        """period=None returns all transactions regardless of date."""
+        from server.main import get_ledger
+
+        ledger_id, _, expense_id = _seed_ledger(db_path, authed_user["user_id"])
+        _seed_transaction(db_path, ledger_id, expense_id, "2020-01-15", 99.0, "OldTxn")
+        _seed_transaction(db_path, ledger_id, expense_id, "2026-05-01", 50.0, "NewTxn")
+
+        result = get_ledger(ledger_id, period=None)
+        expense_item = next(li for li in result["line_items"] if li["id"] == expense_id)
+        assert len(expense_item["transactions"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Test: invalid ledger_id → error
+# ---------------------------------------------------------------------------
+
+
+class TestGetLedgerInvalidId:
+    def test_unknown_ledger_returns_error(self, db_path, authed_user):
+        """get_ledger() with unknown id returns error dict."""
+        from server.main import get_ledger
+
+        result = get_ledger(_uid())
+        assert result.get("status") == "error"
+        assert "not found" in result.get("message", "").lower()
+
+
+# ---------------------------------------------------------------------------
+# Test: not authenticated → error
+# ---------------------------------------------------------------------------
+
+
+class TestGetLedgerUnauthenticated:
+    def test_no_active_user_returns_error(self, db_path):
+        """get_ledger() with no active session returns error."""
+        from server.main import get_ledger
+
+        result = get_ledger(_uid())
+        assert result.get("status") == "error"
+
+
+# ---------------------------------------------------------------------------
+# Test: UI GET /ledgers renders data-line-item-id attrs and totals
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def ui_db_path(tmp_path: Path, monkeypatch) -> Path:
+    import server.paths as paths
+
+    db = tmp_path / "test_ui_drilldown.db"
+    init_db(db)
+    monkeypatch.setattr(paths, "DB_PATH", db)
+    monkeypatch.setattr(paths, "APP_DIR", tmp_path)
+    return db
+
+
+@pytest.fixture()
+def authed_ui_client(ui_db_path: Path):
+    from fastapi.testclient import TestClient
+
+    from ui.server import app
+
+    client = TestClient(app, follow_redirects=False)
+    # Setup wizard
+    client.post("/setup/1", data={"password": "testpass123", "password_confirm": "testpass123"})
+    client.post("/setup/2", data={"notification_pref": "openclaw"})
+    client.post("/setup/3", data={"ledger_name": "Personal"})
+    client.post("/setup/4", data={})
+    # Login
+    client.post("/login", data={"password": "testpass123"})
+    return client
+
+
+class TestLedgersPageDrilldown:
+    def test_page_renders_ok(self, authed_ui_client):
+        """GET /ledgers returns 200."""
+        r = authed_ui_client.get("/ledgers")
+        assert r.status_code == 200
+
+    def test_page_has_data_line_item_id(self, authed_ui_client):
+        """GET /ledgers HTML contains data-line-item-id attributes on line item rows."""
+        r = authed_ui_client.get("/ledgers")
+        assert "data-line-item-id" in r.text
+
+    def test_page_shows_totals(self, authed_ui_client):
+        """GET /ledgers shows C$ formatted totals for line items."""
+        r = authed_ui_client.get("/ledgers")
+        assert "C$" in r.text
+
+    def test_page_shows_transaction_count(self, authed_ui_client):
+        """GET /ledgers shows 'transactions' text for line item counts."""
+        r = authed_ui_client.get("/ledgers")
+        assert "transaction" in r.text
+
+    def test_page_with_entry_shows_expand_button(self, authed_ui_client, ui_db_path):
+        """When a transaction_entry exists, the expand button is present."""
+        # Find the first line item from setup wizard
+        conn = get_db(ui_db_path)
+        try:
+            ledger = conn.execute("SELECT id FROM ledgers LIMIT 1").fetchone()
+            item = conn.execute(
+                "SELECT id FROM line_items WHERE ledger_id = ? LIMIT 1",
+                (ledger["id"],),
+            ).fetchone()
+            txn_id = _uid()
+            entry_id = _uid()
+            conn.execute(
+                "INSERT INTO transactions (id, date, merchant, amount) VALUES (?, ?, ?, ?)",
+                (txn_id, "2026-05-10", "TestMerchant", 42.0),
+            )
+            conn.execute(
+                "INSERT INTO transaction_entries "
+                "(id, transaction_id, ledger_id, line_item_id, amount, amount_home, entry_type, source) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    entry_id,
+                    txn_id,
+                    ledger["id"],
+                    item["id"],
+                    42.0,
+                    42.0,
+                    "spending",
+                    "rule",
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        r = authed_ui_client.get("/ledgers")
+        assert r.status_code == 200
+        assert "btn-expand-item" in r.text
+        assert "txn-detail-row" in r.text

--- a/ui/server.py
+++ b/ui/server.py
@@ -215,34 +215,60 @@ def _set_notification_pref(pref: str) -> None:
     _set_notification_channel(_PREF_TO_CHANNEL.get(pref, pref))
 
 
-def _get_ledgers(user_id: Optional[str] = None) -> list[dict]:
-    """Query ledgers + line_items from the DB and return a list of dicts."""
+def _get_ledgers(user_id: Optional[str] = None, with_drilldown: bool = False) -> list[dict]:
+    """Query ledgers + line_items from the DB and return a list of dicts.
+
+    Parameters
+    ----------
+    user_id :
+        When supplied only ledgers owned by this user (plus legacy NULL-user
+        rows) are returned.
+    with_drilldown :
+        When ``True`` each line-item dict includes ``total`` and
+        ``transactions`` keys (used by the /ledgers page drilldown UI).
+    """
+    from server.main import _build_ledger_drilldown
+
     conn = get_db(_db_path())
     try:
         if user_id:
             # Include rows owned by user_id AND unowned rows (NULL user_id = legacy/migration)
             ledger_rows = conn.execute(
-                "SELECT id, name FROM ledgers WHERE user_id = ? OR user_id IS NULL ORDER BY name",
+                "SELECT id, name, type, description FROM ledgers "
+                "WHERE user_id = ? OR user_id IS NULL ORDER BY name",
                 (user_id,),
             ).fetchall()
         else:
-            ledger_rows = conn.execute("SELECT id, name FROM ledgers ORDER BY name").fetchall()
+            ledger_rows = conn.execute(
+                "SELECT id, name, type, description FROM ledgers ORDER BY name"
+            ).fetchall()
         ledgers = []
         for lr in ledger_rows:
-            items = conn.execute(
-                "SELECT id, name, item_type FROM line_items WHERE ledger_id = ? ORDER BY name",
-                (lr["id"],),
-            ).fetchall()
-            ledgers.append(
-                {
-                    "id": lr["id"],
-                    "name": lr["name"],
-                    "line_items": [
-                        {"id": i["id"], "name": i["name"], "item_type": i["item_type"]}
-                        for i in items
-                    ],
-                }
-            )
+            if with_drilldown:
+                drilldown = _build_ledger_drilldown(conn, lr, period=None)
+                ledgers.append(
+                    {
+                        "id": lr["id"],
+                        "name": lr["name"],
+                        "line_items": drilldown["line_items"],
+                        "totals": drilldown["totals"],
+                    }
+                )
+            else:
+                items = conn.execute(
+                    "SELECT id, name, item_type FROM line_items WHERE ledger_id = ? ORDER BY name",
+                    (lr["id"],),
+                ).fetchall()
+                ledgers.append(
+                    {
+                        "id": lr["id"],
+                        "name": lr["name"],
+                        "line_items": [
+                            {"id": i["id"], "name": i["name"], "item_type": i["item_type"]}
+                            for i in items
+                        ],
+                    }
+                )
         return ledgers
     finally:
         conn.close()
@@ -1203,7 +1229,7 @@ def ledgers_get(request: Request):
     if not _is_authenticated(request):
         return _redirect("/login")
     uid = _current_user_id(request)
-    ledgers = _get_ledgers(uid)
+    ledgers = _get_ledgers(uid, with_drilldown=True)
     return templates.TemplateResponse(
         request,
         "ledgers.html",

--- a/ui/templates/ledgers.html
+++ b/ui/templates/ledgers.html
@@ -3,6 +3,23 @@
 {% block title %}Ledgers — Friday Budgeting Pro{% endblock %}
 
 {% block content %}
+<style>
+  .item-total-cell { text-align: right; white-space: nowrap; padding-right: 0.5em; color: #555; font-size: 0.9em; }
+  .item-count-cell { white-space: nowrap; color: #888; font-size: 0.85em; padding-right: 0.5em; }
+  .item-expand-cell { width: 2em; text-align: center; }
+  .btn-expand-item { background: none; border: none; cursor: pointer; font-size: 1.1em; color: #666; padding: 0 0.3em; transition: transform 0.15s; }
+  .btn-expand-item.expanded { transform: rotate(180deg); }
+  .txn-detail-row td { padding: 0; }
+  .txn-detail-cell { padding: 0.25em 0 0.25em 1.5em !important; background: #f9f9f9; }
+  .txn-table { width: 100%; border-collapse: collapse; font-size: 0.85em; }
+  .txn-table tr { border-bottom: 1px solid #eee; }
+  .txn-tree { font-family: monospace; color: #aaa; padding-right: 0.3em; white-space: nowrap; }
+  .txn-date { white-space: nowrap; padding-right: 0.5em; color: #666; }
+  .txn-merchant { flex: 1; }
+  .txn-account { color: #888; padding-right: 0.5em; font-size: 0.9em; }
+  .txn-amount { text-align: right; white-space: nowrap; }
+  .txn-pending td { color: #aaa; font-style: italic; }
+</style>
 <div class="card">
   <div style="display:flex;justify-content:space-between;align-items:baseline;">
     <h1>Ledgers</h1>
@@ -38,18 +55,42 @@
             <tbody class="items-tbody" data-section="income">
               {% for item in ledger.line_items %}
               {% if item.item_type == "income" %}
-              <tr data-item-id="{{ item.id }}">
-                <td>
+              <tr class="line-item-row" data-item-id="{{ item.id }}" data-line-item-id="{{ item.id }}">
+                <td class="item-name-cell">
                   <span class="item-name-display">{{ item.name }}</span>
                   <input class="item-name-input" type="text" value="{{ item.name }}"
                     style="display:none;" data-item-id="{{ item.id }}"
                     data-ledger-id="{{ ledger.id }}">
+                </td>
+                <td class="item-total-cell">C${{ "%.2f"|format(item.total) }}</td>
+                <td class="item-count-cell">{{ item.transactions|length }} transaction{% if item.transactions|length != 1 %}s{% endif %}</td>
+                <td class="item-expand-cell">
+                  {% if item.transactions %}
+                  <button class="btn-expand-item" data-item-id="{{ item.id }}" aria-label="Toggle transactions">&#8964;</button>
+                  {% endif %}
                 </td>
                 <td>
                   <button class="btn-danger btn-delete-item" data-item-id="{{ item.id }}"
                     data-ledger-id="{{ ledger.id }}">x</button>
                 </td>
               </tr>
+              {% if item.transactions %}
+              <tr class="txn-detail-row" data-parent-item-id="{{ item.id }}" style="display:none;">
+                <td colspan="5" class="txn-detail-cell">
+                  <table class="txn-table">
+                    {% for tx in item.transactions %}
+                    <tr class="{% if tx.pending %}txn-pending{% endif %}">
+                      <td class="txn-tree">{% if loop.last %}&#9492;&#9472;&#9472;{% else %}&#9500;&#9472;&#9472;{% endif %}</td>
+                      <td class="txn-date">{{ tx.date }}</td>
+                      <td class="txn-merchant">{{ tx.merchant or '(unknown)' }}</td>
+                      <td class="txn-account">{{ tx.account_name or '' }}</td>
+                      <td class="txn-amount">C${{ "%.2f"|format(tx.amount) }}</td>
+                    </tr>
+                    {% endfor %}
+                  </table>
+                </td>
+              </tr>
+              {% endif %}
               {% endif %}
               {% endfor %}
             </tbody>
@@ -66,18 +107,42 @@
             <tbody class="items-tbody" data-section="expenses">
               {% for item in ledger.line_items %}
               {% if item.item_type == "expense" %}
-              <tr data-item-id="{{ item.id }}">
-                <td>
+              <tr class="line-item-row" data-item-id="{{ item.id }}" data-line-item-id="{{ item.id }}">
+                <td class="item-name-cell">
                   <span class="item-name-display">{{ item.name }}</span>
                   <input class="item-name-input" type="text" value="{{ item.name }}"
                     style="display:none;" data-item-id="{{ item.id }}"
                     data-ledger-id="{{ ledger.id }}">
+                </td>
+                <td class="item-total-cell">C${{ "%.2f"|format(item.total) }}</td>
+                <td class="item-count-cell">{{ item.transactions|length }} transaction{% if item.transactions|length != 1 %}s{% endif %}</td>
+                <td class="item-expand-cell">
+                  {% if item.transactions %}
+                  <button class="btn-expand-item" data-item-id="{{ item.id }}" aria-label="Toggle transactions">&#8964;</button>
+                  {% endif %}
                 </td>
                 <td>
                   <button class="btn-danger btn-delete-item" data-item-id="{{ item.id }}"
                     data-ledger-id="{{ ledger.id }}">x</button>
                 </td>
               </tr>
+              {% if item.transactions %}
+              <tr class="txn-detail-row" data-parent-item-id="{{ item.id }}" style="display:none;">
+                <td colspan="5" class="txn-detail-cell">
+                  <table class="txn-table">
+                    {% for tx in item.transactions %}
+                    <tr class="{% if tx.pending %}txn-pending{% endif %}">
+                      <td class="txn-tree">{% if loop.last %}&#9492;&#9472;&#9472;{% else %}&#9500;&#9472;&#9472;{% endif %}</td>
+                      <td class="txn-date">{{ tx.date }}</td>
+                      <td class="txn-merchant">{{ tx.merchant or '(unknown)' }}</td>
+                      <td class="txn-account">{{ tx.account_name or '' }}</td>
+                      <td class="txn-amount">C${{ "%.2f"|format(tx.amount) }}</td>
+                    </tr>
+                    {% endfor %}
+                  </table>
+                </td>
+              </tr>
+              {% endif %}
               {% endif %}
               {% endfor %}
             </tbody>
@@ -270,11 +335,16 @@
 
   function buildItemRow(itemId, name, ledgerId) {
     var tr = document.createElement("tr");
+    tr.className = "line-item-row";
     tr.dataset.itemId = itemId;
+    tr.dataset.lineItemId = itemId;
     tr.innerHTML =
-      '<td><span class="item-name-display">' + esc(name) + '</span>' +
+      '<td class="item-name-cell"><span class="item-name-display">' + esc(name) + '</span>' +
       '<input class="item-name-input" type="text" value="' + esc(name) + '"' +
       ' style="display:none;" data-item-id="' + itemId + '" data-ledger-id="' + ledgerId + '"></td>' +
+      '<td class="item-total-cell">C$0.00</td>' +
+      '<td class="item-count-cell">0 transactions</td>' +
+      '<td class="item-expand-cell"></td>' +
       '<td><button class="btn-danger btn-delete-item" data-item-id="' + itemId +
       '" data-ledger-id="' + ledgerId + '">x</button></td>';
     return tr;
@@ -305,6 +375,19 @@
   function esc(s) {
     return String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;");
   }
+
+  // ── Drilldown: expand/collapse transactions per line item ──────────────────
+  document.addEventListener("click", function (e) {
+    var btn = e.target.closest(".btn-expand-item");
+    if (!btn) return;
+    var itemId = btn.dataset.itemId;
+    var detailRow = document.querySelector(".txn-detail-row[data-parent-item-id='" + itemId + "']");
+    if (!detailRow) return;
+    var isOpen = detailRow.style.display !== "none";
+    detailRow.style.display = isOpen ? "none" : "";
+    btn.classList.toggle("expanded", !isOpen);
+    btn.setAttribute("aria-expanded", !isOpen);
+  });
 })();
 </script>
 {% endblock %}


### PR DESCRIPTION
Closes #175

## Summary

Implements ledger drilldown infrastructure — line items now show their running totals and classified transactions inline.

### Changes

****
- New  helper — shared between the MCP tool and the web route
- New  — returns full ledger tree with line items, per-item totals, and classified transactions; supports `this_month`, `last_month`, `this_year`, and `None` (all-time) period filters

****
- `_get_ledgers()` extended with `with_drilldown=True` — shares `_build_ledger_drilldown` logic so the web route and MCP tool stay in sync
- `GET /ledgers` now passes drilldown data to the template

****
- Each line item row now shows: name · `C$total` · `N transactions` · expand toggle (⌄)
- Click toggle → inline transaction table expands with tree-branch chars, date, merchant, account, amount
- Pending transactions styled italic/grey
- Empty line items show `C$0.00 · 0 transactions` with no expand affordance
- New item rows created dynamically (via JS) also carry the new columns
- Vanilla JS only, no framework

**** — 18 new tests covering:
- `get_ledger()` structure with no entries
- Transactions appear under correct line items when entries are seeded
- `period='this_month'` filters correctly; `period=None` returns all
- Invalid `ledger_id` → error
- Not authenticated → error
- UI: `data-line-item-id` attrs, totals, expand button, transaction rows

**** — `get_ledger` added to MCP tools list  
**`README.md`** — Ledgers page description updated to mention drilldown

### Interactive check

```
list_ledgers: 1 ledger(s)
get_ledger keys: ['ledger', 'line_items', 'totals']
ledger name: Personal
line_items count: 10
totals: {'income': 0.0, 'expenses': 0.0, 'net': 0.0}
  Dining (expense): total=0.0, txns=0
  Groceries (expense): total=0.0, txns=0
  Healthcare (expense): total=0.0, txns=0

GET /ledgers: status=200, data-line-item-id=True, C$=True, transaction=True, btn-expand-item=True
```

Transactions list is empty as expected — `transaction_entries` has no data until #165 (auto-categorisation) lands. The drilldown infrastructure is ready.
