### PR TITLE
[P2] Setup wizard: rental property + investment account steps (#176)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -254,8 +254,10 @@ Only what HAL actually needs to call. Grouped:
 
 ### Setup (one-shot)
 - `setup_status()` → returns `not_started | in_progress | complete`
-- `apply_initial_setup(banks_to_link[], extra_ledgers[], hints[])` → does the
+- `apply_initial_setup(banks_to_link[], extra_ledgers[], hints[], rental_properties[], investment_account_ids[])` → does the
   whole setup in one call. HAL asks 2-3 questions, then calls this.
+  - `rental_properties`: list of `{name, description?, account_id?}` — each creates a property ledger and optionally links the bank account.
+  - `investment_account_ids`: list of account IDs — creates a single "Investments" ledger (if non-empty) and links all accounts.
 
 ### Banks
 - `start_link()` → returns URL to open Plaid Link
@@ -504,11 +506,20 @@ transaction review, classification rules editor, charts.
 
 ### What each page does
 
-**Setup wizard** (`/setup`) — one-time, four short steps
+**Setup wizard** (`/setup`) — one-time, six short steps
 1. Welcome + set password
 2. Pick notification preference (OpenClaw chat / macOS notifications / in-UI)
 3. Connect first bank via Plaid Link
-4. Done — redirects to `/dashboard`
+4. Rental properties — optional; enter name, description, and linked bank account
+   per property; creates a property ledger and links the account
+5. Investment accounts — optional; auto-detects Wealthsimple/Questrade/etc. accounts;
+   checking any creates a shared "Investments" ledger and links the accounts
+6. Done — redirects to `/dashboard`
+
+Wizard state is held in `_wizard_state` (server-side dict keyed by a random
+cookie token). Steps 4 and 5 store `rental_properties` and
+`investment_account_ids` in wizard state; step 6 passes them to
+`apply_initial_setup`.
 
 After completion, `/setup` returns 404. Re-running setup means resetting
 the DB (a future operation, not a v0.1 feature).

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Link modal and authenticate normally.
 ## First Run
 
 When you visit `http://127.0.0.1:6789` for the first time, you see a
-small setup wizard (4 short screens):
+small setup wizard (6 short screens):
 
 1. **Set a password** - protects your local dashboard.
 2. **Pick how you want to be notified** about ambiguous transactions:
@@ -110,7 +110,14 @@ small setup wizard (4 short screens):
    - "Just show me a banner in the UI"
 3. **Connect your first bank** - click **+ Connect a bank** and follow
    the Plaid login.
-4. **Done.** Lands on your Profile page.
+4. **Rental properties** *(optional)* - add any rental properties you want to
+   track. Each property gets its own ledger (Rent income, Mortgage, Property tax,
+   Maintenance, Insurance, Utilities) and can be linked to a specific bank account
+   so its transactions auto-route there.
+5. **Investment accounts** *(optional)* - Friday detects Wealthsimple, Questrade,
+   and other investment accounts you’ve linked. Check any you want tracked in a
+   shared **Investments** ledger.
+6. **Done.** Lands on your Dashboard.
 
 The system picks sensible defaults for everything else (Personal ledger
 with standard rows, daily 6 AM sync, LLM confidence threshold 0.75).

--- a/server/main.py
+++ b/server/main.py
@@ -222,29 +222,43 @@ def setup_status() -> dict:
 
 @mcp.tool
 def apply_initial_setup(
-    banks_to_link: List,
-    extra_ledgers: List,
-    hints: List,
+    banks_to_link: List = None,
+    extra_ledgers: List = None,
+    hints: List = None,
+    rental_properties: List = None,
+    investment_account_ids: List = None,
 ) -> dict:
     """Perform the whole first-run setup in one call.
 
     Parameters
     ----------
-    banks_to_link : List[str]
+    banks_to_link : List[str], optional
         Human-readable bank names the user wants to connect.  NOTE: This tool
         does NOT run Plaid Link — that interactive flow lives in start_link /
         complete_link.  We simply acknowledge the requested banks and return
         them so the caller can chain start_link calls for each one.
-    extra_ledgers : List[dict]
+    extra_ledgers : List[dict], optional
         Additional ledgers beyond "Personal".  Each entry is a dict like::
 
             {"name": "Business", "line_items": [{"name": "Office", "type": "expense"}, ...]}
 
         The built-in "Personal" ledger is always created (with the standard
         10 line items below) regardless of this parameter.
-    hints : List[str]
+    hints : List[str], optional
         Natural-language classification hints; each becomes a row in
         ``classification_hints``.  De-duped on exact text.
+    rental_properties : List[dict], optional
+        Rental properties to create ledgers for.  Each entry is a dict like::
+
+            {"name": "123 Main St", "description": "2-bed condo", "account_id": "<uuid>"}
+
+        For each property a ledger is created via ``create_property_ledger``
+        and the given bank account is linked via ``set_account_ledger``.
+        ``account_id`` may be omitted or ``None`` to skip the account link.
+    investment_account_ids : List[str], optional
+        Bank account IDs to route to a shared "Investments" ledger.  If the
+        list is non-empty a single "Investments" ledger is created (once) and
+        every account in the list is linked to it via ``set_account_ledger``.
 
     Standard Personal line items (always created):
       Salary (income), Groceries (expense), Dining (expense),
@@ -257,7 +271,8 @@ def apply_initial_setup(
     -------
     dict
         {"status": "ok", "ledgers_created": [...], "line_items_created": N,
-         "hints_created": N, "banks_to_link": [...]}
+         "hints_created": N, "banks_to_link": [...],
+         "properties_created": N, "investment_ledger_id": str | None}
     """
     PERSONAL_LINE_ITEMS = [
         ("Salary", "income"),
@@ -350,6 +365,34 @@ def apply_initial_setup(
 
     cron_registered = _register_openclaw_cron()
 
+    # ── Rental properties ─────────────────────────────────────────────────
+    properties_created = 0
+    for prop in rental_properties or []:
+        prop_name = prop.get("name", "").strip()
+        if not prop_name:
+            continue
+        result = create_property_ledger(
+            name=prop_name,
+            description=prop.get("description"),
+        )
+        if result.get("status") == "ok":
+            ledgers_created.append(prop_name)
+            properties_created += 1
+            acct_id = prop.get("account_id")
+            if acct_id:
+                set_account_ledger(account_id=acct_id, ledger_id=result["ledger_id"])
+
+    # ── Investment accounts ───────────────────────────────────────────────
+    investment_ledger_id = None
+    inv_ids = [aid for aid in (investment_account_ids or []) if aid]
+    if inv_ids:
+        inv_result = create_investment_ledger(name="Investments")
+        if inv_result.get("status") == "ok":
+            investment_ledger_id = inv_result["ledger_id"]
+            ledgers_created.append("Investments")
+            for acct_id in inv_ids:
+                set_account_ledger(account_id=acct_id, ledger_id=investment_ledger_id)
+
     return {
         "status": "ok",
         "ledgers_created": ledgers_created,
@@ -357,6 +400,8 @@ def apply_initial_setup(
         "hints_created": hints_created,
         "banks_to_link": [*banks_to_link] if banks_to_link else [],
         "cron_registered": cron_registered,
+        "properties_created": properties_created,
+        "investment_ledger_id": investment_ledger_id,
     }
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -56,7 +56,11 @@ def _complete_setup(client: TestClient, password: str = "correcthorsebattery") -
     assert r.status_code == 200
     r = client.post("/setup/3", data={"ledger_name": "Personal"})
     assert r.status_code == 200
-    r = client.post("/setup/4", data={})
+    r = client.post("/setup/4", data={"action": "skip"})
+    assert r.status_code == 200
+    r = client.post("/setup/5", data={"action": "skip"})
+    assert r.status_code == 200
+    r = client.post("/setup/6", data={})
     assert r.status_code == 302
 
 

--- a/tests/test_ledger_drilldown.py
+++ b/tests/test_ledger_drilldown.py
@@ -329,7 +329,9 @@ def authed_ui_client(ui_db_path: Path):
     client.post("/setup/1", data={"password": "testpass123", "password_confirm": "testpass123"})
     client.post("/setup/2", data={"notification_pref": "openclaw"})
     client.post("/setup/3", data={"ledger_name": "Personal"})
-    client.post("/setup/4", data={})
+    client.post("/setup/4", data={})  # skip rental properties
+    client.post("/setup/5", data={})  # skip investment accounts
+    client.post("/setup/6", data={})  # done
     # Login
     client.post("/login", data={"password": "testpass123"})
     return client

--- a/tests/test_mcp_decoupling.py
+++ b/tests/test_mcp_decoupling.py
@@ -60,7 +60,11 @@ def _complete_setup(client: TestClient, password: str = "testpassword123") -> No
     r = client.post("/setup/3", data={"ledger_name": "Personal"})
     assert r.status_code == 200, f"Setup step 3 failed: {r.status_code}"
 
-    r = client.post("/setup/4", data={})
+    r = client.post("/setup/4", data={"action": "skip"})
+    assert r.status_code == 200
+    r = client.post("/setup/5", data={"action": "skip"})
+    assert r.status_code == 200
+    r = client.post("/setup/6", data={})
     assert r.status_code == 302, f"Setup step 4 failed: {r.status_code}"
     assert r.headers["location"] == "/dashboard"
 
@@ -381,11 +385,17 @@ class TestSetupWizardCompletesWithoutMcp:
         r = cl.post("/setup/3", data={"ledger_name": "Budget"})
         assert r.status_code == 200, f"Setup step 3 failed: {r.status_code}"
 
-        # Step 4: finalise — must redirect to /profile.
-        with patch("server.main.apply_initial_setup", return_value={"status": "ok"}) as mock_apply:
-            r = cl.post("/setup/4", data={})
+        # Steps 4 (properties) and 5 (investments): skip both.
+        r = cl.post("/setup/4", data={"action": "skip"})
+        assert r.status_code == 200, f"Setup step 4 failed: {r.status_code}"
+        r = cl.post("/setup/5", data={"action": "skip"})
+        assert r.status_code == 200, f"Setup step 5 failed: {r.status_code}"
 
-        assert r.status_code == 302, f"Setup step 4 failed: {r.status_code}"
+        # Step 6: finalise — must redirect to /dashboard.
+        with patch("server.main.apply_initial_setup", return_value={"status": "ok"}) as mock_apply:
+            r = cl.post("/setup/6", data={})
+
+        assert r.status_code == 302, f"Setup step 6 failed: {r.status_code}"
         assert r.headers["location"] == "/dashboard"
 
         # Verify a user was created in the DB — the wizard persisted state.

--- a/tests/test_multi_profile.py
+++ b/tests/test_multi_profile.py
@@ -59,7 +59,11 @@ def _do_setup(client: TestClient, username: str = "alice", password: str = "alic
     assert r.status_code == 200
     r = client.post("/setup/3", data={"ledger_name": "Personal"})
     assert r.status_code == 200
-    r = client.post("/setup/4", data={})
+    r = client.post("/setup/4", data={"action": "skip"})
+    assert r.status_code == 200
+    r = client.post("/setup/5", data={"action": "skip"})
+    assert r.status_code == 200
+    r = client.post("/setup/6", data={})
     assert r.status_code == 302
 
 

--- a/tests/test_recovery_reset.py
+++ b/tests/test_recovery_reset.py
@@ -64,7 +64,11 @@ def setup_user(db_path: Path, client: TestClient) -> dict:
     assert r.status_code == 200
     r = client.post("/setup/3", data={})
     assert r.status_code == 200
-    r = client.post("/setup/4", data={})
+    r = client.post("/setup/4", data={"action": "skip"})
+    assert r.status_code == 200
+    r = client.post("/setup/5", data={"action": "skip"})
+    assert r.status_code == 200
+    r = client.post("/setup/6", data={})
     assert r.status_code == 302
     return {"username": "testuser", "password": "hunter2abc"}
 

--- a/tests/test_setup_properties.py
+++ b/tests/test_setup_properties.py
@@ -1,0 +1,399 @@
+"""
+tests/test_setup_properties.py — Tests for rental property and investment
+account setup flows added in #176.
+
+Covers:
+  MCP layer (apply_initial_setup):
+    - rental_properties creates ledger + links account
+    - investment_account_ids creates investment ledger + links all accounts
+    - both at once: properties first, then investments
+    - empty lists are no-ops for the new params
+    - missing account_id in property dict skips set_account_ledger
+  UI wizard:
+    - POST /setup/4 renders step 5 (investment step)
+    - POST /setup/4 with properties populates wizard state
+    - POST /setup/4 skip → investment step with empty rental_properties
+    - POST /setup/5 renders step 6 (done)
+    - POST /setup/5 skip → step 6
+    - POST /setup/6 calls apply_initial_setup with stored properties/investments
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+import server.main
+import server.paths
+from server.db import get_db, init_db
+
+# ---------------------------------------------------------------------------
+# Fixtures — MCP layer
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def tmp_db(tmp_path, monkeypatch):
+    """Fresh DB with an active user; patches DB_PATH and cron home."""
+    db_file = tmp_path / "test.db"
+    monkeypatch.setattr(server.paths, "DB_PATH", db_file)
+    init_db(db_file)
+
+    # Disable cron registration for all tests.
+    monkeypatch.setattr(server.main, "_OPENCLAW_HOME", tmp_path / "dot-openclaw-absent")
+
+    # Insert a user so get_active_user_id returns something.
+    from ui.auth import create_user
+
+    create_user(db_file, "testuser", "securepass1")
+
+    return db_file
+
+
+def _make_bank_account(
+    db_file, user_id: str | None = None, acct_type: str = "checking", institution: str = "TD Bank"
+) -> str:
+    """Insert a minimal bank_connection + bank_account; return account id."""
+    conn = get_db(db_file)
+    conn_id = str(uuid.uuid4())
+    acct_id = str(uuid.uuid4())
+    conn.execute(
+        "INSERT INTO bank_connections "
+        "(id, plaid_item_id, plaid_access_token_encrypted, user_id, institution_name) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (conn_id, f"item_{conn_id}", "enc_tok", user_id, institution),
+    )
+    conn.execute(
+        "INSERT INTO bank_accounts (id, connection_id, plaid_account_id, name, type) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (acct_id, conn_id, f"plaid_{acct_id}", "Chequing", acct_type),
+    )
+    conn.commit()
+    conn.close()
+    return acct_id
+
+
+def _get_user_id(db_file) -> str:
+    conn = get_db(db_file)
+    row = conn.execute("SELECT id FROM users LIMIT 1").fetchone()
+    conn.close()
+    return row["id"]
+
+
+# ---------------------------------------------------------------------------
+# MCP tests — apply_initial_setup with rental_properties
+# ---------------------------------------------------------------------------
+
+
+class TestApplyInitialSetupRentalProperties:
+    def test_creates_property_ledger(self, tmp_db):
+        uid = _get_user_id(tmp_db)
+        acct_id = _make_bank_account(tmp_db, uid)
+
+        result = server.main.apply_initial_setup(
+            rental_properties=[
+                {"name": "123 Main St", "description": "2-bed condo", "account_id": acct_id}
+            ],
+            investment_account_ids=[],
+        )
+
+        assert result["status"] == "ok"
+        assert result["properties_created"] == 1
+        assert "123 Main St" in result["ledgers_created"]
+
+        conn = get_db(tmp_db)
+        ledger = conn.execute("SELECT id, type FROM ledgers WHERE name = '123 Main St'").fetchone()
+        conn.close()
+        assert ledger is not None
+        assert ledger["type"] == "property"
+
+    def test_links_account_to_property_ledger(self, tmp_db):
+        uid = _get_user_id(tmp_db)
+        acct_id = _make_bank_account(tmp_db, uid)
+
+        server.main.apply_initial_setup(
+            rental_properties=[{"name": "Oak Ave", "account_id": acct_id}],
+        )
+
+        conn = get_db(tmp_db)
+        row = conn.execute(
+            "SELECT ba.default_ledger_id, l.name "
+            "FROM bank_accounts ba JOIN ledgers l ON l.id = ba.default_ledger_id "
+            "WHERE ba.id = ?",
+            (acct_id,),
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        assert row["name"] == "Oak Ave"
+
+    def test_no_account_id_skips_link(self, tmp_db):
+        result = server.main.apply_initial_setup(
+            rental_properties=[{"name": "No Account Prop", "description": "desc"}],
+        )
+        assert result["status"] == "ok"
+        assert result["properties_created"] == 1
+
+    def test_empty_name_skipped(self, tmp_db):
+        result = server.main.apply_initial_setup(
+            rental_properties=[{"name": "", "account_id": None}],
+        )
+        assert result["properties_created"] == 0
+
+    def test_empty_list_is_noop(self, tmp_db):
+        result = server.main.apply_initial_setup(rental_properties=[])
+        assert result["properties_created"] == 0
+        assert result["investment_ledger_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# MCP tests — apply_initial_setup with investment_account_ids
+# ---------------------------------------------------------------------------
+
+
+class TestApplyInitialSetupInvestments:
+    def test_creates_investment_ledger_and_links_accounts(self, tmp_db):
+        uid = _get_user_id(tmp_db)
+        acct1 = _make_bank_account(tmp_db, uid, institution="Wealthsimple")
+        acct2 = _make_bank_account(tmp_db, uid, institution="Questrade")
+
+        result = server.main.apply_initial_setup(
+            investment_account_ids=[acct1, acct2],
+        )
+
+        assert result["status"] == "ok"
+        assert result["investment_ledger_id"] is not None
+        assert "Investments" in result["ledgers_created"]
+
+        conn = get_db(tmp_db)
+        # Both accounts should point to the same investment ledger.
+        for acct_id in (acct1, acct2):
+            row = conn.execute(
+                "SELECT default_ledger_id FROM bank_accounts WHERE id = ?", (acct_id,)
+            ).fetchone()
+            assert row["default_ledger_id"] == result["investment_ledger_id"]
+        conn.close()
+
+    def test_empty_list_skips_investment_ledger(self, tmp_db):
+        result = server.main.apply_initial_setup(investment_account_ids=[])
+        assert result["investment_ledger_id"] is None
+
+        conn = get_db(tmp_db)
+        inv = conn.execute("SELECT id FROM ledgers WHERE name = 'Investments'").fetchone()
+        conn.close()
+        assert inv is None
+
+    def test_none_is_treated_as_empty(self, tmp_db):
+        result = server.main.apply_initial_setup(investment_account_ids=None)
+        assert result["investment_ledger_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# MCP tests — both at once
+# ---------------------------------------------------------------------------
+
+
+class TestApplyInitialSetupCombined:
+    def test_properties_and_investments_together(self, tmp_db):
+        uid = _get_user_id(tmp_db)
+        prop_acct = _make_bank_account(tmp_db, uid, institution="RBC")
+        inv_acct = _make_bank_account(tmp_db, uid, institution="Wealthsimple")
+
+        result = server.main.apply_initial_setup(
+            rental_properties=[{"name": "Elm St", "account_id": prop_acct}],
+            investment_account_ids=[inv_acct],
+        )
+
+        assert result["status"] == "ok"
+        assert result["properties_created"] == 1
+        assert result["investment_ledger_id"] is not None
+        assert "Elm St" in result["ledgers_created"]
+        assert "Investments" in result["ledgers_created"]
+
+        conn = get_db(tmp_db)
+        # Property account → Elm St ledger
+        elm_ledger = conn.execute("SELECT id FROM ledgers WHERE name = 'Elm St'").fetchone()
+        assert elm_ledger is not None
+        prop_link = conn.execute(
+            "SELECT default_ledger_id FROM bank_accounts WHERE id = ?", (prop_acct,)
+        ).fetchone()
+        assert prop_link["default_ledger_id"] == elm_ledger["id"]
+
+        # Investment account → Investments ledger
+        inv_link = conn.execute(
+            "SELECT default_ledger_id FROM bank_accounts WHERE id = ?", (inv_acct,)
+        ).fetchone()
+        assert inv_link["default_ledger_id"] == result["investment_ledger_id"]
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — UI layer
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path, monkeypatch) -> Path:
+    import server.paths as paths
+
+    db = tmp_path / "ui_setup_test.db"
+    init_db(db)
+    monkeypatch.setattr(paths, "DB_PATH", db)
+    monkeypatch.setattr(paths, "APP_DIR", tmp_path)
+    return db
+
+
+@pytest.fixture()
+def client(db_path: Path) -> TestClient:
+    from ui.server import app
+
+    return TestClient(app, follow_redirects=False)
+
+
+def _wizard_through_step3(client: TestClient) -> None:
+    """Drive through steps 1→3 (bank skip)."""
+    client.post("/setup/1", data={"password": "securepass1", "password_confirm": "securepass1"})
+    client.post("/setup/2", data={"notification_channel": "openclaw_chat"})
+    client.post("/setup/3", data={"action": "skip"})
+
+
+# ---------------------------------------------------------------------------
+# UI tests — step 4 (properties)
+# ---------------------------------------------------------------------------
+
+
+class TestSetupWizardStep4Properties:
+    def test_step4_renders_after_step3(self, client):
+        _wizard_through_step3(client)
+        # The last call already returned step 4 HTML; call again from step 3.
+        r = client.post("/setup/3", data={"action": "skip"})
+        assert r.status_code == 200
+        assert b"Rental properties" in r.content or b"rental" in r.content.lower()
+
+    def test_step4_skip_goes_to_step5(self, client):
+        _wizard_through_step3(client)
+        r = client.post("/setup/4", data={"action": "skip"})
+        assert r.status_code == 200
+        assert b"Investment" in r.content
+
+    def test_step4_continue_without_checkbox_goes_to_step5(self, client):
+        _wizard_through_step3(client)
+        r = client.post("/setup/4", data={"action": "continue"})
+        assert r.status_code == 200
+        assert b"Investment" in r.content
+
+    def test_step4_with_properties_stores_in_wizard_state(self, client):
+        _wizard_through_step3(client)
+        r = client.post(
+            "/setup/4",
+            data={
+                "action": "continue",
+                "has_properties": "yes",
+                "property_name[]": "Oak Ave",
+                "property_description[]": "Cottage",
+                "property_account_id[]": "",
+            },
+        )
+        assert r.status_code == 200
+        # Step 5 page rendered
+        assert b"Investment" in r.content
+
+
+# ---------------------------------------------------------------------------
+# UI tests — step 5 (investments)
+# ---------------------------------------------------------------------------
+
+
+class TestSetupWizardStep5Investments:
+    def _through_step4(self, client):
+        _wizard_through_step3(client)
+        client.post("/setup/4", data={"action": "skip"})
+
+    def test_step5_skip_goes_to_step6(self, client):
+        self._through_step4(client)
+        r = client.post("/setup/5", data={"action": "skip"})
+        assert r.status_code == 200
+        assert b"all set" in r.content.lower() or b"Done" in r.content or b"Dashboard" in r.content
+
+    def test_step5_continue_with_accounts_goes_to_step6(self, client):
+        self._through_step4(client)
+        r = client.post(
+            "/setup/5",
+            data={"action": "continue", "investment_account_id": "fake-uuid-123"},
+        )
+        assert r.status_code == 200
+        # Step 6 rendered
+        assert b"set" in r.content.lower() or b"Dashboard" in r.content
+
+
+# ---------------------------------------------------------------------------
+# UI tests — step 6 (final — calls apply_initial_setup with stored data)
+# ---------------------------------------------------------------------------
+
+
+class TestSetupWizardStep6Final:
+    def _through_step5(self, client):
+        _wizard_through_step3(client)
+        client.post("/setup/4", data={"action": "skip"})
+        client.post("/setup/5", data={"action": "skip"})
+
+    def test_step6_calls_apply_initial_setup(self, client):
+        self._through_step5(client)
+        with patch("server.main.apply_initial_setup") as mock_setup:
+            mock_setup.return_value = {
+                "status": "ok",
+                "ledgers_created": [],
+                "line_items_created": 0,
+                "hints_created": 0,
+                "banks_to_link": [],
+                "properties_created": 0,
+                "investment_ledger_id": None,
+                "cron_registered": False,
+            }
+            r = client.post("/setup/6", data={})
+        assert r.status_code == 302
+        mock_setup.assert_called_once()
+
+    def test_step6_passes_properties_to_apply(self, client):
+        """If properties were entered at step 4, step 6 passes them through."""
+        _wizard_through_step3(client)
+        client.post(
+            "/setup/4",
+            data={
+                "action": "continue",
+                "has_properties": "yes",
+                "property_name[]": "Maple St",
+                "property_description[]": "",
+                "property_account_id[]": "",
+            },
+        )
+        client.post("/setup/5", data={"action": "skip"})
+
+        with patch("server.main.apply_initial_setup") as mock_setup:
+            mock_setup.return_value = {
+                "status": "ok",
+                "ledgers_created": ["Personal", "Maple St"],
+                "line_items_created": 10,
+                "hints_created": 0,
+                "banks_to_link": [],
+                "properties_created": 1,
+                "investment_ledger_id": None,
+                "cron_registered": False,
+            }
+            client.post("/setup/6", data={})
+
+        call_kwargs = mock_setup.call_args[1] if mock_setup.call_args.kwargs else {}
+        call_args = mock_setup.call_args
+        # Extract rental_properties from positional or keyword args.
+        try:
+            props = (
+                call_args.kwargs.get("rental_properties")
+                or call_args[1].get("rental_properties")
+                or []
+            )
+        except Exception:
+            props = []
+        assert any(p.get("name") == "Maple St" for p in props)

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -1,13 +1,15 @@
 """
-tests/test_setup_wizard.py — Tests for the 4-step setup wizard (issue #56).
+tests/test_setup_wizard.py — Tests for the 6-step setup wizard.
 
 Covers:
   - GET /setup on empty DB → step 1
   - POST /setup/1 validation errors (mismatch, too short)
   - POST /setup/1 success → password hash set, session cookie returned, advance to step 2
   - POST /setup/2 → notification_channel persisted, advance to step 3
-  - POST /setup/3 skip → advance to step 4
-  - POST /setup/4 → apply_initial_setup called, redirect to /profile
+  - POST /setup/3 skip → advance to step 4 (rental properties)
+  - POST /setup/4 skip → advance to step 5 (investments)
+  - POST /setup/5 skip → advance to step 6 (done)
+  - POST /setup/6 → apply_initial_setup called, redirect to /dashboard
   - After complete → GET /setup → 404
   - Redirect-to-setup middleware regression (non-setup routes redirect when no password)
 """
@@ -266,11 +268,11 @@ class TestSetupStep3:
         _wizard_through_step2(client)
         r = client.post("/setup/3", data={"action": "skip"})
         assert r.status_code == 200
-        # Step 4 done-page content should be rendered.
+        # Step 4 (rental properties) content should be rendered.
         assert (
-            b"profile" in r.content.lower()
-            or b"done" in r.content.lower()
-            or b"set" in r.content.lower()
+            b"rental" in r.content.lower()
+            or b"propert" in r.content.lower()
+            or b"Properties" in r.content
         )
 
     def test_no_action_treated_as_skip(self, client):
@@ -281,30 +283,43 @@ class TestSetupStep3:
 
 
 # ---------------------------------------------------------------------------
-# Tests — POST /setup/4
+# Tests — POST /setup/4 (rental properties)
 # ---------------------------------------------------------------------------
 
 
 class TestSetupStep4:
-    def test_apply_initial_setup_called(self, client):
+    def test_skip_advances_to_step5(self, client):
         _wizard_through_step3(client)
-        with patch("server.main.apply_initial_setup") as mock_setup:
-            mock_setup.return_value = {
-                "status": "ok",
-                "ledgers_created": [],
-                "line_items_created": 0,
-                "hints_created": 0,
-                "banks_to_link": [],
-            }
-            r = client.post("/setup/4", data={})
-        mock_setup.assert_called_once_with(
-            banks_to_link=[],
-            extra_ledgers=[],
-            hints=[],
-        )
+        r = client.post("/setup/4", data={"action": "skip"})
+        assert r.status_code == 200
+        assert b"Investment" in r.content or b"investment" in r.content.lower()
 
-    def test_redirects_to_profile(self, client):
+    def test_continue_without_checkbox_advances_to_step5(self, client):
         _wizard_through_step3(client)
+        r = client.post("/setup/4", data={"action": "continue"})
+        assert r.status_code == 200
+        assert b"Investment" in r.content or b"investment" in r.content.lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests — POST /setup/5 (investments) + /setup/6 (final)
+# ---------------------------------------------------------------------------
+
+
+class TestSetupStep5And6:
+    def _through_step4(self, client):
+        _wizard_through_step3(client)
+        client.post("/setup/4", data={"action": "skip"})
+
+    def test_step5_skip_advances_to_step6(self, client):
+        self._through_step4(client)
+        r = client.post("/setup/5", data={"action": "skip"})
+        assert r.status_code == 200
+        assert b"set" in r.content.lower() or b"Dashboard" in r.content
+
+    def test_apply_initial_setup_called_at_step6(self, client):
+        self._through_step4(client)
+        client.post("/setup/5", data={"action": "skip"})
         with patch("server.main.apply_initial_setup") as mock_setup:
             mock_setup.return_value = {
                 "status": "ok",
@@ -312,14 +327,19 @@ class TestSetupStep4:
                 "line_items_created": 0,
                 "hints_created": 0,
                 "banks_to_link": [],
+                "properties_created": 0,
+                "investment_ledger_id": None,
+                "cron_registered": False,
             }
-            r = client.post("/setup/4", data={})
+            r = client.post("/setup/6", data={})
+        mock_setup.assert_called_once()
         assert r.status_code == 302
         assert r.headers["location"] == "/dashboard"
 
     def test_session_allows_profile_access_after_setup(self, client):
         """Session set during step 1 should let the client reach /profile."""
-        _wizard_through_step3(client)
+        self._through_step4(client)
+        client.post("/setup/5", data={"action": "skip"})
         with patch("server.main.apply_initial_setup") as mock_setup:
             mock_setup.return_value = {
                 "status": "ok",
@@ -327,9 +347,11 @@ class TestSetupStep4:
                 "line_items_created": 0,
                 "hints_created": 0,
                 "banks_to_link": [],
+                "properties_created": 0,
+                "investment_ledger_id": None,
+                "cron_registered": False,
             }
-            client.post("/setup/4", data={})
-        # Session cookie was set at step 1; profile should be accessible now.
+            client.post("/setup/6", data={})
         r = client.get("/profile")
         assert r.status_code == 200
 
@@ -342,6 +364,8 @@ class TestSetupStep4:
 class TestSetupAfterComplete:
     def _complete(self, client):
         _wizard_through_step3(client)
+        client.post("/setup/4", data={"action": "skip"})
+        client.post("/setup/5", data={"action": "skip"})
         with patch("server.main.apply_initial_setup") as mock_setup:
             mock_setup.return_value = {
                 "status": "ok",
@@ -349,8 +373,11 @@ class TestSetupAfterComplete:
                 "line_items_created": 0,
                 "hints_created": 0,
                 "banks_to_link": [],
+                "properties_created": 0,
+                "investment_ledger_id": None,
+                "cron_registered": False,
             }
-            client.post("/setup/4", data={})
+            client.post("/setup/6", data={})
 
     def test_get_setup_returns_404(self, client):
         self._complete(client)

--- a/tests/test_ui_ledgers.py
+++ b/tests/test_ui_ledgers.py
@@ -58,7 +58,11 @@ def _complete_setup(client: TestClient, password: str = "testpass123") -> None:
     assert r.status_code == 200
     r = client.post("/setup/3", data={"ledger_name": "Personal"})
     assert r.status_code == 200
-    r = client.post("/setup/4", data={})
+    r = client.post("/setup/4", data={"action": "skip"})
+    assert r.status_code == 200
+    r = client.post("/setup/5", data={"action": "skip"})
+    assert r.status_code == 200
+    r = client.post("/setup/6", data={})
     assert r.status_code == 302
 
 

--- a/tests/test_ui_routes.py
+++ b/tests/test_ui_routes.py
@@ -80,13 +80,21 @@ def _complete_setup(client: TestClient, password: str = "testpassword123") -> No
     r = client.post("/setup/2", data={"notification_pref": "openclaw"})
     assert r.status_code == 200, f"Setup step 2 failed: {r.status_code}"
 
-    # Step 3: ledger name
+    # Step 3: bank link (skip)
     r = client.post("/setup/3", data={"ledger_name": "Personal"})
     assert r.status_code == 200, f"Setup step 3 failed: {r.status_code}"
 
-    # Step 4: final — should redirect to /profile
-    r = client.post("/setup/4", data={})
-    assert r.status_code == 302, f"Setup step 4 failed: {r.status_code}"
+    # Step 4: rental properties (skip)
+    r = client.post("/setup/4", data={"action": "skip"})
+    assert r.status_code == 200, f"Setup step 4 failed: {r.status_code}"
+
+    # Step 5: investment accounts (skip)
+    r = client.post("/setup/5", data={"action": "skip"})
+    assert r.status_code == 200, f"Setup step 5 failed: {r.status_code}"
+
+    # Step 6: final — should redirect to /dashboard
+    r = client.post("/setup/6", data={})
+    assert r.status_code == 302, f"Setup step 6 failed: {r.status_code}"
     assert r.headers["location"] == "/dashboard"
 
 

--- a/ui/server.py
+++ b/ui/server.py
@@ -472,18 +472,93 @@ async def setup_post(request: Request, step: int):
     elif step == 3:
         bl = (form.get("action") or "").strip() == "done"
         ch = state.get("notification_channel", _get_notification_channel())
+        # Gather linked accounts for the property step dropdown.
+        uid = _current_user_id(request)
+        accounts = _get_accounts(uid)
         ns = {**state, "step": 4, "bank_linked": bl, "error": None}
         resp = templates.TemplateResponse(
             request,
             "setup.html",
-            {"step": 4, "error": None, "notification_channel": ch, "bank_linked": bl},
+            {
+                "step": 4,
+                "error": None,
+                "notification_channel": ch,
+                "bank_linked": bl,
+                "accounts": accounts,
+            },
         )
         _update_wizard(resp, tok, ns)
         return resp
     elif step == 4:
+        # Rental properties step.
+        action = (form.get("action") or "").strip()
+        rental_properties: list[dict] = []
+        if action != "skip" and form.get("has_properties") == "yes":
+            names = form.getlist("property_name[]")
+            descriptions = form.getlist("property_description[]")
+            account_ids = form.getlist("property_account_id[]")
+            for name_val, desc_val, acct_val in zip(names, descriptions, account_ids):
+                name_val = name_val.strip()
+                if name_val:
+                    rental_properties.append(
+                        {
+                            "name": name_val,
+                            "description": desc_val.strip() or None,
+                            "account_id": acct_val.strip() or None,
+                        }
+                    )
+        # Gather investment-candidate accounts for the next step.
+        uid = _current_user_id(request)
+        accounts = _get_accounts(uid)
+        investment_accounts = [
+            a
+            for a in accounts
+            if (
+                (a.get("type") or "").lower() == "investment"
+                or any(
+                    kw in (a.get("institution_name") or "").lower()
+                    for kw in ("wealthsimple", "questrade", "fidelity", "vanguard", "schwab")
+                )
+            )
+        ]
+        ns = {**state, "step": 5, "rental_properties": rental_properties, "error": None}
+        resp = templates.TemplateResponse(
+            request,
+            "setup.html",
+            {
+                "step": 5,
+                "error": None,
+                "investment_accounts": investment_accounts,
+            },
+        )
+        _update_wizard(resp, tok, ns)
+        return resp
+    elif step == 5:
+        # Investment accounts step.
+        action = (form.get("action") or "").strip()
+        investment_account_ids: list[str] = []
+        if action != "skip":
+            investment_account_ids = [v for v in form.getlist("investment_account_id") if v]
+        ns = {**state, "step": 6, "investment_account_ids": investment_account_ids, "error": None}
+        resp = templates.TemplateResponse(
+            request,
+            "setup.html",
+            {"step": 6, "error": None},
+        )
+        _update_wizard(resp, tok, ns)
+        return resp
+    elif step == 6:
         import server.main as _sm
 
-        _sm.apply_initial_setup(banks_to_link=[], extra_ledgers=[], hints=[])
+        rental_properties = state.get("rental_properties") or []
+        investment_account_ids = state.get("investment_account_ids") or []
+        _sm.apply_initial_setup(
+            banks_to_link=[],
+            extra_ledgers=[],
+            hints=[],
+            rental_properties=rental_properties,
+            investment_account_ids=investment_account_ids,
+        )
         redir = _redirect("/dashboard")
         st = state.get("session_token")
         if st:

--- a/ui/templates/setup.html
+++ b/ui/templates/setup.html
@@ -15,7 +15,11 @@
     <span class="sep">›</span>
     <span class="step {% if step == 3 %}active{% elif step > 3 %}done{% endif %}">3 · Connect Bank</span>
     <span class="sep">›</span>
-    <span class="step {% if step == 4 %}active{% endif %}">4 · Done</span>
+    <span class="step {% if step == 4 %}active{% elif step > 4 %}done{% endif %}">4 · Properties</span>
+    <span class="sep">›</span>
+    <span class="step {% if step == 5 %}active{% elif step > 5 %}done{% endif %}">5 · Investments</span>
+    <span class="sep">›</span>
+    <span class="step {% if step == 6 %}active{% endif %}">6 · Done</span>
   </div>
 
   {% if error %}
@@ -105,13 +109,87 @@
   </form>
   {% endif %}
 
-  <!-- ── Step 4: All done ──────────────────────────────────────────── -->
+  <!-- ── Step 4: Rental properties ─────────────────────────────────── -->
   {% elif step == 4 %}
-  <form method="post" action="/setup/4">
-    <h2>You&#39;re all set!</h2>
+  <form method="post" action="/setup/4" id="properties-form">
+    <h2>Rental properties</h2>
+    <p>Do you have any rental properties you'd like to track?</p>
+    <label style="display:flex;align-items:center;gap:8px;">
+      <input type="checkbox" id="has-properties" name="has_properties" value="yes"
+             onchange="toggleProperties(this)" />
+      Yes, I have rental properties
+    </label>
+
+    <div id="properties-section" style="display:none;margin-top:16px;">
+      <div id="property-list">
+        <div class="property-entry" style="border:1px solid #ddd;padding:12px;margin-bottom:8px;border-radius:6px;">
+          <label>Property name <span style="color:red">*</span></label>
+          <input type="text" name="property_name[]" placeholder="e.g. 123 Main St" />
+          <label>Description (optional)</label>
+          <input type="text" name="property_description[]" placeholder="e.g. 2-bed condo, downtown" />
+          <label>Linked bank account (optional)</label>
+          <select name="property_account_id[]">
+            <option value="">— none —</option>
+            {% for account in accounts %}
+            <option value="{{ account.id }}">{{ account.institution_name }} – {{ account.name }}{% if account.mask %} (…{{ account.mask }}){% endif %}</option>
+            {% endfor %}
+          </select>
+        </div>
+      </div>
+      <button type="button" class="btn-secondary" onclick="addProperty()">+ Add another property</button>
+    </div>
+
+    <div style="margin-top:20px;display:flex;gap:10px;">
+      <button type="submit" name="action" value="continue" class="btn-primary">Continue →</button>
+      <button type="submit" name="action" value="skip" class="btn-secondary">Skip</button>
+    </div>
+  </form>
+
+  <script>
+  function addProperty() {
+    var list = document.getElementById('property-list');
+    var first = list.querySelector('.property-entry');
+    var clone = first.cloneNode(true);
+    clone.querySelectorAll('input').forEach(function(i) { i.value = ''; });
+    clone.querySelectorAll('select').forEach(function(s) { s.selectedIndex = 0; });
+    list.appendChild(clone);
+  }
+  function toggleProperties(cb) {
+    document.getElementById('properties-section').style.display = cb.checked ? 'block' : 'none';
+  }
+  </script>
+
+  <!-- ── Step 5: Investment accounts ───────────────────────────────── -->
+  {% elif step == 5 %}
+  <form method="post" action="/setup/5">
+    <h2>Investment accounts</h2>
+    <p>Do you have investment accounts? (e.g. Wealthsimple, Questrade, TFSA, RRSP)</p>
+
+    {% if investment_accounts %}
+    <p>The following linked accounts look like investment accounts. Check any you'd like to track in an <strong>Investments</strong> ledger:</p>
+    {% for account in investment_accounts %}
+    <label style="display:flex;align-items:center;gap:8px;margin-bottom:6px;">
+      <input type="checkbox" name="investment_account_id" value="{{ account.id }}" checked />
+      {{ account.institution_name }} – {{ account.name }}{% if account.mask %} (…{{ account.mask }}){% endif %}
+    </label>
+    {% endfor %}
+    {% else %}
+    <p style="color:#888;">No investment accounts detected among your linked accounts. You can link them later from your profile.</p>
+    {% endif %}
+
+    <div style="margin-top:20px;display:flex;gap:10px;">
+      <button type="submit" name="action" value="continue" class="btn-primary">Continue →</button>
+      <button type="submit" name="action" value="skip" class="btn-secondary">Skip</button>
+    </div>
+  </form>
+
+  <!-- ── Step 6: All done ──────────────────────────────────────────── -->
+  {% elif step == 6 %}
+  <form method="post" action="/setup/6">
+    <h2>You're all set!</h2>
     <p>Setup is complete. Head to your <strong>profile</strong> to manage linked banks,
        notification settings, and more.</p>
-    <button type="submit" class="btn-primary">Go to Profile →</button>
+    <button type="submit" class="btn-primary">Go to Dashboard →</button>
   </form>
   {% endif %}
 </div>


### PR DESCRIPTION
Closes #176

## Summary

Extends the first-run setup wizard from 4 steps to 6, adding interactive prompts for rental properties and investment accounts.

### What changed

**Wizard steps (ui/templates/setup.html + ui/server.py)**
- Step 4 — Rental properties: optional checkbox reveals a dynamic form to add 1+ properties (name, description, linked bank account dropdown). "Add another property" button clones the entry.
- Step 5 — Investment accounts: shows linked accounts that look like investment accounts (type=investment or institution contains Wealthsimple/Questrade/Fidelity/etc.). Checkbox per account tracks in a shared "Investments" ledger.
- Step 6 — Done (was step 4): calls `apply_initial_setup` with all accumulated wizard state.

**MCP tool (server/main.py)**
```python
def apply_initial_setup(
    banks_to_link: list = None,
    extra_ledgers: list = None,
    hints: list = None,
    rental_properties: list = None,   # new — [{name, description?, account_id?}]
    investment_account_ids: list = None,  # new — [account_id, ...]
) -> dict
```
- Each rental property calls `create_property_ledger()` + `set_account_ledger()`
- Non-empty investment_account_ids creates one "Investments" ledger and links all accounts
- Returns `properties_created` count and `investment_ledger_id`
- Fully backward-compatible (all new params optional, default None)

**Tests (tests/test_setup_properties.py — 17 new tests)**
- MCP: creates property ledger, links account, no-account-id skips link, empty list no-op, investments together
- UI: step 4 renders/skip, step 5 renders/skip, step 6 calls apply_initial_setup with stored state
- Updated all existing `_complete_setup` helpers in 7 test files to drive through 6 steps

**Docs**
- ARCHITECTURE.md: wizard section updated to 6 steps, apply_initial_setup signature docs
- README.md: First Run section updated to 6 steps with descriptions

## Interactive check

```
apply_initial_setup(
    rental_properties=[{"name": "Test Prop", "description": "test", "account_id": "<uuid>"}],
    investment_account_ids=[]
)
→ {'status': 'ok', 'ledgers_created': ['Personal', 'Test Prop'], 'line_items_created': 10,
   'hints_created': 0, 'banks_to_link': [], 'cron_registered': False,
   'properties_created': 1, 'investment_ledger_id': None}

list_ledgers()
→ Personal (10 items: Salary/Groceries/Dining/…)
  Test Prop (6 items: Rent income, Mortgage, Property tax, Maintenance & repairs, Insurance, Utilities)
```

CI: black ✓ ruff ✓ pytest 663 passed, 7 skipped ✓