### PR TITLE
[Infra] SKILL.md sync check: CI job + script (#190)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,16 @@ jobs:
       - name: Check test isolation (no hard-coded production paths)
         run: python3 scripts/check_test_isolation.py
 
+  skill-md-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Check SKILL.md is in sync with MCP tools
+        run: python3 scripts/check_skill_md_sync.py
+
   integration:
     runs-on: ubuntu-latest
     needs: unit          # only run if unit tests pass

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,16 @@ If nothing in these files needs updating for your ticket, add a note in the PR b
   queries, and response shapes end-to-end.  Run them with
   `python3 -m pytest tests/integration/ -v`.
 
+## MCP Tool Changes Require SKILL.md Updates
+
+Any PR that adds, removes, or renames an `@mcp.tool` in `server/main.py` **must** update `SKILL.md` in the same commit:
+
+- Add new tools to the correct section under `## Available MCP Tools`
+- Include: tool name, one-line description, and key parameters
+- Remove or correct entries for deleted/renamed tools
+
+The `skill-md-sync` CI job enforces this automatically — PRs that drift will fail CI.
+
 ## Anti-Patterns (Don't Do These)
 
 - ❌ Refactoring code outside your ticket

--- a/SKILL.md
+++ b/SKILL.md
@@ -105,6 +105,7 @@ Invoke for any personal finance request:
 
 ### Ledgers
 - `list_ledgers` — show all ledgers (personal/property/investment) and their line items
+- `get_ledger(ledger_id, period?)` — get a single ledger with all line items and classified transactions for the period
 - `add_ledger(name)` — create a new ledger
 - `add_line_item(ledger_id, name, item_type)` — add a line item (`income | expense`) to a ledger
 - `remove_line_item(id)` — remove a line item

--- a/SWARM.md
+++ b/SWARM.md
@@ -44,6 +44,7 @@ For each open PR (`gh pr list --state open`):
   - CONTRIBUTING.md anti-patterns
   - Interactive check line present in PR body (required for UI + MCP tickets)
 - **Documentation check:** verify the PR updates ARCHITECTURE.md, README.md, and the route overview comment where relevant. If docs are missing, request changes — do not merge undocumented behaviour changes.
+- **SKILL.md check:** if the PR adds, removes, or renames any `@mcp.tool` in `server/main.py`, verify SKILL.md is updated in the same commit. The `skill-md-sync` CI job catches this automatically — a green CI badge is sufficient; reject if it's red.
 - **Decide:**
   - ✅ Looks good + CI green → `gh pr review --approve`, then `gh pr merge --squash --delete-branch`
   - ❌ Issues → `gh pr review --request-changes --body "<specific feedback>"`, leave PR open. Worker will fix and re-push.

--- a/scripts/check_skill_md_sync.py
+++ b/scripts/check_skill_md_sync.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""
+check_skill_md_sync.py
+~~~~~~~~~~~~~~~~~~~~~~
+Verify that every @mcp.tool in server/main.py is documented in SKILL.md and
+vice-versa.  Exits 0 when in sync; exits 1 with a diff when not.
+
+Usage:
+    python3 scripts/check_skill_md_sync.py        # from repo root
+"""
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Paths (relative to repo root)
+# ---------------------------------------------------------------------------
+MAIN_PY = Path("server/main.py")
+SKILL_MD = Path("SKILL.md")
+
+# ---------------------------------------------------------------------------
+# Names that appear in SKILL.md for reasons other than being MCP tools
+# (e.g. code-block examples, prose references).  Add here if the regex
+# produces false positives.
+# ---------------------------------------------------------------------------
+SKILL_MD_IGNORE: set[str] = set()
+
+
+def get_mcp_tools_in_code() -> set[str]:
+    """Return the set of function names decorated with @mcp.tool in main.py."""
+    src = MAIN_PY.read_text(encoding="utf-8")
+    tree = ast.parse(src, filename=str(MAIN_PY))
+    tools: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            for dec in node.decorator_list:
+                d_str = ast.unparse(dec) if hasattr(ast, "unparse") else ""
+                if "mcp.tool" in d_str:
+                    tools.append(node.name)
+                    break
+    return set(tools)
+
+
+def get_mcp_tools_in_skill_md() -> set[str]:
+    """
+    Extract tool names referenced in the MCP-tools section of SKILL.md.
+
+    Recognises two list-item patterns used throughout the file:
+      - `tool_name`        (no-arg tools, e.g. ``- `sync` — …``)
+      - `tool_name(…`      (tools with parameters,  e.g. ``- `list(filters?)` — …``)
+
+    Only lines that start with "- `" are considered to avoid picking up inline
+    mentions in prose or code examples.
+    """
+    text = SKILL_MD.read_text(encoding="utf-8")
+    found: set[str] = set()
+    for line in text.splitlines():
+        stripped = line.strip()
+        # Must be a bullet-list item starting with a backtick-quoted identifier
+        m = re.match(r"^- `([a-z_][a-z0-9_]*)(?:\(|`)", stripped)
+        if m:
+            found.add(m.group(1))
+    return found - SKILL_MD_IGNORE
+
+
+def main() -> None:
+    if not MAIN_PY.exists():
+        print(f"ERROR: {MAIN_PY} not found — run from repo root.", file=sys.stderr)
+        sys.exit(2)
+    if not SKILL_MD.exists():
+        print(f"ERROR: {SKILL_MD} not found — run from repo root.", file=sys.stderr)
+        sys.exit(2)
+
+    in_code = get_mcp_tools_in_code()
+    in_doc = get_mcp_tools_in_skill_md()
+
+    missing_doc = in_code - in_doc  # in code but not documented
+    missing_code = in_doc - in_code  # documented but not in code
+
+    if missing_doc:
+        print("❌  Tools in server/main.py but MISSING from SKILL.md:")
+        for t in sorted(missing_doc):
+            print(f"     - {t}")
+
+    if missing_code:
+        print("❌  Tools in SKILL.md but NOT FOUND in server/main.py")
+        print("    (renamed or deleted without updating the docs?):")
+        for t in sorted(missing_code):
+            print(f"     - {t}")
+
+    if missing_doc or missing_code:
+        sys.exit(1)
+
+    print(f"✅  OK — {len(in_code)} MCP tools, all documented in SKILL.md")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_skill_md_sync.py
+++ b/tests/test_skill_md_sync.py
@@ -1,0 +1,147 @@
+"""
+tests/test_skill_md_sync.py
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Regression tests for scripts/check_skill_md_sync.py.
+
+1. Running against the real repo exits 0 (code + docs in sync).
+2. Synthetic: adding a fake @mcp.tool that's absent from SKILL.md → exits 1.
+3. Synthetic: adding a fake tool entry to SKILL.md absent from code → exits 1.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "check_skill_md_sync.py"
+
+
+def _run(cwd: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Real repo must be in sync
+# ---------------------------------------------------------------------------
+
+
+def test_real_repo_is_in_sync():
+    """scripts/check_skill_md_sync.py exits 0 on the current repo."""
+    result = _run(REPO_ROOT)
+    assert result.returncode == 0, (
+        "SKILL.md is out of sync with server/main.py!\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+    assert "OK" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a minimal fake repo tree in tmp_path
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_repo(tmp_path: Path, extra_code_tool: str = "", extra_doc_tool: str = "") -> Path:
+    """
+    Create a stripped-down repo with:
+      - server/main.py  — one real @mcp.tool (real_tool) + optional extra
+      - SKILL.md        — documents real_tool + optional extra
+    Returns tmp_path.
+    """
+    server_dir = tmp_path / "server"
+    server_dir.mkdir(parents=True)
+
+    extra_code_block = ""
+    if extra_code_tool:
+        extra_code_block = (
+            f"\n@mcp.tool\n" f"def {extra_code_tool}() -> dict:\n" f"    return {{}}\n"
+        )
+
+    # Build main.py without textwrap.dedent so embedded extra_code_block
+    # (which has no leading indent) does not confuse the common-prefix calc.
+    main_py_lines = [
+        "class _MCP:",
+        "    @staticmethod",
+        "    def tool(fn=None):",
+        "        if fn is None:",
+        "            return lambda f: f",
+        "        return fn",
+        "",
+        "mcp = _MCP()",
+        "",
+        "@mcp.tool",
+        "def real_tool() -> dict:",
+        "    return {}",
+    ]
+    main_py_content = "\n".join(main_py_lines) + "\n" + extra_code_block
+    (server_dir / "main.py").write_text(main_py_content, encoding="utf-8")
+
+    extra_doc_line = ""
+    if extra_doc_tool:
+        extra_doc_line = f"- `{extra_doc_tool}` — a phantom tool\n"
+
+    skill_md_content = (
+        "---\n"
+        "name: test-skill\n"
+        "description: test\n"
+        "---\n"
+        "## Available MCP Tools\n"
+        "- `real_tool` — does the real thing\n" + extra_doc_line
+    )
+    (tmp_path / "SKILL.md").write_text(skill_md_content, encoding="utf-8")
+
+    # Copy the script into scripts/
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "check_skill_md_sync.py").write_text(
+        SCRIPT.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# 2. Fake @mcp.tool not in SKILL.md → exits 1
+# ---------------------------------------------------------------------------
+
+
+def test_missing_from_skill_md_fails(tmp_path):
+    """A tool in code but absent from SKILL.md must be flagged (exit 1)."""
+    repo = _make_fake_repo(tmp_path, extra_code_tool="undocumented_tool")
+    result = _run(repo)
+    assert result.returncode == 1, "Expected exit 1 when code has undocumented tool"
+    assert "undocumented_tool" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# 3. Fake SKILL.md entry not in code → exits 1
+# ---------------------------------------------------------------------------
+
+
+def test_missing_from_code_fails(tmp_path):
+    """A tool documented in SKILL.md but absent from code must be flagged (exit 1)."""
+    repo = _make_fake_repo(tmp_path, extra_doc_tool="phantom_tool")
+    result = _run(repo)
+    assert result.returncode == 1, "Expected exit 1 when SKILL.md documents a ghost tool"
+    assert "phantom_tool" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# 4. Synthetic in-sync repo exits 0
+# ---------------------------------------------------------------------------
+
+
+def test_synthetic_in_sync_passes(tmp_path):
+    """A minimal synthetic repo with code and docs in sync exits 0."""
+    repo = _make_fake_repo(tmp_path)
+    result = _run(repo)
+    assert (
+        result.returncode == 0
+    ), f"Expected exit 0 for in-sync repo.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    assert "OK" in result.stdout


### PR DESCRIPTION
Closes #190

## Summary

Adds a lightweight CI guard that prevents `server/main.py` and `SKILL.md` from drifting apart in future PRs.

### What's in this PR

| File | Change |
|------|--------|
| `scripts/check_skill_md_sync.py` | New: pure-stdlib script that AST-parses `@mcp.tool` defs from code and line-scans SKILL.md, diffs the two, exits 1 on any mismatch |
| `.github/workflows/test.yml` | New `skill-md-sync` CI job that runs the script on every push/PR |
| `CONTRIBUTING.md` | Rule: any PR adding/removing/renaming an `@mcp.tool` must update SKILL.md |
| `SWARM.md` | PM checklist: SKILL.md check; CI badge is enforcement |
| `SKILL.md` | Fix: add `get_ledger(ledger_id, period?)` which was introduced in #175 but missed by the 3268738 bulk update |
| `tests/test_skill_md_sync.py` | 4 tests: real repo exits 0, undocumented code tool → exits 1, phantom doc entry → exits 1, synthetic in-sync → exits 0 |

**Interactive check:**
```
✅  OK — 42 MCP tools, all documented in SKILL.md
```

### Note on SKILL.md fix

The `get_ledger` tool (added in #175, commit 9d51c20) was absent from SKILL.md — the script caught this immediately, confirming the check works. Fixed in this same commit per the rule we're introducing.