### PR TITLE
[P4] Auto-categorize transactions into line items (#165)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -296,14 +296,28 @@ That's the whole API. ~15 tools.
 ```
 New transaction
    │
+   ├─▶ classify_pending_transactions(user_id)  (#165)
+   │     Runs after sync completes (or can be called standalone).
+   │     Finds all non-pending transactions with no transaction_entries row.
+   │     For each:
+   │       1. Build tx dict (merchant, amount, date, account, plaid_category)
+   │       2. get_transfer_hint() → possible_internal_transfer context
+   │       3. classify_with_rules(tx, rules, context)  (see Tier 1 v2 below)
+   │       4. classification_type='skip' → skip entry (no line_item)
+   │       5. line_item_id set → write transaction_entries row directly
+   │       6. line_item_id=None + account.default_ledger_id set → fallback
+   │            income → first income line_item in that ledger
+   │            other  → first expense line_item in that ledger
+   │       7. No fallback found → uncertain entry (surfaces in get_needs_review)
+   │     Returns { classified: N, skipped: M, uncertain: K }
+   │
    ├─▶ Tier 1 v2: classify_with_rules()  (LLM-first, #170)
    │     Passes the full priority-ordered classification_rules list to the
    │     LLM.  First matching rule wins.  Returns:
    │       { rule_id, line_item_id, classification_type, confidence,
    │         uncertain, reasoning }
-   │     Optional context: possible_internal_transfer hint (#171),
+   │     Optional context: possible_internal_transfer hint,
    │     recent_corrections.
-   │     Results available for #165 to write to transaction_entries.
    │
    ├─▶ Tier 1 legacy: apply_rules() (substring matching, routing_rules)
    │     Still runs for backward-compat; new writes use classify_with_rules.
@@ -322,12 +336,23 @@ New transaction
 After 3 successful LLM classifications of the same merchant, auto-promote
 to a legacy Tier-1 routing_rule. System gets cheaper and faster over time.
 
+### classify_pending_transactions — key design notes (#165)
+- Called automatically at the end of `sync()`. Errors are logged but never
+  block the sync response.
+- Idempotent: already-classified transactions (any `transaction_entries` row)
+  are skipped on every call.
+- Pending transactions (`pending=1`) are never classified.
+- `classification_type='skip'` writes a `skip` entry so the transaction
+  is not re-evaluated on the next run.
+- When `line_item_id=None` from the LLM and the account has a
+  `default_ledger_id`, a fallback line item is selected from that ledger.
+- Transactions that cannot be routed get an unrouted entry with
+  `uncertain=1` and surface in `get_needs_review()`.
+
 ### classify_with_rules — key design notes
 - Disabled rules (`enabled=0`) are excluded from the LLM prompt.
 - `uncertain=True` when `confidence < 0.7`.
-- Does NOT write to `transaction_entries` — that is #165's responsibility.
-- The sync loop (`server/main.py`) calls it as a read-only integration point
-  and logs the result at DEBUG level for now.
+- Writes to `transaction_entries` via `classify_pending_transactions`.
 
 ### Transfer Detection
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ other MCP client).
 
 ## What AI Does for You
 
+After every sync, `classify_pending_transactions` automatically routes all
+newly imported transactions into your ledger line items.  No manual step
+needed — just sync and your budget is up to date.
+
 Every transaction goes through a three-tier classifier:
 
 1. **Rules (LLM-first)** - the LLM evaluates your priority-ordered
@@ -175,7 +179,13 @@ Every transaction goes through a three-tier classifier:
    reasons about the transaction using your hints, full ledger tree, and
    recent similar transactions, and auto-routes if confident enough.
 3. **Review queue** - if it's unsure, the transaction lands in a review
-   queue. You'll get a notification through your chosen channel.
+   queue (`get_needs_review`). You'll get a notification through your
+   chosen channel.
+
+**Transfer detection**: before classification, each transaction is checked
+against internal transfer pairs (same amount, different accounts, within
+3 days). Detected transfers are passed as context to the LLM so they are
+classified as `transfer` rather than `spending`.
 
 After 3 successful classifications of the same merchant, it becomes a
 Tier 1 legacy rule automatically. The longer you use it, the less it asks.

--- a/SKILL.md
+++ b/SKILL.md
@@ -115,7 +115,7 @@ Invoke for any personal finance request:
 ### Transactions
 - `sync` — pull latest transactions from all connected banks
 - `list(filters?)` — query transactions (supports date, ledger, category, account filters)
-- `get_needs_review` — transactions awaiting classification or flagged as uncertain
+- `get_needs_review` — transactions that need manual review: uncertain classifications (confidence < 0.7) or unrouted transactions with no line item assigned
 - `route(transaction_id, allocations)` — manually assign a transaction to a ledger/line item
 - `add_hint(text)` — add a natural-language classification hint for the LLM
 - `list_hints` — list all classification hints

--- a/server/main.py
+++ b/server/main.py
@@ -30,6 +30,7 @@ from server.db import get_db
 from server.db import transaction as db_txn
 from server.providers.plaid import PlaidProvider
 from server.sync_lock import LockBusy, sync_lock
+from server.transfer_detect import get_transfer_hint
 from ui.auth import (
     add_recovery_token,
     get_active_user_id,
@@ -1213,6 +1214,217 @@ def create_investment_ledger(name: str) -> dict:
 # ---------------------------------------------------------------------------
 
 
+def classify_pending_transactions(user_id: str) -> dict:
+    """Classify all unclassified transactions for *user_id* and write entries.
+
+    Finds transactions owned by *user_id* that have no row in
+    ``transaction_entries``, then for each one:
+
+    1. Builds a rich transaction dict (merchant, amount, date, account
+       name/description, plaid_category).
+    2. Calls :func:`get_transfer_hint` to check for possible internal
+       transfers and passes the result as context to the LLM.
+    3. Calls :func:`classify_with_rules` with the active
+       ``classification_rules`` and the transfer hint.
+    4. If ``classification_type == 'skip'`` → no entry is written; counted
+       as skipped.
+    5. If ``line_item_id`` is set → inserts a ``transaction_entries`` row
+       linking the transaction to that line item.
+    6. If ``line_item_id`` is None but the owning account has a
+       ``default_ledger_id`` → picks a fallback line item from that ledger
+       (first income item for 'income', first expense item for all others).
+    7. If no fallback is found → transaction is left unrouted and counted
+       as 'uncertain'.
+
+    Already-classified transactions (any existing row in
+    ``transaction_entries``) are always skipped → idempotent.
+
+    Args:
+        user_id: The user whose transactions to classify.
+
+    Returns:
+        ``{"classified": N, "skipped": M, "uncertain": K}``
+    """
+    classified = 0
+    skipped = 0
+    uncertain = 0
+
+    if not user_id:
+        return {"classified": classified, "skipped": skipped, "uncertain": uncertain}
+
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        # Fetch rules once — shared across all transactions in this pass.
+        rules_result = list_rules()
+        rules = rules_result.get("rules", [])
+
+        # Fetch all unclassified, non-pending transactions for this user.
+        unclassified = conn.execute(
+            """
+            SELECT t.id, t.merchant, t.amount, t.date,
+                   t.plaid_category, t.bank_account_id
+            FROM transactions t
+            JOIN bank_accounts ba ON ba.id = t.bank_account_id
+            JOIN bank_connections bc ON bc.id = ba.connection_id
+            WHERE bc.user_id = ?
+              AND t.pending = 0
+              AND NOT EXISTS (
+                SELECT 1 FROM transaction_entries te
+                WHERE te.transaction_id = t.id
+              )
+            ORDER BY t.date ASC
+            """,
+            (user_id,),
+        ).fetchall()
+
+        for row in unclassified:
+            tx_id = row["id"]
+            merchant = row["merchant"] or ""
+            amount = row["amount"]
+            date = row["date"]
+            plaid_category = row["plaid_category"] or ""
+            bank_account_id = row["bank_account_id"]
+
+            # Enrich with account context.
+            ba_row = conn.execute(
+                "SELECT name, description, default_ledger_id FROM bank_accounts WHERE id = ?",
+                (bank_account_id,),
+            ).fetchone()
+            account_name = ba_row["name"] if ba_row else None
+            account_description = ba_row["description"] if ba_row else None
+            default_ledger_id = ba_row["default_ledger_id"] if ba_row else None
+
+            tx_dict = {
+                "merchant": merchant,
+                "amount": amount,
+                "date": date,
+                "account_name": account_name,
+                "account_description": account_description,
+                "plaid_category": plaid_category,
+            }
+
+            # Build transfer hint context.
+            try:
+                hint = get_transfer_hint(tx_id, str(server.paths.DB_PATH))
+            except Exception:
+                hint = None
+
+            context: dict | None = None
+            if hint and hint.get("is_possible_transfer"):
+                context = {"possible_internal_transfer": True}
+
+            # Run classifier.
+            try:
+                result = classify_with_rules(tx_dict, rules, context)
+            except Exception as exc:
+                _logger.warning(
+                    "classify_pending_transactions: classify_with_rules failed for " "tx_id=%s: %s",
+                    tx_id,
+                    exc,
+                )
+                uncertain += 1
+                continue
+
+            classification_type = result.get("classification_type", "spending")
+            line_item_id = result.get("line_item_id")
+            confidence = float(result.get("confidence", 0.0))
+            is_uncertain = bool(result.get("uncertain", False))
+            reasoning = result.get("reasoning", "")
+
+            # skip → don't write entry.
+            if classification_type == "skip":
+                # Still write a skip entry so we don't re-process.
+                entry_id = str(uuid.uuid4())
+                conn.execute(
+                    "INSERT OR IGNORE INTO transaction_entries "
+                    "(id, transaction_id, ledger_id, line_item_id, amount, "
+                    " entry_type, source, confidence, uncertain, reasoning, reviewed) "
+                    "VALUES (?, ?, NULL, NULL, ?, 'skip', 'llm', ?, ?, ?, 0)",
+                    (entry_id, tx_id, amount, confidence, 1 if is_uncertain else 0, reasoning),
+                )
+                conn.commit()
+                skipped += 1
+                continue
+
+            # Resolve ledger_id from line_item if we have one.
+            ledger_id = None
+            if line_item_id:
+                li_row = conn.execute(
+                    "SELECT ledger_id FROM line_items WHERE id = ?",
+                    (line_item_id,),
+                ).fetchone()
+                if li_row:
+                    ledger_id = li_row["ledger_id"]
+                else:
+                    # line_item_id is stale/invalid; clear it.
+                    line_item_id = None
+
+            # Fallback: use default_ledger_id when no line_item routed.
+            if line_item_id is None and default_ledger_id:
+                if classification_type == "income":
+                    item_type_filter = "income"
+                else:
+                    item_type_filter = "expense"
+                fb_row = conn.execute(
+                    "SELECT id FROM line_items "
+                    "WHERE ledger_id = ? AND item_type = ? "
+                    "ORDER BY rowid ASC LIMIT 1",
+                    (default_ledger_id, item_type_filter),
+                ).fetchone()
+                if fb_row:
+                    line_item_id = fb_row["id"]
+                    ledger_id = default_ledger_id
+
+            if line_item_id is None:
+                # Could not route — mark uncertain and leave unrouted entry so
+                # get_needs_review() can surface it.
+                entry_id = str(uuid.uuid4())
+                conn.execute(
+                    "INSERT OR IGNORE INTO transaction_entries "
+                    "(id, transaction_id, ledger_id, line_item_id, amount, "
+                    " entry_type, source, confidence, uncertain, reasoning, reviewed) "
+                    "VALUES (?, ?, NULL, NULL, ?, ?, 'llm', ?, 1, ?, 0)",
+                    (
+                        entry_id,
+                        tx_id,
+                        amount,
+                        classification_type,
+                        confidence,
+                        reasoning,
+                    ),
+                )
+                conn.commit()
+                uncertain += 1
+                continue
+
+            # Write the classified entry.
+            entry_id = str(uuid.uuid4())
+            conn.execute(
+                "INSERT OR IGNORE INTO transaction_entries "
+                "(id, transaction_id, ledger_id, line_item_id, amount, "
+                " entry_type, source, confidence, uncertain, reasoning, reviewed) "
+                "VALUES (?, ?, ?, ?, ?, ?, 'llm', ?, ?, ?, 0)",
+                (
+                    entry_id,
+                    tx_id,
+                    ledger_id,
+                    line_item_id,
+                    amount,
+                    classification_type,
+                    confidence,
+                    1 if is_uncertain else 0,
+                    reasoning,
+                ),
+            )
+            conn.commit()
+            classified += 1
+
+    finally:
+        conn.close()
+
+    return {"classified": classified, "skipped": skipped, "uncertain": uncertain}
+
+
 @mcp.tool
 def sync() -> dict:
     """Pull new transactions from Plaid, classify them, and return a summary."""
@@ -1506,6 +1718,17 @@ def sync() -> dict:
                     total_removed += conn_removed
                     total_classified += conn_classified
 
+                # After all connections are synced, run auto-classification on
+                # any newly inserted (unclassified) transactions.  Errors are
+                # caught so a classification failure never blocks sync.
+                auto_classify_result = {"classified": 0, "skipped": 0, "uncertain": 0}
+                try:
+                    uid = get_active_user_id(server.paths.DB_PATH)
+                    if uid:
+                        auto_classify_result = classify_pending_transactions(uid)
+                except Exception as _exc:
+                    _logger.warning("Auto-classification after sync failed: %s", _exc)
+
             finally:
                 db_conn.close()
 
@@ -1519,6 +1742,9 @@ def sync() -> dict:
         "modified": total_modified,
         "removed": total_removed,
         "classified_by_rule": total_classified,
+        "auto_classified": auto_classify_result.get("classified", 0),
+        "auto_skipped": auto_classify_result.get("skipped", 0),
+        "auto_uncertain": auto_classify_result.get("uncertain", 0),
         "health_check": health_check_result,
     }
 
@@ -1591,8 +1817,59 @@ def list(filters: Optional[dict] = None) -> dict:
 
 @mcp.tool
 def get_needs_review() -> dict:
-    """Return transactions that require manual classification review."""
-    return list(filters={"reviewed": False})
+    """Return transactions that need manual classification review.
+
+    Returns transactions where the classifier was uncertain
+    (``uncertain=1`` in ``transaction_entries``) OR where no
+    ``line_item_id`` was assigned (unrouted), scoped to the active user.
+
+    Returns
+    -------
+    dict
+        ``{"transactions": [{id, merchant, amount, date, account_name,
+        reasoning}, ...]}``
+    """
+    uid = get_active_user_id(server.paths.DB_PATH)
+    if not uid:
+        return {"transactions": []}
+
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        rows = conn.execute(
+            """
+            SELECT t.id, t.merchant, t.amount, t.date,
+                   ba.name AS account_name,
+                   te.reasoning
+            FROM transaction_entries te
+            JOIN transactions t ON t.id = te.transaction_id
+            JOIN bank_accounts ba ON ba.id = t.bank_account_id
+            JOIN bank_connections bc ON bc.id = ba.connection_id
+            WHERE bc.user_id = ?
+              AND te.reviewed = 0
+              AND (
+                te.uncertain = 1
+                OR te.line_item_id IS NULL
+              )
+              AND te.entry_type != 'skip'
+            ORDER BY t.date DESC
+            """,
+            (uid,),
+        ).fetchall()
+        return {
+            "transactions": [
+                {
+                    "id": r["id"],
+                    "merchant": r["merchant"],
+                    "amount": r["amount"],
+                    "date": r["date"],
+                    "account_name": r["account_name"],
+                    "reasoning": r["reasoning"] or "",
+                }
+                for r in rows
+            ]
+        }
+    finally:
+        conn.close()
 
 
 @mcp.tool

--- a/tests/test_auto_categorize.py
+++ b/tests/test_auto_categorize.py
@@ -1,0 +1,490 @@
+"""
+tests/test_auto_categorize.py — Tests for auto-categorization of transactions (#165).
+
+Covers:
+- classify_pending_transactions: 3 transactions → 3 entries written (mocked LLM)
+- Idempotent: running classify_pending_transactions again does not double-write
+- classification_type='skip' → no entry written (entry type recorded as skip)
+- get_needs_review() returns uncertain transactions
+- No active user → graceful no-op (returns all zeros)
+- Fallback to default_ledger_id line item when LLM returns no line_item_id
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from server.db import get_db, init_db
+from server.main import classify_pending_transactions, get_needs_review
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _new_id() -> str:
+    return str(uuid.uuid4())
+
+
+def _seed_user(conn, username: str = "testuser") -> str:
+    user_id = _new_id()
+    conn.execute(
+        "INSERT INTO users (id, username, password_hash, created_at) VALUES (?, ?, ?, ?)",
+        (user_id, username, "hash", int(time.time())),
+    )
+    conn.commit()
+    return user_id
+
+
+def _seed_connection(conn, user_id: str) -> str:
+    conn_id = _new_id()
+    conn.execute(
+        "INSERT INTO bank_connections "
+        "(id, plaid_access_token_encrypted, institution_name, user_id, plaid_env) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (conn_id, "enc", "RBC", user_id, "sandbox"),
+    )
+    conn.commit()
+    return conn_id
+
+
+def _seed_account(conn, connection_id: str, default_ledger_id: str = None) -> str:
+    acct_id = _new_id()
+    conn.execute(
+        "INSERT INTO bank_accounts "
+        "(id, connection_id, plaid_account_id, name, type, default_ledger_id) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (acct_id, connection_id, _new_id(), "Chequing", "depository", default_ledger_id),
+    )
+    conn.commit()
+    return acct_id
+
+
+def _seed_ledger(conn, user_id: str, name: str = "Household") -> str:
+    ledger_id = _new_id()
+    conn.execute(
+        "INSERT INTO ledgers (id, name, user_id) VALUES (?, ?, ?)",
+        (ledger_id, name, user_id),
+    )
+    conn.commit()
+    return ledger_id
+
+
+def _seed_line_item(conn, ledger_id: str, name: str, item_type: str = "expense") -> str:
+    li_id = _new_id()
+    conn.execute(
+        "INSERT INTO line_items (id, ledger_id, name, item_type) VALUES (?, ?, ?, ?)",
+        (li_id, ledger_id, name, item_type),
+    )
+    conn.commit()
+    return li_id
+
+
+def _seed_transaction(
+    conn,
+    bank_account_id: str,
+    merchant: str = "Starbucks",
+    amount: float = 5.50,
+    date: str = "2024-01-01",
+    pending: int = 0,
+) -> str:
+    tx_id = _new_id()
+    conn.execute(
+        "INSERT INTO transactions "
+        "(id, bank_account_id, plaid_transaction_id, date, merchant, amount, pending) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (tx_id, bank_account_id, _new_id(), date, merchant, amount, pending),
+    )
+    conn.commit()
+    return tx_id
+
+
+def _seed_rule(
+    conn, name: str, rule_type: str, line_item_id: str = None, priority: int = 10
+) -> str:
+    rule_id = _new_id()
+    conn.execute(
+        "INSERT INTO classification_rules "
+        "(id, name, description, rule_type, line_item_id, priority, is_default, enabled, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, 0, 1, ?)",
+        (rule_id, name, f"Rule for {name}", rule_type, line_item_id, priority, int(time.time())),
+    )
+    conn.commit()
+    return rule_id
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_db(tmp_path: Path, monkeypatch):
+    """Create a fresh isolated DB and monkeypatch server.paths.DB_PATH."""
+    import server.paths
+
+    db_file = tmp_path / "test.db"
+    monkeypatch.setattr(server.paths, "DB_PATH", db_file)
+    init_db(db_file)
+    return db_file
+
+
+@pytest.fixture
+def db_env(tmp_db):
+    """Return (db_file, user_id, account_id, ledger_id, expense_li_id, income_li_id)."""
+    conn = get_db(tmp_db)
+    try:
+        user_id = _seed_user(conn)
+        conn_id = _seed_connection(conn, user_id)
+        ledger_id = _seed_ledger(conn, user_id)
+        expense_li_id = _seed_line_item(conn, ledger_id, "Groceries", "expense")
+        income_li_id = _seed_line_item(conn, ledger_id, "Salary", "income")
+        acct_id = _seed_account(conn, conn_id, default_ledger_id=ledger_id)
+    finally:
+        conn.close()
+    return {
+        "db": tmp_db,
+        "user_id": user_id,
+        "account_id": acct_id,
+        "ledger_id": ledger_id,
+        "expense_li_id": expense_li_id,
+        "income_li_id": income_li_id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def _make_llm_response(
+    classification_type: str, line_item_id: str = None, confidence: float = 0.9
+) -> str:
+    import json
+
+    return json.dumps(
+        {
+            "rule_id": None,
+            "line_item_id": line_item_id,
+            "classification_type": classification_type,
+            "confidence": confidence,
+            "reasoning": f"Classified as {classification_type}",
+        }
+    )
+
+
+class TestClassifyPendingTransactions:
+    def test_classifies_three_transactions(self, db_env):
+        """classify_pending_transactions should classify 3 unclassified txns."""
+        conn = get_db(db_env["db"])
+        try:
+            # Seed a rule pointing to the expense line item.
+            _seed_rule(conn, "Spending Rule", "spending", db_env["expense_li_id"], priority=10)
+            # Insert 3 transactions.
+            tx_ids = []
+            for i in range(3):
+                tx_ids.append(
+                    _seed_transaction(
+                        conn,
+                        db_env["account_id"],
+                        merchant=f"Merchant {i}",
+                        amount=float(10 + i),
+                        date=f"2024-01-0{i + 1}",
+                    )
+                )
+        finally:
+            conn.close()
+
+        mock_response = _make_llm_response("spending", db_env["expense_li_id"])
+
+        with (
+            patch("server.llm.chat", return_value=mock_response),
+            patch("server.main.get_transfer_hint", return_value=None),
+        ):
+            result = classify_pending_transactions(db_env["user_id"])
+
+        assert result["classified"] == 3
+        assert result["skipped"] == 0
+        assert result["uncertain"] == 0
+
+        # Verify DB entries were written.
+        conn = get_db(db_env["db"])
+        try:
+            entries = conn.execute("SELECT * FROM transaction_entries").fetchall()
+            assert len(entries) == 3
+            for entry in entries:
+                assert entry["line_item_id"] == db_env["expense_li_id"]
+                assert entry["ledger_id"] == db_env["ledger_id"]
+                assert entry["source"] == "llm"
+        finally:
+            conn.close()
+
+    def test_idempotent(self, db_env):
+        """Running classify_pending_transactions twice must not double-write."""
+        conn = get_db(db_env["db"])
+        try:
+            _seed_rule(conn, "Spending Rule", "spending", db_env["expense_li_id"], priority=10)
+            _seed_transaction(conn, db_env["account_id"])
+        finally:
+            conn.close()
+
+        mock_response = _make_llm_response("spending", db_env["expense_li_id"])
+
+        with (
+            patch("server.llm.chat", return_value=mock_response),
+            patch("server.main.get_transfer_hint", return_value=None),
+        ):
+            first = classify_pending_transactions(db_env["user_id"])
+            second = classify_pending_transactions(db_env["user_id"])
+
+        assert first["classified"] == 1
+        # Second run should find nothing to classify.
+        assert second["classified"] == 0
+        assert second["skipped"] == 0
+        assert second["uncertain"] == 0
+
+        conn = get_db(db_env["db"])
+        try:
+            count = conn.execute("SELECT COUNT(*) FROM transaction_entries").fetchone()[0]
+            assert count == 1
+        finally:
+            conn.close()
+
+    def test_skip_classification_type(self, db_env):
+        """classification_type='skip' must write a skip entry, not a routing entry."""
+        conn = get_db(db_env["db"])
+        try:
+            _seed_rule(conn, "Skip Rule", "skip", None, priority=5)
+            _seed_transaction(conn, db_env["account_id"], merchant="Credit Card Payment")
+        finally:
+            conn.close()
+
+        mock_response = _make_llm_response("skip", None)
+
+        with (
+            patch("server.llm.chat", return_value=mock_response),
+            patch("server.main.get_transfer_hint", return_value=None),
+        ):
+            result = classify_pending_transactions(db_env["user_id"])
+
+        assert result["skipped"] == 1
+        assert result["classified"] == 0
+
+        conn = get_db(db_env["db"])
+        try:
+            entry = conn.execute("SELECT * FROM transaction_entries").fetchone()
+            assert entry is not None
+            assert entry["entry_type"] == "skip"
+            assert entry["line_item_id"] is None
+        finally:
+            conn.close()
+
+    def test_uncertain_transaction_no_line_item_and_no_default_ledger(self, db_env):
+        """When LLM gives no line_item_id and no default_ledger → uncertain."""
+        # Remove default_ledger_id from the account.
+        conn = get_db(db_env["db"])
+        try:
+            conn.execute(
+                "UPDATE bank_accounts SET default_ledger_id = NULL WHERE id = ?",
+                (db_env["account_id"],),
+            )
+            conn.commit()
+            _seed_transaction(conn, db_env["account_id"], merchant="Mystery Merchant")
+        finally:
+            conn.close()
+
+        mock_response = _make_llm_response("spending", None, confidence=0.4)
+
+        with (
+            patch("server.llm.chat", return_value=mock_response),
+            patch("server.main.get_transfer_hint", return_value=None),
+        ):
+            result = classify_pending_transactions(db_env["user_id"])
+
+        assert result["uncertain"] == 1
+        assert result["classified"] == 0
+
+    def test_fallback_to_default_ledger_expense(self, db_env):
+        """When LLM returns no line_item_id but account has default_ledger_id,
+        fallback to first expense line item for 'spending'."""
+        conn = get_db(db_env["db"])
+        try:
+            _seed_transaction(conn, db_env["account_id"], merchant="Unknown Merchant")
+        finally:
+            conn.close()
+
+        # LLM returns spending but no specific line_item_id.
+        mock_response = _make_llm_response("spending", None, confidence=0.85)
+
+        with (
+            patch("server.llm.chat", return_value=mock_response),
+            patch("server.main.get_transfer_hint", return_value=None),
+        ):
+            result = classify_pending_transactions(db_env["user_id"])
+
+        # Should be classified via fallback, not uncertain.
+        assert result["classified"] == 1
+        assert result["uncertain"] == 0
+
+        conn = get_db(db_env["db"])
+        try:
+            entry = conn.execute("SELECT * FROM transaction_entries").fetchone()
+            assert entry["line_item_id"] == db_env["expense_li_id"]
+            assert entry["ledger_id"] == db_env["ledger_id"]
+        finally:
+            conn.close()
+
+    def test_fallback_to_default_ledger_income(self, db_env):
+        """When classification_type='income', fallback picks income line item."""
+        conn = get_db(db_env["db"])
+        try:
+            _seed_transaction(conn, db_env["account_id"], merchant="Employer", amount=-2000.0)
+        finally:
+            conn.close()
+
+        mock_response = _make_llm_response("income", None, confidence=0.92)
+
+        with (
+            patch("server.llm.chat", return_value=mock_response),
+            patch("server.main.get_transfer_hint", return_value=None),
+        ):
+            result = classify_pending_transactions(db_env["user_id"])
+
+        assert result["classified"] == 1
+
+        conn = get_db(db_env["db"])
+        try:
+            entry = conn.execute("SELECT * FROM transaction_entries").fetchone()
+            assert entry["line_item_id"] == db_env["income_li_id"]
+        finally:
+            conn.close()
+
+    def test_no_active_user_graceful_noop(self, tmp_db, monkeypatch):
+        """No active user → classify_pending_transactions returns all zeros."""
+        result = classify_pending_transactions("")
+        assert result == {"classified": 0, "skipped": 0, "uncertain": 0}
+
+    def test_transfer_hint_passed_to_classifier(self, db_env):
+        """Transfer hint should be included in classify_with_rules context."""
+        conn = get_db(db_env["db"])
+        try:
+            _seed_rule(conn, "Transfer Rule", "transfer", db_env["expense_li_id"], priority=1)
+            _seed_transaction(conn, db_env["account_id"], merchant="Transfer To Savings")
+        finally:
+            conn.close()
+
+        mock_response = _make_llm_response("transfer", db_env["expense_li_id"])
+
+        captured_contexts = []
+
+        def mock_classify(tx_dict, rules, context=None):
+            captured_contexts.append(context)
+
+            # Short-circuit: return a pre-built result.
+            return {
+                "rule_id": None,
+                "line_item_id": db_env["expense_li_id"],
+                "classification_type": "transfer",
+                "confidence": 0.9,
+                "uncertain": False,
+                "reasoning": "Transfer detected",
+            }
+
+        hint = {"is_possible_transfer": True, "matched_account": "acct-2", "matched_amount": 50.0}
+
+        with (
+            patch("server.main.classify_with_rules", side_effect=mock_classify),
+            patch("server.main.get_transfer_hint", return_value=hint),
+        ):
+            classify_pending_transactions(db_env["user_id"])
+
+        assert len(captured_contexts) == 1
+        assert captured_contexts[0] is not None
+        assert captured_contexts[0].get("possible_internal_transfer") is True
+
+
+class TestGetNeedsReview:
+    def test_returns_uncertain_transactions(self, db_env, monkeypatch):
+        """get_needs_review returns transactions flagged uncertain=1."""
+        from server.main import get_needs_review
+
+        conn = get_db(db_env["db"])
+        try:
+            tx_id = _seed_transaction(conn, db_env["account_id"], merchant="Mystery Merchant")
+            entry_id = _new_id()
+            conn.execute(
+                "INSERT INTO transaction_entries "
+                "(id, transaction_id, ledger_id, line_item_id, amount, "
+                " entry_type, source, confidence, uncertain, reasoning, reviewed) "
+                "VALUES (?, ?, NULL, NULL, 9.99, 'spending', 'llm', 0.4, 1, 'LLM unsure', 0)",
+                (entry_id, tx_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        # Patch get_active_user_id to return our test user.
+        monkeypatch.setattr("server.main.get_active_user_id", lambda _: db_env["user_id"])
+
+        result = get_needs_review()
+        assert len(result["transactions"]) == 1
+        txn = result["transactions"][0]
+        assert txn["merchant"] == "Mystery Merchant"
+        assert txn["reasoning"] == "LLM unsure"
+
+    def test_reviewed_transactions_excluded(self, db_env, monkeypatch):
+        """Transactions with reviewed=1 must NOT appear in get_needs_review."""
+        conn = get_db(db_env["db"])
+        try:
+            tx_id = _seed_transaction(conn, db_env["account_id"], merchant="Reviewed")
+            entry_id = _new_id()
+            conn.execute(
+                "INSERT INTO transaction_entries "
+                "(id, transaction_id, ledger_id, line_item_id, amount, "
+                " entry_type, source, confidence, uncertain, reviewed) "
+                "VALUES (?, ?, ?, ?, 5.0, 'spending', 'llm', 0.95, 1, 1)",
+                (entry_id, tx_id, db_env["ledger_id"], db_env["expense_li_id"]),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        monkeypatch.setattr("server.main.get_active_user_id", lambda _: db_env["user_id"])
+
+        result = get_needs_review()
+        assert result["transactions"] == []
+
+    def test_skip_entries_excluded(self, db_env, monkeypatch):
+        """Skip entries with uncertain=1 must NOT appear (entry_type='skip' excluded)."""
+        conn = get_db(db_env["db"])
+        try:
+            tx_id = _seed_transaction(conn, db_env["account_id"], merchant="Credit Payment")
+            entry_id = _new_id()
+            conn.execute(
+                "INSERT INTO transaction_entries "
+                "(id, transaction_id, ledger_id, line_item_id, amount, "
+                " entry_type, source, confidence, uncertain, reviewed) "
+                "VALUES (?, ?, NULL, NULL, 100.0, 'skip', 'llm', 0.99, 0, 0)",
+                (entry_id, tx_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        monkeypatch.setattr("server.main.get_active_user_id", lambda _: db_env["user_id"])
+
+        result = get_needs_review()
+        assert result["transactions"] == []
+
+    def test_no_active_user_returns_empty(self, tmp_db, monkeypatch):
+        """No active user → get_needs_review returns empty transactions list."""
+
+        monkeypatch.setattr("server.main.get_active_user_id", lambda _: None)
+
+        result = get_needs_review()
+        assert result == {"transactions": []}

--- a/tests/test_list_tool.py
+++ b/tests/test_list_tool.py
@@ -214,29 +214,114 @@ def test_list_filter_source_manual(seeded_db):
 # ---------------------------------------------------------------------------
 
 
-def test_get_needs_review_returns_only_unreviewed(seeded_db):
-    result = main_module.get_needs_review()
-    entries = result["entries"]
-    assert len(entries) == 2
-    for e in entries:
-        assert e["reviewed"] == 0
+def _seed_needs_review_db(db_path: Path) -> dict:
+    """Seed a DB with bank infra + uncertain/unrouted entries for get_needs_review tests."""
+    import time
+
+    conn = get_db(db_path)
+
+    user_id = _uid()
+    conn.execute(
+        "INSERT INTO users (id, username, password_hash, created_at) VALUES (?, ?, ?, ?)",
+        (user_id, "testuser", "hash", int(time.time())),
+    )
+    conn_id = _uid()
+    conn.execute(
+        "INSERT INTO bank_connections "
+        "(id, plaid_access_token_encrypted, institution_name, user_id, plaid_env) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (conn_id, "enc", "RBC", user_id, "sandbox"),
+    )
+    acct_id = _uid()
+    conn.execute(
+        "INSERT INTO bank_accounts (id, connection_id, plaid_account_id, name) VALUES (?, ?, ?, ?)",
+        (acct_id, conn_id, _uid(), "Chequing"),
+    )
+
+    # 2 uncertain transactions, 1 reviewed (should not appear)
+    txn1 = _uid()
+    txn2 = _uid()
+    txn3 = _uid()
+    for txn_id, merchant in [(txn1, "Mystery A"), (txn2, "Mystery B"), (txn3, "Known")]:
+        conn.execute(
+            "INSERT INTO transactions (id, bank_account_id, plaid_transaction_id, date, merchant, amount) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (txn_id, acct_id, _uid(), "2024-01-01", merchant, 10.0),
+        )
+
+    # Uncertain entry (uncertain=1, unreviewed)
+    e1 = _uid()
+    conn.execute(
+        "INSERT INTO transaction_entries "
+        "(id, transaction_id, ledger_id, line_item_id, amount, entry_type, source, "
+        " confidence, uncertain, reasoning, reviewed) "
+        "VALUES (?, ?, NULL, NULL, 10.0, 'spending', 'llm', 0.4, 1, 'Not sure', 0)",
+        (e1, txn1),
+    )
+    # Unrouted entry (line_item_id IS NULL, uncertain=0 but still unrouted)
+    e2 = _uid()
+    conn.execute(
+        "INSERT INTO transaction_entries "
+        "(id, transaction_id, ledger_id, line_item_id, amount, entry_type, source, "
+        " confidence, uncertain, reasoning, reviewed) "
+        "VALUES (?, ?, NULL, NULL, 10.0, 'spending', 'llm', 0.5, 0, 'Unrouted', 0)",
+        (e2, txn2),
+    )
+    # Reviewed entry (should NOT appear)
+    ledger_id = _uid()
+    li_id = _uid()
+    conn.execute("INSERT INTO ledgers (id, name) VALUES (?, ?)", (ledger_id, "Household"))
+    conn.execute(
+        "INSERT INTO line_items (id, ledger_id, name) VALUES (?, ?, ?)",
+        (li_id, ledger_id, "Groceries"),
+    )
+    e3 = _uid()
+    conn.execute(
+        "INSERT INTO transaction_entries "
+        "(id, transaction_id, ledger_id, line_item_id, amount, entry_type, source, "
+        " confidence, uncertain, reviewed) "
+        "VALUES (?, ?, ?, ?, 10.0, 'spending', 'llm', 0.95, 1, 1)",
+        (e3, txn3, ledger_id, li_id),
+    )
+
+    conn.commit()
+    conn.close()
+    return {"user_id": user_id}
 
 
-def test_get_needs_review_shape(seeded_db):
-    """Each entry must have the joined fields from both tables."""
+@pytest.fixture
+def needs_review_db(tmp_path: Path, monkeypatch):
+    """DB seeded with uncertain/unrouted entries for get_needs_review tests."""
+    db_path = tmp_path / "nr_test.db"
+    init_db(db_path)
+    ids = _seed_needs_review_db(db_path)
+    monkeypatch.setattr(server.paths, "DB_PATH", db_path)
+    monkeypatch.setattr("server.main.get_active_user_id", lambda _: ids["user_id"])
+    return ids
+
+
+def test_get_needs_review_returns_only_unreviewed(needs_review_db):
+    """get_needs_review returns uncertain + unrouted transactions, not reviewed ones."""
     result = main_module.get_needs_review()
-    entries = result["entries"]
-    assert len(entries) > 0
+    assert "transactions" in result
+    transactions = result["transactions"]
+    assert len(transactions) == 2
+
+
+def test_get_needs_review_shape(needs_review_db):
+    """Each transaction must have the expected fields."""
+    result = main_module.get_needs_review()
+    transactions = result["transactions"]
+    assert len(transactions) > 0
     required_fields = {
         "id",
-        "transaction_id",
-        "ledger_id",
-        "line_item_id",
-        "amount",
-        "source",
-        "reviewed",
-        "date",
         "merchant",
+        "amount",
+        "date",
+        "account_name",
+        "reasoning",
     }
-    for e in entries:
-        assert required_fields.issubset(e.keys()), f"Missing fields: {required_fields - e.keys()}"
+    for txn in transactions:
+        assert required_fields.issubset(
+            txn.keys()
+        ), f"Missing fields: {required_fields - txn.keys()}"


### PR DESCRIPTION
Closes #165

## Summary

Implements automatic transaction classification after sync, writing results to `transaction_entries` and exposing uncertain/unrouted transactions via a proper `get_needs_review` tool.

### Changes

**`server/main.py`**
- New `classify_pending_transactions(user_id) -> dict` function:
  - Finds all non-pending transactions with no `transaction_entries` row (idempotent by design)
  - Calls `get_transfer_hint()` per transaction and passes it as context to the LLM
  - Calls `classify_with_rules(tx, rules, context)` with priority-ordered rules
  - `classification_type='skip'` → writes a `skip` entry (no line item) so it's not re-evaluated
  - `line_item_id` set → inserts full `transaction_entries` row
  - `line_item_id=None` + account has `default_ledger_id` → fallback to first income/expense line item
  - No fallback found → uncertain entry (surfaces in `get_needs_review`)
  - Returns `{classified: N, skipped: M, uncertain: K}`
- Integrates into `sync()`: called after all connections sync; errors logged, never block sync
  - Adds `auto_classified`, `auto_skipped`, `auto_uncertain` to the sync return dict
- Replaces the `get_needs_review()` stub:
  - Returns `{transactions: [{id, merchant, amount, date, account_name, reasoning}]}`
  - Scoped to active user; filters for `uncertain=1 OR line_item_id IS NULL`, excludes reviewed and skip entries

**`tests/test_auto_categorize.py`** (12 new tests)
- Classify 3 txns → 3 entries written
- Idempotent: second run writes nothing new
- `skip` classification type → skip entry recorded, no line_item
- Uncertain with no `default_ledger_id` → counted as uncertain
- Fallback to `default_ledger_id` for both expense and income
- No active user → graceful no-op
- Transfer hint forwarded as context to `classify_with_rules`
- `get_needs_review`: uncertain surfaced, reviewed excluded, skip excluded

**`tests/test_list_tool.py`** — updated `get_needs_review` tests to match new contract

**`ARCHITECTURE.md`** — classification engine section updated with `classify_pending_transactions` flow and design notes

**`SKILL.md`** — `get_needs_review` description updated

**`README.md`** — auto-categorization and transfer detection mentioned

## Interactive check

```
classify_pending_transactions result:
{
  "classified": 3,
  "skipped": 1,
  "uncertain": 0
}

get_needs_review result:
{
  "transactions": []
}
```

Setup: 4 transactions (2 food → `li_food`, 1 payroll → income fallback via `default_ledger_id`, 1 credit card payment → skip). Mock LLM returns canned responses. All 3 classified, 1 skipped, 0 uncertain (payroll routed via default ledger income line item). `get_needs_review` empty since all were classified with confidence.