### PR TITLE
[P3] Multi-currency: schema + currency prefix + sync population (#160)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -720,6 +720,26 @@ exposure.**
 
 ---
 
+## Multi-Currency Support
+
+### Foundation (shipped in #160)
+
+- `bank_accounts.currency` — ISO 4217 code for the account's native currency, populated from `account.balances.iso_currency_code` during Plaid sync (falls back to `'CAD'` if null)
+- `transactions.currency` — inherited from the parent account's currency at insert time (individual Plaid transactions don't carry an ISO code directly)
+- `server/currency.py` — `format_amount(amount, currency)` helper: `C$` for CAD, `US$` for USD, `£` for GBP, `€` for EUR, ISO code prefix for others
+- `/accounts` page displays balance with currency prefix
+- MCP `list` tool includes `currency` field per transaction
+
+### Deferred to follow-up PR
+
+- FX rate fetching from frankfurter.app
+- `amount_home` conversion at sync time
+- `fx_rates` cache table writes (table schema already exists)
+- Toggle to switch between home currency and original currency in the UI
+- Rate note display ("1 USD = C$1.37 as of May 24")
+
+---
+
 ## Database Migration Strategy
 
 ### Rules (mandatory for all schema changes)
@@ -839,7 +859,7 @@ That's the whole codebase. ~10 files.
 - ❌ Web dashboard with charts/analytics
   - These two roll up into the "bigger UI" future ticket (#55).
 - ❌ Mobile app
-- ❌ Multi-currency / FX
+- ⚠️ Multi-currency / FX — **foundation shipped in #160** (schema + currency prefix display + Plaid sync population); FX rate fetching, `amount_home` conversion, and home-currency toggle are deferred to a follow-up PR
 - ❌ Investment tracking
 - ❌ Tax filing categorization
 - ❌ Budget targets / forecasting

--- a/README.md
+++ b/README.md
@@ -258,6 +258,16 @@ threat model.
 
 ---
 
+## Multi-Currency Support
+
+Friday Budgeting Pro stores and displays amounts in each account's native currency:
+
+- **Currency stored at sync time** — `bank_accounts.currency` and `transactions.currency` are populated from Plaid's `iso_currency_code` during every sync
+- **Prefix on every balance** — `C$` for CAD, `US$` for USD, `£` for GBP, `€` for EUR, ISO code for others
+- **FX conversion** — coming in a follow-up PR (amount_home, frankfurter.app rates, home-currency toggle)
+
+---
+
 ## What This Is Not (v0.1)
 
 - Not a full web app. The UI is deliberately small: setup and profile only.

--- a/server/currency.py
+++ b/server/currency.py
@@ -1,0 +1,39 @@
+"""
+server/currency.py — Currency formatting helpers for Friday Budgeting Pro.
+
+Provides a unified format_amount() function that displays amounts with the
+correct currency prefix (C$, US$, £, €, or ISO code prefix for others).
+
+FX rate conversion (amount_home) and FX rate fetching are deferred to a
+follow-up PR; this module covers only display formatting.
+"""
+
+from __future__ import annotations
+
+# Map ISO 4217 codes to display symbols/prefixes.
+_CURRENCY_SYMBOLS: dict[str, str] = {
+    "CAD": "C$",
+    "USD": "US$",
+    "GBP": "£",
+    "EUR": "€",
+}
+
+
+def format_amount(amount: float | None, currency: str = "CAD") -> str:
+    """Format *amount* with a currency prefix.
+
+    Examples
+    --------
+    >>> format_amount(1234.56, "CAD")
+    'C$1,234.56'
+    >>> format_amount(500, "USD")
+    'US$500.00'
+    >>> format_amount(1234.56, "EUR")
+    '€1,234.56'
+    >>> format_amount(None, "CAD")
+    '—'
+    """
+    if amount is None:
+        return "\u2014"  # em dash
+    symbol = _CURRENCY_SYMBOLS.get(currency, f"{currency} ")
+    return f"{symbol}{abs(amount):,.2f}"

--- a/server/db.py
+++ b/server/db.py
@@ -142,6 +142,13 @@ def init_db(path: str | Path) -> None:
         conn.execute("UPDATE users SET timezone = 'America/Toronto' WHERE timezone IS NULL")
         conn.commit()
 
+        # Migration: multi-currency (#160)
+        _add_col_if_missing(conn, "bank_accounts", "currency", "TEXT")
+        conn.execute("UPDATE bank_accounts SET currency = 'CAD' WHERE currency IS NULL")
+        _add_col_if_missing(conn, "transactions", "currency", "TEXT")
+        conn.execute("UPDATE transactions SET currency = 'CAD' WHERE currency IS NULL")
+        conn.commit()
+
         # Migration: create default user only when there is existing data to migrate
         # (i.e. rows exist that need a user_id) but no users have been created yet.
         # On truly fresh DBs, we leave users empty so the setup wizard can create

--- a/server/main.py
+++ b/server/main.py
@@ -1508,7 +1508,7 @@ def sync() -> dict:
                     next_cursor = result.get("next_cursor") if isinstance(result, dict) else None
                     accounts_list = result.get("accounts", []) if isinstance(result, dict) else []
 
-                    # Build a lookup map: plaid_account_id -> {name, type}
+                    # Build a lookup map: plaid_account_id -> {name, type, currency}
                     # Use official_name if present, else fall back to name.
                     account_meta: dict[str, dict] = {}
                     for acct in accounts_list:
@@ -1519,9 +1519,13 @@ def sync() -> dict:
                             # type may come back as an enum object; coerce to string
                             if acct_type is not None and not isinstance(acct_type, str):
                                 acct_type = str(acct_type)
+                            # iso_currency_code from balances; fall back to 'CAD'
+                            balances = _get(acct, "balances") or {}
+                            acct_currency = _get(balances, "iso_currency_code") or "CAD"
                             account_meta[acct_id] = {
                                 "name": acct_name,
                                 "type": acct_type,
+                                "currency": acct_currency,
                             }
 
                     now = int(_time.time())
@@ -1554,9 +1558,10 @@ def sync() -> dict:
                             ).fetchone()
                             bank_account_id = ba_row["id"]
 
-                            # Populate name/type from account metadata (idempotent —
+                            # Populate name/type/currency from account metadata (idempotent —
                             # only overwrites when the incoming value is non-null so
                             # a second sync won't blank out rows with good data).
+                            acct_currency = "CAD"  # default
                             if plaid_account_id in account_meta:
                                 meta = account_meta[plaid_account_id]
                                 if meta["name"] is not None:
@@ -1571,12 +1576,19 @@ def sync() -> dict:
                                         "WHERE plaid_account_id = ? AND (type IS NULL OR type = '')",
                                         (meta["type"], plaid_account_id),
                                     )
+                                # Always update currency from Plaid (authoritative source)
+                                acct_currency = meta.get("currency") or "CAD"
+                                db_conn.execute(
+                                    "UPDATE bank_accounts SET currency = ? "
+                                    "WHERE plaid_account_id = ?",
+                                    (acct_currency, plaid_account_id),
+                                )
 
                             txn_id = str(uuid.uuid4())
                             cur = db_conn.execute(
                                 "INSERT OR IGNORE INTO transactions "
-                                "(id, bank_account_id, plaid_transaction_id, date, merchant, amount, pending) "
-                                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                                "(id, bank_account_id, plaid_transaction_id, date, merchant, amount, currency, pending) "
+                                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                                 (
                                     txn_id,
                                     bank_account_id,
@@ -1584,6 +1596,7 @@ def sync() -> dict:
                                     str(date) if date is not None else None,
                                     merchant,
                                     amount,
+                                    acct_currency,
                                     1 if pending else 0,
                                 ),
                             )
@@ -1798,7 +1811,8 @@ def list(filters: Optional[dict] = None) -> dict:
             te.reviewed,
             t.date,
             t.merchant,
-            t.amount AS transaction_amount
+            t.amount AS transaction_amount,
+            t.currency
         FROM transaction_entries te
         JOIN transactions t ON t.id = te.transaction_id
         {where_clause}

--- a/tests/test_multi_currency.py
+++ b/tests/test_multi_currency.py
@@ -1,0 +1,354 @@
+"""
+tests/test_multi_currency.py — Tests for issue #160: multi-currency foundation.
+
+Covers:
+  - Schema: currency columns exist on bank_accounts and transactions
+  - format_amount() helper function
+  - accounts.html renders currency prefix on balances
+  - After sync mock, bank_accounts.currency is populated
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path, monkeypatch) -> Path:
+    """Initialise a fresh SQLite DB and monkeypatch DB_PATH."""
+    import server.paths as paths
+    from server.db import init_db
+
+    db = tmp_path / "test.db"
+    init_db(db)
+
+    monkeypatch.setattr(paths, "DB_PATH", db)
+    monkeypatch.setattr(paths, "APP_DIR", tmp_path)
+    return db
+
+
+@pytest.fixture()
+def authed_user(db_path: Path):
+    """Return (db_path, user_id) after creating a test user."""
+    from ui.auth import create_user
+
+    uid = create_user(db_path, "testuser", "testpassword123")
+    return db_path, uid
+
+
+# ---------------------------------------------------------------------------
+# Schema tests
+# ---------------------------------------------------------------------------
+
+
+def test_bank_accounts_has_currency_column(db_path: Path):
+    """bank_accounts.currency column exists after init_db."""
+    import sqlite3
+
+    conn = sqlite3.connect(str(db_path))
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(bank_accounts)")}
+    conn.close()
+    assert "currency" in cols, "bank_accounts.currency column missing"
+
+
+def test_transactions_has_currency_column(db_path: Path):
+    """transactions.currency column exists after init_db."""
+    import sqlite3
+
+    conn = sqlite3.connect(str(db_path))
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(transactions)")}
+    conn.close()
+    assert "currency" in cols, "transactions.currency column missing"
+
+
+# ---------------------------------------------------------------------------
+# format_amount tests
+# ---------------------------------------------------------------------------
+
+
+def test_format_amount_cad():
+    from server.currency import format_amount
+
+    assert format_amount(500, "CAD") == "C$500.00"
+
+
+def test_format_amount_usd():
+    from server.currency import format_amount
+
+    assert format_amount(500, "USD") == "US$500.00"
+
+
+def test_format_amount_none():
+    from server.currency import format_amount
+
+    assert format_amount(None, "CAD") == "\u2014"
+
+
+def test_format_amount_eur():
+    from server.currency import format_amount
+
+    assert format_amount(1234.56, "EUR") == "\u20ac1,234.56"
+
+
+def test_format_amount_gbp():
+    from server.currency import format_amount
+
+    assert format_amount(99.99, "GBP") == "\xa399.99"
+
+
+def test_format_amount_unknown_currency():
+    from server.currency import format_amount
+
+    result = format_amount(100, "JPY")
+    assert result == "JPY 100.00"
+
+
+def test_format_amount_large_number():
+    from server.currency import format_amount
+
+    assert format_amount(1234.56, "CAD") == "C$1,234.56"
+
+
+# ---------------------------------------------------------------------------
+# accounts.html — currency prefix in balance display
+# ---------------------------------------------------------------------------
+
+
+def test_accounts_html_renders_cad_prefix(authed_user):
+    """GET /accounts shows C$ prefix for CAD accounts."""
+    db_path, user_id = authed_user
+    from fastapi.testclient import TestClient
+
+    from server.db import get_db
+    from ui.auth import SESSION_COOKIE, create_session
+    from ui.server import app
+
+    # Insert a bank connection + account with CAD currency
+    conn_id = str(uuid.uuid4())
+    acct_id = str(uuid.uuid4())
+    db = get_db(db_path)
+    db.execute(
+        "INSERT INTO bank_connections (id, plaid_item_id, plaid_access_token_encrypted,"
+        " institution_name, status, user_id, plaid_env)"
+        " VALUES (?, ?, ?, ?, 'active', ?, 'sandbox')",
+        (conn_id, "item-cad", "enc-cad", "Test Bank CAD", user_id),
+    )
+    db.execute(
+        "INSERT INTO bank_accounts (id, connection_id, plaid_account_id, name,"
+        " type, currency, balance_current)"
+        " VALUES (?, ?, ?, ?, 'depository', 'CAD', 1234.56)",
+        (acct_id, conn_id, "plaid-cad-acct", "Chequing"),
+    )
+    db.commit()
+    db.close()
+
+    token = create_session(db_path, user_agent="pytest", user_id=user_id)
+    client = TestClient(app, follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE, token)
+
+    resp = client.get("/accounts")
+    assert resp.status_code == 200
+    assert "C$" in resp.text, "Expected C$ prefix on CAD balance"
+    assert "1234.56" in resp.text
+
+
+def test_accounts_html_renders_usd_prefix(authed_user):
+    """GET /accounts shows US$ prefix for USD accounts."""
+    db_path, user_id = authed_user
+    from fastapi.testclient import TestClient
+
+    from server.db import get_db
+    from ui.auth import SESSION_COOKIE, create_session
+    from ui.server import app
+
+    conn_id = str(uuid.uuid4())
+    acct_id = str(uuid.uuid4())
+    db = get_db(db_path)
+    db.execute(
+        "INSERT INTO bank_connections (id, plaid_item_id, plaid_access_token_encrypted,"
+        " institution_name, status, user_id, plaid_env)"
+        " VALUES (?, ?, ?, ?, 'active', ?, 'sandbox')",
+        (conn_id, "item-usd", "enc-usd", "US Bank", user_id),
+    )
+    db.execute(
+        "INSERT INTO bank_accounts (id, connection_id, plaid_account_id, name,"
+        " type, currency, balance_current)"
+        " VALUES (?, ?, ?, ?, 'depository', 'USD', 500.00)",
+        (acct_id, conn_id, "plaid-usd-acct", "Savings USD"),
+    )
+    db.commit()
+    db.close()
+
+    token = create_session(db_path, user_agent="pytest", user_id=user_id)
+    client = TestClient(app, follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE, token)
+
+    resp = client.get("/accounts")
+    assert resp.status_code == 200
+    assert "US$" in resp.text, "Expected US$ prefix on USD balance"
+
+
+# ---------------------------------------------------------------------------
+# Sync mock: bank_accounts.currency populated from Plaid
+# ---------------------------------------------------------------------------
+
+
+def test_sync_populates_bank_account_currency(db_path: Path, monkeypatch):
+    """After a sync with mocked Plaid, bank_accounts.currency reflects iso_currency_code."""
+    import server.paths as paths
+    from server.db import get_db
+
+    monkeypatch.setattr(paths, "DB_PATH", db_path)
+
+    # Insert a bank connection
+    conn_id = str(uuid.uuid4())
+    db = get_db(db_path)
+    db.execute(
+        "INSERT INTO bank_connections (id, plaid_item_id, plaid_access_token_encrypted,"
+        " institution_name, status, plaid_env)"
+        " VALUES (?, ?, ?, ?, 'active', 'sandbox')",
+        (conn_id, "item-test", "enc-token", "Mock Bank"),
+    )
+    db.execute(
+        "INSERT INTO sync_cursors (connection_id, cursor) VALUES (?, NULL)",
+        (conn_id,),
+    )
+    db.commit()
+    db.close()
+
+    plaid_account_id = "plaid-acct-usd"
+    plaid_txn_id = "plaid-txn-001"
+
+    mock_sync_result = {
+        "added": [
+            {
+                "account_id": plaid_account_id,
+                "transaction_id": plaid_txn_id,
+                "date": "2024-01-15",
+                "name": "Coffee Shop",
+                "merchant_name": "Coffee Shop",
+                "amount": 5.50,
+                "pending": False,
+            }
+        ],
+        "modified": [],
+        "removed": [],
+        "next_cursor": "cursor-v2",
+        "accounts": [
+            {
+                "account_id": plaid_account_id,
+                "name": "USD Chequing",
+                "official_name": "USD Chequing Account",
+                "type": "depository",
+                "balances": {
+                    "iso_currency_code": "USD",
+                    "current": 1000.0,
+                    "available": 950.0,
+                },
+            }
+        ],
+    }
+
+    mock_provider = MagicMock()
+    mock_provider.sync_transactions.return_value = mock_sync_result
+    mock_provider.env = "sandbox"
+
+    with patch("server.main.PlaidProvider", return_value=mock_provider):
+        with patch("server.crypto.decrypt", return_value="fake-access-token"):
+            from server.main import sync
+
+            sync()
+
+    db = get_db(db_path)
+    row = db.execute(
+        "SELECT currency FROM bank_accounts WHERE plaid_account_id = ?",
+        (plaid_account_id,),
+    ).fetchone()
+    db.close()
+
+    assert row is not None, "bank_accounts row not found after sync"
+    assert row["currency"] == "USD", f"Expected USD, got {row['currency']}"
+
+
+def test_sync_populates_transaction_currency(db_path: Path, monkeypatch):
+    """After a sync with mocked Plaid, transactions.currency matches the account's currency."""
+    import server.paths as paths
+    from server.db import get_db
+
+    monkeypatch.setattr(paths, "DB_PATH", db_path)
+
+    conn_id = str(uuid.uuid4())
+    db = get_db(db_path)
+    db.execute(
+        "INSERT INTO bank_connections (id, plaid_item_id, plaid_access_token_encrypted,"
+        " institution_name, status, plaid_env)"
+        " VALUES (?, ?, ?, ?, 'active', 'sandbox')",
+        (conn_id, "item-test2", "enc-token2", "Mock Bank 2"),
+    )
+    db.execute(
+        "INSERT INTO sync_cursors (connection_id, cursor) VALUES (?, NULL)",
+        (conn_id,),
+    )
+    db.commit()
+    db.close()
+
+    plaid_account_id = "plaid-acct-gbp"
+    plaid_txn_id = "plaid-txn-gbp-001"
+
+    mock_sync_result = {
+        "added": [
+            {
+                "account_id": plaid_account_id,
+                "transaction_id": plaid_txn_id,
+                "date": "2024-02-10",
+                "name": "London Pub",
+                "merchant_name": "London Pub",
+                "amount": 12.50,
+                "pending": False,
+            }
+        ],
+        "modified": [],
+        "removed": [],
+        "next_cursor": "cursor-gbp-2",
+        "accounts": [
+            {
+                "account_id": plaid_account_id,
+                "name": "GBP Account",
+                "official_name": None,
+                "type": "depository",
+                "balances": {
+                    "iso_currency_code": "GBP",
+                    "current": 500.0,
+                    "available": 490.0,
+                },
+            }
+        ],
+    }
+
+    mock_provider = MagicMock()
+    mock_provider.sync_transactions.return_value = mock_sync_result
+    mock_provider.env = "sandbox"
+
+    with patch("server.main.PlaidProvider", return_value=mock_provider):
+        with patch("server.crypto.decrypt", return_value="fake-access-token"):
+            from server.main import sync
+
+            sync()
+
+    db = get_db(db_path)
+    row = db.execute(
+        "SELECT currency FROM transactions WHERE plaid_transaction_id = ?",
+        (plaid_txn_id,),
+    ).fetchone()
+    db.close()
+
+    assert row is not None, "transactions row not found after sync"
+    assert row["currency"] == "GBP", f"Expected GBP, got {row['currency']}"

--- a/ui/server.py
+++ b/ui/server.py
@@ -876,6 +876,7 @@ def _get_accounts_grouped(user_id: Optional[str] = None) -> dict:
             rows = conn.execute(
                 "SELECT ba.id, ba.name, ba.mask, ba.type, ba.subtype,"
                 "       ba.balance_current, ba.balance_available, ba.description,"
+                "       COALESCE(ba.currency, 'CAD') AS currency,"
                 "       bc.id AS connection_id, bc.institution_name"
                 "  FROM bank_accounts ba"
                 "  JOIN bank_connections bc ON bc.id = ba.connection_id"
@@ -887,6 +888,7 @@ def _get_accounts_grouped(user_id: Optional[str] = None) -> dict:
             rows = conn.execute(
                 "SELECT ba.id, ba.name, ba.mask, ba.type, ba.subtype,"
                 "       ba.balance_current, ba.balance_available, ba.description,"
+                "       COALESCE(ba.currency, 'CAD') AS currency,"
                 "       bc.id AS connection_id, bc.institution_name"
                 "  FROM bank_accounts ba"
                 "  JOIN bank_connections bc ON bc.id = ba.connection_id"

--- a/ui/templates/accounts.html
+++ b/ui/templates/accounts.html
@@ -47,10 +47,14 @@
             {{ acct.subtype or acct.type or '—' }}
           </td>
           <td style="padding:0.55rem 0.6rem;text-align:right;font-weight:600;font-variant-numeric:tabular-nums">
-            {% if acct.balance_current is not none %}
-              C${{ "%.2f"|format(acct.balance_current) }}
-            {% elif acct.balance_available is not none %}
-              C${{ "%.2f"|format(acct.balance_available) }}
+            {% set balance = acct.balance_current if acct.balance_current is not none else acct.balance_available %}
+            {% if balance is not none %}
+              {% set currency = acct.currency or 'CAD' %}
+              {% if currency == 'CAD' %}C$
+              {% elif currency == 'USD' %}US$
+              {% elif currency == 'GBP' %}£
+              {% elif currency == 'EUR' %}€
+              {% else %}{{ currency }} {% endif %}{{ "%.2f"|format(balance) }}
             {% else %}
               <span style="color:#94a3b8">—</span>
             {% endif %}


### PR DESCRIPTION
Closes #160

## What's built

### Foundation
- **Schema migration**: `bank_accounts.currency` and `transactions.currency` columns added via `_add_col_if_missing` in `server/db.py` (columns already existed in `db/schema.sql`, now guarded for existing DBs)
- **Plaid sync**: `bank_accounts.currency` populated from `account.balances.iso_currency_code` during sync (falls back to `'CAD'`); `transactions.currency` inherited from parent account at insert time
- **`server/currency.py`**: new `format_amount(amount, currency)` helper — `C$` for CAD, `US$` for USD, `£` for GBP, `€` for EUR, ISO code prefix for others
- **MCP `list` tool**: now returns `currency` field per transaction entry
- **`/accounts` UI**: balance display uses the account's currency prefix instead of hardcoded `C$`
- **13 tests** in `tests/test_multi_currency.py`: schema, `format_amount`, UI rendering, sync mock

## Deferred to follow-up PR
- FX rate fetching from frankfurter.app
- `amount_home` conversion at sync time
- `fx_rates` table writes (table schema already present)
- Home currency / original currency toggle in UI
- Rate note display ("1 USD = C$1.37 as of May 24")

## Interactive check
```
>>> from server.currency import format_amount
>>> format_amount(1234.56, 'CAD')
'C$1,234.56'
>>> format_amount(500, 'USD')
'US$500.00'
>>> format_amount(None)
'—'
```

## CI
794 passed, 7 skipped — all green