### PR TITLE
[P4] Rules list in Settings page (#172)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ Default rules can be **disabled** but not deleted.  You can add your own rules
 (priority 100+) and reorder them via MCP tools: `list_rules`, `add_rule`,
 `update_rule`, `reorder_rules`, `disable_rule`, `enable_rule`, `delete_rule`.
 
+All active rules are visible in the **Settings page** (`/settings`) under
+*Classification Rules*, shown in priority order.  The table is read-only —
+editing is done via MCP/chat.
+
 ---
 
 ## With OpenClaw (and any other MCP client)

--- a/tests/test_rules_ui.py
+++ b/tests/test_rules_ui.py
@@ -1,0 +1,135 @@
+"""
+tests/test_rules_ui.py — Tests for issue #172: Rules list UI in Settings page.
+
+Covers:
+  - GET /settings (authed) → 200 with rules table present
+  - HTML contains rule names from seeded default rules
+  - Disabled rule shows 'disabled' in HTML
+  - Default rule shows 'default' badge text
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path, monkeypatch) -> Path:
+    """Initialise a fresh SQLite DB in tmp_path and monkeypatch DB_PATH."""
+    import server.paths as paths
+    from server.db import init_db
+
+    db = tmp_path / "test.db"
+    init_db(db)
+
+    monkeypatch.setattr(paths, "DB_PATH", db)
+    monkeypatch.setattr(paths, "APP_DIR", tmp_path)
+    return db
+
+
+@pytest.fixture()
+def authed_client(db_path: Path) -> tuple[TestClient, str]:
+    """TestClient with a valid session cookie for a real user."""
+    from ui.auth import SESSION_COOKIE, create_session, create_user
+    from ui.server import app
+
+    uid = create_user(db_path, "testuser", "testpassword1")
+    token = create_session(db_path, user_agent="pytest", user_id=uid)
+
+    client = TestClient(app, follow_redirects=False)
+    client.cookies.set(SESSION_COOKIE, token)
+    return client, uid
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRulesUI:
+    def test_get_settings_returns_200(self, authed_client):
+        """GET /settings (authed) returns 200."""
+        client, _ = authed_client
+        r = client.get("/settings")
+        assert r.status_code == 200
+
+    def test_get_settings_has_rules_table(self, authed_client):
+        """GET /settings includes the Classification Rules section and a table."""
+        client, _ = authed_client
+        r = client.get("/settings")
+        assert r.status_code == 200
+        assert "Classification Rules" in r.text
+        assert "<table" in r.text
+
+    def test_get_settings_shows_pending_skip(self, authed_client):
+        """Default rule 'Pending skip' appears in the settings page."""
+        client, _ = authed_client
+        r = client.get("/settings")
+        assert r.status_code == 200
+        assert "Pending skip" in r.text
+
+    def test_get_settings_shows_internal_transfer(self, authed_client):
+        """Default rule 'Internal transfer' appears in the settings page."""
+        client, _ = authed_client
+        r = client.get("/settings")
+        assert r.status_code == 200
+        assert "Internal transfer" in r.text
+
+    def test_get_settings_enabled_rule_shows_enabled(self, authed_client):
+        """Enabled rules are shown with 'enabled' status text."""
+        client, _ = authed_client
+        r = client.get("/settings")
+        assert r.status_code == 200
+        assert "enabled" in r.text
+
+    def test_disabled_rule_shows_disabled(self, db_path: Path, authed_client):
+        """A disabled rule shows 'disabled' in the settings page."""
+        from server.main import disable_rule, list_rules
+
+        # Disable the first rule
+        rules = list_rules().get("rules", [])
+        assert rules, "Expected seeded default rules"
+        first_rule_id = rules[0]["id"]
+        disable_rule(first_rule_id)
+
+        client, _ = authed_client
+        r = client.get("/settings")
+        assert r.status_code == 200
+        assert "disabled" in r.text
+
+    def test_default_rule_shows_default_badge(self, authed_client):
+        """Default rules are labelled with 'default' badge text."""
+        client, _ = authed_client
+        r = client.get("/settings")
+        assert r.status_code == 200
+        assert "default" in r.text
+
+    def test_rules_shown_in_priority_order(self, authed_client):
+        """Priority numbers appear in the rendered HTML in ascending order."""
+        client, _ = authed_client
+        r = client.get("/settings")
+        assert r.status_code == 200
+        # Priority 1 (Pending skip) should appear before priority 50 (Bank fees)
+        idx_1 = r.text.find(">1<")
+        idx_50 = r.text.find(">50<")
+        assert idx_1 != -1, "Priority 1 not found"
+        assert idx_50 != -1, "Priority 50 not found"
+        assert idx_1 < idx_50, "Priority 1 should appear before priority 50"
+
+    def test_no_edit_controls_present(self, authed_client):
+        """Rules table must not contain edit buttons or input controls."""
+        client, _ = authed_client
+        r = client.get("/settings")
+        assert r.status_code == 200
+        # Check that no edit/delete buttons are in the rules section
+        # (The form for currency/timezone settings is fine)
+        # We look for buttons labelled Edit/Delete near rule content
+        assert "Edit rule" not in r.text
+        assert "Delete rule" not in r.text

--- a/ui/server.py
+++ b/ui/server.py
@@ -44,6 +44,7 @@ from fastapi.templating import Jinja2Templates
 
 import server.paths as _paths
 from server.db import get_db
+from server.main import list_rules as _list_rules
 
 # ── Recovery token store (in-memory, 10-min TTL) ──────────────────────────
 # Shared with the MCP tools (reset_ui_password) via ui.auth so both operate
@@ -978,6 +979,11 @@ def settings_get(request: Request):
     finally:
         conn.close()
     saved = request.query_params.get("saved") == "1"
+    # Load classification rules (gracefully degrade if DB not ready)
+    try:
+        rules = _list_rules().get("rules", [])
+    except Exception:
+        rules = []
     return templates.TemplateResponse(
         request,
         "settings.html",
@@ -988,6 +994,7 @@ def settings_get(request: Request):
             "timezone": timezone,
             "timezones": _VALID_TIMEZONES,
             "saved": saved,
+            "rules": rules,
         },
     )
 

--- a/ui/static/style.css
+++ b/ui/static/style.css
@@ -299,3 +299,12 @@ th {
 .ledger-block {
   margin-top: 16px;
 }
+
+/* ── Classification Rules table (#172) ───────────────────────────────── */
+
+.rule-disabled td {
+  color: var(--muted);
+  opacity: 0.65;
+}
+
+.badge-default { background: #eef2ff; color: #3730a3; }

--- a/ui/templates/settings.html
+++ b/ui/templates/settings.html
@@ -38,4 +38,36 @@
     <button type="submit">Save</button>
   </form>
 </div>
+
+<div class="card">
+  <h2>Classification Rules</h2>
+  <p class="hint">Rules are evaluated in priority order. Edit via OpenClaw chat.</p>
+  {% if rules %}
+  <table>
+    <thead>
+      <tr>
+        <th>Priority</th>
+        <th>Name</th>
+        <th>Type</th>
+        <th>Status</th>
+      </tr>
+    </thead>
+    <tbody>
+    {% for rule in rules %}
+    <tr class="{% if not rule.enabled %}rule-disabled{% endif %}">
+      <td>{{ rule.priority }}</td>
+      <td>{{ rule.name }}</td>
+      <td>{{ rule.rule_type }}</td>
+      <td>
+        {% if rule.enabled %}● enabled{% else %}○ disabled{% endif %}
+        {% if rule.is_default %}<span class="badge badge-default">default</span>{% endif %}
+      </td>
+    </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="hint">No classification rules configured yet.</p>
+  {% endif %}
+</div>
 {% endblock %}


### PR DESCRIPTION
Closes #172

## Summary

Adds a read-only **Classification Rules** section to the `/settings` page, showing all rules in priority order.

### Changes
- **`ui/server.py`**: `settings_get` now calls `list_rules()` and passes rules to the template. Gracefully falls back to an empty list if the classification DB is not ready.
- **`ui/templates/settings.html`**: New "Classification Rules" card with a `<table>` showing Priority, Name, Type, and Status columns. Disabled rules get a `.rule-disabled` CSS class (muted). Default rules show a `[default]` badge.
- **`ui/static/style.css`**: Added `.rule-disabled` (muted/dimmed rows) and `.badge-default` styles.
- **`tests/test_rules_ui.py`**: 9 new tests covering 200 response, table presence, rule names (Pending skip, Internal transfer), disabled/enabled display, default badge, priority order, and no edit controls.
- **`README.md`**: Brief mention that classification rules are visible in the Settings page.

### Interactive check
Loaded `/settings` via TestClient (authed). Verified:
- HTTP 200 ✓
- "Classification Rules" section present ✓
- "Pending skip" and "Internal transfer" visible ✓
- Table with Priority/Name/Type/Status columns ✓
- Default badge rendered for all 6 built-in rules ✓
- No edit controls ✓