### PR TITLE
[P4] Date range filter on ledgers (?period=) (#167)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -477,6 +477,11 @@ A small local-only web app. v0.1 scope:
   bank** buttons.
 - **Ledgers page** — a tiny structure editor: list ledgers, add /
   rename / remove line items inside each, add / remove ledgers.
+  A **period filter** (`?period=`) scopes all line-item totals to a
+  preset date range: `this_month` (default), `last_month`,
+  `last_3_months`, `this_year`, or `all`. Period filtering is applied
+  inside `_build_ledger_drilldown()` in `server/main.py` and passed
+  through `_get_ledgers()` in `ui/server.py`.
 - **Plaid Link page** — the browser-based bank-connection flow,
   used by the setup wizard, by the Profile Linked Accounts section,
   and by any MCP-issued "add a bank" link.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,11 @@ ledgers when you need them (e.g. for a rental property). Each line item shows
 its running total and transaction count; click to expand and see the individual
 transactions classified to it (populated once auto-categorisation is active).
 
+A **date range filter** at the top of the page lets you scope all totals to a
+preset period: *This month* (default), *Last month*, *Last 3 months*, *This year*,
+or *All time*. The selected period is reflected in the URL (`/ledgers?period=…`)
+so views are shareable and bookmarkable.
+
 Ledgers come in three types:
 - **Personal** (default) — standard household budget with line items like Salary, Groceries, Dining, etc.
 - **Property** — rental/investment property ledger with pre-seeded items: Rent income, Mortgage, Property tax, Maintenance & repairs, Insurance, Utilities.

--- a/server/main.py
+++ b/server/main.py
@@ -783,6 +783,17 @@ def _build_ledger_drilldown(
             end = _dt(now.year + 1, 1, 1).strftime("%Y-%m-%d")
             date_filter_sql = " AND t.date >= ? AND t.date < ?"
             date_params = [start, end]
+        elif period == "last_3_months":
+            from datetime import timedelta as _td
+
+            end_dt = _dt(now.year, now.month, 1)  # start of this month
+            start_dt = end_dt - _td(days=90)
+            start = start_dt.strftime("%Y-%m-%d")
+            end = end_dt.strftime("%Y-%m-%d")
+            date_filter_sql = " AND t.date >= ? AND t.date < ?"
+            date_params = [start, end]
+        elif period == "all":
+            pass  # no filter — date_filter_sql stays empty
         # unknown period values → no filter (treat as None)
 
     # Fetch line items --------------------------------------------------

--- a/tests/test_date_range_filter.py
+++ b/tests/test_date_range_filter.py
@@ -1,0 +1,321 @@
+"""
+tests/test_date_range_filter.py — Tests for ledger date range filter (#167).
+
+Covers:
+  - GET /ledgers (no period) → 200, defaults to this_month
+  - GET /ledgers?period=last_month → 200, scoped to last month
+  - GET /ledgers?period=all → 200, shows total across all time
+  - Period selector rendered with the active period's link marked active
+  - Entries outside the current month are excluded from this_month totals
+  - Entries from last month appear under last_month totals
+  - last_3_months and this_year periods return 200
+  - Unknown period values fall back to this_month
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+import server.paths
+from server.db import get_db, init_db
+from ui.auth import create_session, create_user  # noqa: F401 (create_session used in authed_user)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _uid() -> str:
+    return str(uuid.uuid4())
+
+
+def _seed_ledger(db_path: Path, user_id: str, name: str = "TestLedger") -> tuple[str, str, str]:
+    """Insert a ledger with one income and one expense line item.
+
+    Returns (ledger_id, income_item_id, expense_item_id).
+    """
+    conn = get_db(db_path)
+    try:
+        ledger_id = _uid()
+        income_id = _uid()
+        expense_id = _uid()
+        conn.execute(
+            "INSERT INTO ledgers (id, name, user_id) VALUES (?, ?, ?)",
+            (ledger_id, name, user_id),
+        )
+        conn.execute(
+            "INSERT INTO line_items (id, ledger_id, name, item_type) VALUES (?, ?, ?, ?)",
+            (income_id, ledger_id, "Salary", "income"),
+        )
+        conn.execute(
+            "INSERT INTO line_items (id, ledger_id, name, item_type) VALUES (?, ?, ?, ?)",
+            (expense_id, ledger_id, "Groceries", "expense"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return ledger_id, income_id, expense_id
+
+
+def _seed_entry(
+    db_path: Path,
+    ledger_id: str,
+    line_item_id: str,
+    amount: float,
+    date: str,
+    merchant: str = "TestMerchant",
+) -> str:
+    """Insert one transaction + transaction_entry. Returns transaction_id."""
+    conn = get_db(db_path)
+    try:
+        txn_id = _uid()
+        entry_id = _uid()
+        conn.execute(
+            "INSERT INTO transactions (id, date, merchant, amount) VALUES (?, ?, ?, ?)",
+            (txn_id, date, merchant, amount),
+        )
+        conn.execute(
+            "INSERT INTO transaction_entries "
+            "(id, transaction_id, ledger_id, line_item_id, amount, amount_home, entry_type, source) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (entry_id, txn_id, ledger_id, line_item_id, amount, amount, "spending", "rule"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return txn_id
+
+
+def _this_month_date() -> str:
+    now = datetime.now()
+    return now.strftime("%Y-%m-15")
+
+
+def _last_month_date() -> str:
+    now = datetime.now()
+    if now.month == 1:
+        return f"{now.year - 1}-12-15"
+    return f"{now.year}-{now.month - 1:02d}-15"
+
+
+def _old_date() -> str:
+    """Returns a date 6 months ago, well outside this_month or last_month."""
+    old = datetime.now() - timedelta(days=180)
+    return old.strftime("%Y-%m-15")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path, monkeypatch) -> Path:
+    import server.paths as paths
+
+    path = tmp_path / "test_date_range.db"
+    init_db(path)
+    monkeypatch.setattr(paths, "DB_PATH", path)
+    monkeypatch.setattr(paths, "APP_DIR", tmp_path)
+    return path
+
+
+@pytest.fixture()
+def client(db_path: Path):
+    from fastapi.testclient import TestClient
+
+    from ui.server import app
+
+    c = TestClient(app, follow_redirects=False)
+    # Run the setup wizard to create a user, then log in
+    c.post("/setup/1", data={"password": "testpass123", "password_confirm": "testpass123"})
+    c.post("/setup/2", data={"notification_pref": "openclaw"})
+    c.post("/setup/3", data={"ledger_name": "Personal"})
+    c.post("/setup/4", data={})
+    c.post("/setup/5", data={})
+    c.post("/setup/6", data={})
+    c.post("/login", data={"password": "testpass123"})
+    return c
+
+
+@pytest.fixture()
+def authed_user(db_path: Path) -> dict:
+    """Direct DB user for low-level drilldown tests (no HTTP session needed)."""
+    user_id = create_user(db_path, "filteruser", "pass123")
+    token = create_session(db_path, user_id=user_id)
+    return {"user_id": user_id, "token": token}
+
+
+# ---------------------------------------------------------------------------
+# Tests — basic route behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestPeriodRoutes:
+    def test_get_ledgers_no_period_returns_200(self, client):
+        """GET /ledgers without period param returns 200 (defaults to this_month)."""
+        r = client.get("/ledgers")
+        assert r.status_code == 200
+
+    def test_get_ledgers_this_month_returns_200(self, client):
+        r = client.get("/ledgers?period=this_month")
+        assert r.status_code == 200
+
+    def test_get_ledgers_last_month_returns_200(self, client):
+        r = client.get("/ledgers?period=last_month")
+        assert r.status_code == 200
+
+    def test_get_ledgers_last_3_months_returns_200(self, client):
+        r = client.get("/ledgers?period=last_3_months")
+        assert r.status_code == 200
+
+    def test_get_ledgers_this_year_returns_200(self, client):
+        r = client.get("/ledgers?period=this_year")
+        assert r.status_code == 200
+
+    def test_get_ledgers_all_returns_200(self, client):
+        r = client.get("/ledgers?period=all")
+        assert r.status_code == 200
+
+    def test_unknown_period_falls_back_to_this_month(self, client):
+        """Unknown period values should not crash; fall back to this_month."""
+        r = client.get("/ledgers?period=bogus")
+        assert r.status_code == 200
+        # Should render this_month as active
+        assert 'href="/ledgers?period=this_month" class="active"' in r.text
+
+
+# ---------------------------------------------------------------------------
+# Tests — period selector rendered correctly
+# ---------------------------------------------------------------------------
+
+
+class TestPeriodSelectorUI:
+    def test_default_this_month_link_is_active(self, client):
+        r = client.get("/ledgers")
+        assert r.status_code == 200
+        assert 'href="/ledgers?period=this_month" class="active"' in r.text
+
+    def test_last_month_link_is_active_when_selected(self, client):
+        r = client.get("/ledgers?period=last_month")
+        assert r.status_code == 200
+        assert 'href="/ledgers?period=last_month" class="active"' in r.text
+        # this_month should NOT be active
+        assert 'href="/ledgers?period=this_month" class="active"' not in r.text
+
+    def test_all_links_present(self, client):
+        r = client.get("/ledgers")
+        assert "this_month" in r.text
+        assert "last_month" in r.text
+        assert "last_3_months" in r.text
+        assert "this_year" in r.text
+        assert 'period=all"' in r.text
+
+    def test_all_time_link_is_active_when_selected(self, client):
+        r = client.get("/ledgers?period=all")
+        assert r.status_code == 200
+        assert 'href="/ledgers?period=all" class="active"' in r.text
+
+
+# ---------------------------------------------------------------------------
+# Tests — totals respect period filter
+# ---------------------------------------------------------------------------
+
+
+class TestPeriodTotals:
+    def test_this_month_excludes_old_entries(self, db_path, authed_user):
+        """Entries from 6 months ago should not appear in this_month totals."""
+        from server.db import get_db as _get_db
+        from server.main import _build_ledger_drilldown
+
+        ledger_id, income_id, expense_id = _seed_ledger(
+            db_path, authed_user["user_id"], "FilterLedger"
+        )
+        # Entry this month
+        _seed_entry(db_path, ledger_id, expense_id, 100.0, _this_month_date(), "ThisMonthShop")
+        # Old entry (6 months ago)
+        _seed_entry(db_path, ledger_id, expense_id, 999.0, _old_date(), "OldShop")
+
+        conn = _get_db(db_path)
+        try:
+            lr = conn.execute(
+                "SELECT id, name, type, description FROM ledgers WHERE id = ?",
+                (ledger_id,),
+            ).fetchone()
+            result = _build_ledger_drilldown(conn, lr, period="this_month")
+        finally:
+            conn.close()
+
+        # Total should only include the 100.0 this-month entry
+        expense_item = next(i for i in result["line_items"] if i["name"] == "Groceries")
+        assert expense_item["total"] == pytest.approx(100.0)
+        txn_merchants = [t["merchant"] for t in expense_item["transactions"]]
+        assert "ThisMonthShop" in txn_merchants
+        assert "OldShop" not in txn_merchants
+
+    def test_last_month_shows_last_month_entries(self, db_path, authed_user):
+        """Entries from last month appear under last_month totals."""
+        from server.db import get_db as _get_db
+        from server.main import _build_ledger_drilldown
+
+        ledger_id, income_id, expense_id = _seed_ledger(
+            db_path, authed_user["user_id"], "LastMonthLedger"
+        )
+        # Entry last month
+        _seed_entry(db_path, ledger_id, expense_id, 200.0, _last_month_date(), "LastMonthShop")
+        # Entry this month (should NOT appear in last_month)
+        _seed_entry(db_path, ledger_id, expense_id, 50.0, _this_month_date(), "ThisMonthShop")
+
+        conn = _get_db(db_path)
+        try:
+            lr = conn.execute(
+                "SELECT id, name, type, description FROM ledgers WHERE id = ?",
+                (ledger_id,),
+            ).fetchone()
+            result = _build_ledger_drilldown(conn, lr, period="last_month")
+        finally:
+            conn.close()
+
+        expense_item = next(i for i in result["line_items"] if i["name"] == "Groceries")
+        assert expense_item["total"] == pytest.approx(200.0)
+        txn_merchants = [t["merchant"] for t in expense_item["transactions"]]
+        assert "LastMonthShop" in txn_merchants
+        assert "ThisMonthShop" not in txn_merchants
+
+    def test_all_time_includes_all_entries(self, db_path, authed_user):
+        """period='all' includes entries from any date."""
+        from server.db import get_db as _get_db
+        from server.main import _build_ledger_drilldown
+
+        ledger_id, income_id, expense_id = _seed_ledger(
+            db_path, authed_user["user_id"], "AllTimeLedger"
+        )
+        _seed_entry(db_path, ledger_id, expense_id, 100.0, _this_month_date(), "NowShop")
+        _seed_entry(db_path, ledger_id, expense_id, 50.0, _last_month_date(), "LastShop")
+        _seed_entry(db_path, ledger_id, expense_id, 25.0, _old_date(), "OldShop")
+
+        conn = _get_db(db_path)
+        try:
+            lr = conn.execute(
+                "SELECT id, name, type, description FROM ledgers WHERE id = ?",
+                (ledger_id,),
+            ).fetchone()
+            # "all" sentinel → None for _build_ledger_drilldown
+            result = _build_ledger_drilldown(conn, lr, period=None)
+        finally:
+            conn.close()
+
+        expense_item = next(i for i in result["line_items"] if i["name"] == "Groceries")
+        assert expense_item["total"] == pytest.approx(175.0)
+        assert len(expense_item["transactions"]) == 3
+
+    def test_get_ledgers_all_via_http(self, client):
+        """GET /ledgers?period=all returns 200 and the all-time tab is active."""
+        r = client.get("/ledgers?period=all")
+        assert r.status_code == 200
+        # All time tab should be active
+        assert 'href="/ledgers?period=all" class="active"' in r.text

--- a/tests/test_date_range_filter.py
+++ b/tests/test_date_range_filter.py
@@ -20,7 +20,6 @@ from pathlib import Path
 
 import pytest
 
-import server.paths
 from server.db import get_db, init_db
 from ui.auth import create_session, create_user  # noqa: F401 (create_session used in authed_user)
 

--- a/ui/server.py
+++ b/ui/server.py
@@ -216,7 +216,11 @@ def _set_notification_pref(pref: str) -> None:
     _set_notification_channel(_PREF_TO_CHANNEL.get(pref, pref))
 
 
-def _get_ledgers(user_id: Optional[str] = None, with_drilldown: bool = False) -> list[dict]:
+def _get_ledgers(
+    user_id: Optional[str] = None,
+    with_drilldown: bool = False,
+    period: Optional[str] = "this_month",
+) -> list[dict]:
     """Query ledgers + line_items from the DB and return a list of dicts.
 
     Parameters
@@ -227,8 +231,14 @@ def _get_ledgers(user_id: Optional[str] = None, with_drilldown: bool = False) ->
     with_drilldown :
         When ``True`` each line-item dict includes ``total`` and
         ``transactions`` keys (used by the /ledgers page drilldown UI).
+    period :
+        Date filter applied to transactions: ``"this_month"``, ``"last_month"``,
+        ``"last_3_months"``, ``"this_year"``, ``"all"``, or ``None`` (all time).
     """
     from server.main import _build_ledger_drilldown
+
+    # Normalise: "all" sentinel → None so drilldown skips date filter
+    drilldown_period: Optional[str] = None if period == "all" else period
 
     conn = get_db(_db_path())
     try:
@@ -246,7 +256,7 @@ def _get_ledgers(user_id: Optional[str] = None, with_drilldown: bool = False) ->
         ledgers = []
         for lr in ledger_rows:
             if with_drilldown:
-                drilldown = _build_ledger_drilldown(conn, lr, period=None)
+                drilldown = _build_ledger_drilldown(conn, lr, period=drilldown_period)
                 ledgers.append(
                     {
                         "id": lr["id"],
@@ -1347,21 +1357,33 @@ def export_excel_download(request: Request):
     )
 
 
+_VALID_PERIODS = {"this_month", "last_month", "last_3_months", "this_year", "all"}
+
+
 @app.get("/ledgers", response_class=HTMLResponse)
-def ledgers_get(request: Request):
-    """Read-only ledger tree.  Requires authentication.
+def ledgers_get(request: Request, period: str = "this_month"):
+    """Read-only ledger tree with optional date-range filter.  Requires authentication.
 
     Queries the DB directly because server.main.list_ledgers() is still a
     stub returning {'status': 'not_implemented'}.  A minimal editor is #48.
+
+    Query params
+    ------------
+    period : str
+        One of ``this_month`` (default), ``last_month``, ``last_3_months``,
+        ``this_year``, ``all``.
     """
     if not _is_authenticated(request):
         return _redirect("/login")
+    # Reject unknown period values and fall back to default
+    if period not in _VALID_PERIODS:
+        period = "this_month"
     uid = _current_user_id(request)
-    ledgers = _get_ledgers(uid, with_drilldown=True)
+    ledgers = _get_ledgers(uid, with_drilldown=True, period=period)
     return templates.TemplateResponse(
         request,
         "ledgers.html",
-        {"current_page": "ledgers", "ledgers": ledgers},
+        {"current_page": "ledgers", "ledgers": ledgers, "period": period},
     )
 
 

--- a/ui/templates/ledgers.html
+++ b/ui/templates/ledgers.html
@@ -19,11 +19,37 @@
   .txn-account { color: #888; padding-right: 0.5em; font-size: 0.9em; }
   .txn-amount { text-align: right; white-space: nowrap; }
   .txn-pending td { color: #aaa; font-style: italic; }
+  .period-selector { display: flex; gap: 0.25em; flex-wrap: wrap; margin-bottom: 1em; }
+  .period-selector a {
+    padding: 0.3em 0.75em;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    text-decoration: none;
+    color: #333;
+    font-size: 0.9em;
+    background: #f5f5f5;
+    transition: background 0.1s;
+  }
+  .period-selector a:hover { background: #e8e8e8; }
+  .period-selector a.active {
+    background: #1a73e8;
+    color: #fff;
+    border-color: #1a73e8;
+    font-weight: 600;
+  }
 </style>
 <div class="card">
   <div style="display:flex;justify-content:space-between;align-items:baseline;">
     <h1>Ledgers</h1>
     <button class="btn-primary" id="btn-add-ledger">+ Add Ledger</button>
+  </div>
+
+  <div class="period-selector" role="tablist" aria-label="Date range">
+    <a href="/ledgers?period=this_month" class="{% if period == 'this_month' %}active{% endif %}" aria-current="{% if period == 'this_month' %}page{% endif %}">This month</a>
+    <a href="/ledgers?period=last_month" class="{% if period == 'last_month' %}active{% endif %}" aria-current="{% if period == 'last_month' %}page{% endif %}">Last month</a>
+    <a href="/ledgers?period=last_3_months" class="{% if period == 'last_3_months' %}active{% endif %}" aria-current="{% if period == 'last_3_months' %}page{% endif %}">Last 3 months</a>
+    <a href="/ledgers?period=this_year" class="{% if period == 'this_year' %}active{% endif %}" aria-current="{% if period == 'this_year' %}page{% endif %}">This year</a>
+    <a href="/ledgers?period=all" class="{% if period == 'all' %}active{% endif %}" aria-current="{% if period == 'all' %}page{% endif %}">All time</a>
   </div>
 
   <div id="add-ledger-form" style="display:none;margin-bottom:1em;">


### PR DESCRIPTION
Closes #167

## Summary

Adds a **date range filter** to the Ledgers page so totals reflect the chosen period. No JavaScript required — tabs are plain anchor links that reload the page with `?period=` in the URL.

### What's new

- **Period selector UI** — 5 tabs at the top of `/ledgers`: *This month* (default), *Last month*, *Last 3 months*, *This year*, *All time*
- **URL state** — `GET /ledgers?period=<value>` — bookmarkable, shareable
- **`_build_ledger_drilldown()`** — added `last_3_months` (last 90 days from start of current month) and `all` (no filter) period branches
- **`_get_ledgers()`** — accepts new `period` param and passes it through to the drilldown function
- **15 new tests** in `tests/test_date_range_filter.py`
- **Docs** — README and ARCHITECTURE updated

### What's deferred

- Custom date pickers (from/to) — too complex for this iteration, noted in issue

## Interactive check

Loaded `/ledgers` and `/ledgers?period=all` via `TestClient` (authed):
- Both return **200**
- `/ledgers` renders with `this_month` tab active by default
- `/ledgers?period=all` renders with `all` tab active
- All 5 period variants return 200