### PR TITLE
[P4] Natural language corrections: find_transactions + correct_transaction MCP tools (#173)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -229,6 +229,8 @@ Full schema lives in `db/schema.sql` (source of truth). Summary:
 - `uncertain` — 1 if classifier confidence < threshold
 - `reasoning` — LLM explanation
 - `corrected_from_line_item_id` + `corrected_at` — audit trail for corrections
+- When `source = 'manual'`, `corrected_from_line_item_id` holds the previous
+  line item so corrections can be reviewed or undone
 
 ### classification_rules key fields
 - `description` — natural language rule (what it matches and does)
@@ -282,6 +284,23 @@ Only what HAL actually needs to call. Grouped:
 - `get_needs_review()` → ambiguous ones HAL should ask about
 - `route(transaction_id, allocations[])` → manual or HAL-driven routing
 - `add_hint(text)` → save a natural-language hint
+
+### Corrections (natural language reclassification, #173)
+- `find_transactions(merchant?, date?, amount?, account?, days_window?)` →
+  fuzzy-search: merchant substring, date ±window, amount ±$0.50, account name;
+  returns up to 10 matches with `current_classification` and `line_item_id`
+- `correct_transaction(transaction_id, line_item_id, create_rule?, rule_description?)` →
+  reclassifies a transaction (`source='manual'`, `reviewed=1`), preserves audit
+  trail (`corrected_from_line_item_id`, `corrected_at`), and optionally creates
+  a priority-80 rule for future auto-classification of the same merchant
+
+**Correction audit trail:** Every `correct_transaction` call records:
+- `corrected_from_line_item_id` — the previous classification
+- `corrected_at` — Unix timestamp of the correction
+- `source = 'manual'` — distinguishes human overrides from automatic classifications
+
+**Retroactive bulk corrections** (e.g. "all my Uber rides over $40 are airport trips")
+are tracked as a follow-up (deferred from #173 to keep scope manageable).
 
 ### Reports
 - `summary(period)` → spending totals

--- a/README.md
+++ b/README.md
@@ -222,6 +222,26 @@ All active rules are visible in the **Settings page** (`/settings`) under
 *Classification Rules*, shown in priority order.  The table is read-only —
 editing is done via MCP/chat.
 
+### Correcting Classifications via Chat
+
+If a transaction is classified wrong, just tell your AI assistant:
+
+```
+You:    That $42 Uber from last Tuesday was an airport trip, not a regular ride.
+Agent:  Got it — I'll reclassify it as Travel.
+        Should I also create a rule so future Uber charges over $40 are
+        automatically marked as Travel?
+You:    Yes please.
+Agent:  Done! Uber transactions will now be routed to Travel automatically.
+```
+
+Under the hood the agent uses `find_transactions` to locate the right
+transaction (fuzzy match on merchant, date, and amount) and
+`correct_transaction` to update the classification and optionally create a
+priority-80 rule.  Every correction is audited: the original
+`line_item_id` is preserved in `corrected_from_line_item_id` and the
+timestamp is recorded in `corrected_at`.
+
 ---
 
 ## With OpenClaw (and any other MCP client)

--- a/SKILL.md
+++ b/SKILL.md
@@ -122,6 +122,10 @@ Invoke for any personal finance request:
 - `list_hints` — list all classification hints
 - `remove_hint(id)` — remove a classification hint
 
+### Corrections
+- `find_transactions(merchant?, date?, amount?, account?, days_window?)` — fuzzy-search transactions by merchant name, ISO date (±`days_window` days), amount (±$0.50), or account name; returns up to 10 matches with their current classification
+- `correct_transaction(transaction_id, line_item_id, create_rule?, rule_description?)` — reclassify a transaction; set `create_rule=True` to also create a rule so future matches are classified the same way automatically
+
 ### Classification Rules
 - `list_rules` — list all classification rules sorted by priority (lower = evaluated first)
 - `add_rule(name, description, rule_type, line_item_id?, priority?)` — add a natural-language rule (`transfer | savings | spending | income | skip`)

--- a/server/db.py
+++ b/server/db.py
@@ -149,6 +149,12 @@ def init_db(path: str | Path) -> None:
         conn.execute("UPDATE transactions SET currency = 'CAD' WHERE currency IS NULL")
         conn.commit()
 
+        # Migration: natural-language corrections (#173)
+        _add_col_if_missing(conn, "transaction_entries", "source", "TEXT")
+        _add_col_if_missing(conn, "transaction_entries", "corrected_from_line_item_id", "TEXT")
+        _add_col_if_missing(conn, "transaction_entries", "corrected_at", "INTEGER")
+        conn.commit()
+
         # Migration: create default user only when there is existing data to migrate
         # (i.e. rows exist that need a user_id) but no users have been created yet.
         # On truly fresh DBs, we leave users empty so the setup wizard can create

--- a/server/main.py
+++ b/server/main.py
@@ -2752,6 +2752,231 @@ def get_ui_url(page: str = None) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Natural-language corrections (#173)
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool
+def find_transactions(
+    merchant: str = None,
+    date: str = None,
+    amount: float = None,
+    account: str = None,
+    days_window: int = 7,
+) -> dict:
+    """Fuzzy search for transactions matching natural-language hints.
+
+    Parameters
+    ----------
+    merchant : str, optional
+        Partial merchant name (case-insensitive substring match).
+    date : str, optional
+        ISO date ``YYYY-MM-DD`` — transactions within ±``days_window`` days
+        of this date are included.
+    amount : float, optional
+        Absolute transaction amount — transactions within ±$0.50 of this
+        value are included.
+    account : str, optional
+        Partial bank account or institution name (case-insensitive).
+    days_window : int, optional
+        Number of days either side of ``date`` to search.  Default 7.
+
+    Returns
+    -------
+    dict
+        ``{"transactions": [{id, merchant, date, amount, account_name,
+        current_classification, line_item_id, entry_id}, ...]}``
+        Up to 10 matches sorted by date descending.
+    """
+    uid = get_active_user_id(server.paths.DB_PATH)
+    if not uid:
+        return {"transactions": [], "error": "not_authenticated"}
+
+    conditions: list[str] = [
+        "bc.user_id = ?",
+        "t.pending = 0",
+    ]
+    params: list = [uid]
+
+    if merchant is not None:
+        conditions.append("LOWER(COALESCE(t.merchant, '')) LIKE LOWER(?)")
+        params.append(f"%{merchant}%")
+
+    if date is not None:
+        import datetime as _dt
+
+        try:
+            pivot = _dt.date.fromisoformat(date)
+        except ValueError:
+            return {"transactions": [], "error": f"invalid date: {date!r}"}
+        lo = (pivot - _dt.timedelta(days=days_window)).isoformat()
+        hi = (pivot + _dt.timedelta(days=days_window)).isoformat()
+        conditions.append("t.date BETWEEN ? AND ?")
+        params.extend([lo, hi])
+
+    if amount is not None:
+        conditions.append("ABS(t.amount - ?) <= 0.50")
+        params.append(amount)
+
+    if account is not None:
+        conditions.append(
+            "(LOWER(COALESCE(ba.name, '')) LIKE LOWER(?)"
+            " OR LOWER(COALESCE(bc.institution_name, '')) LIKE LOWER(?))"
+        )
+        params.extend([f"%{account}%", f"%{account}%"])
+
+    where_clause = " AND ".join(conditions)
+    sql = f"""
+        SELECT
+            t.id,
+            t.merchant,
+            t.date,
+            t.amount,
+            ba.name        AS account_name,
+            te.id          AS entry_id,
+            te.line_item_id,
+            te.entry_type  AS current_classification
+        FROM transactions t
+        JOIN bank_accounts ba     ON ba.id = t.bank_account_id
+        JOIN bank_connections bc  ON bc.id = ba.connection_id
+        LEFT JOIN transaction_entries te ON te.transaction_id = t.id
+        WHERE {where_clause}
+        ORDER BY t.date DESC
+        LIMIT 10
+    """
+
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        rows = conn.execute(sql, params).fetchall()
+        return {
+            "transactions": [
+                {
+                    "id": r["id"],
+                    "merchant": r["merchant"],
+                    "date": r["date"],
+                    "amount": r["amount"],
+                    "account_name": r["account_name"],
+                    "entry_id": r["entry_id"],
+                    "line_item_id": r["line_item_id"],
+                    "current_classification": r["current_classification"],
+                }
+                for r in rows
+            ]
+        }
+    finally:
+        conn.close()
+
+
+@mcp.tool
+def correct_transaction(
+    transaction_id: str,
+    line_item_id: str,
+    create_rule: bool = False,
+    rule_description: str = None,
+) -> dict:
+    """Reclassify a transaction and optionally create a matching rule.
+
+    Parameters
+    ----------
+    transaction_id : str
+        ID of the transaction to reclassify.
+    line_item_id : str
+        New line item ID to assign.
+    create_rule : bool, optional
+        When ``True``, also call :func:`add_rule` so future transactions
+        from the same merchant are automatically classified the same way.
+    rule_description : str, optional
+        Custom description for the new rule.  If omitted an auto-generated
+        description based on the merchant name is used.
+
+    Returns
+    -------
+    dict
+        ``{"status": "ok", "transaction_id": ..., "new_line_item_id": ...,
+        "rule_created": bool}``
+    """
+    uid = get_active_user_id(server.paths.DB_PATH)
+    if not uid:
+        return {"status": "error", "error": "not_authenticated"}
+
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        # Verify transaction belongs to this user.
+        tx_row = conn.execute(
+            """
+            SELECT t.id, t.merchant
+            FROM transactions t
+            JOIN bank_accounts ba    ON ba.id = t.bank_account_id
+            JOIN bank_connections bc ON bc.id = ba.connection_id
+            WHERE t.id = ? AND bc.user_id = ?
+            """,
+            (transaction_id, uid),
+        ).fetchone()
+        if not tx_row:
+            return {"status": "error", "error": f"transaction {transaction_id!r} not found"}
+
+        merchant = tx_row["merchant"] or "Unknown"
+        now = int(_time.time())
+
+        # Check for an existing entry.
+        entry_row = conn.execute(
+            "SELECT id, line_item_id FROM transaction_entries WHERE transaction_id = ?",
+            (transaction_id,),
+        ).fetchone()
+
+        if entry_row:
+            old_line_item_id = entry_row["line_item_id"]
+            conn.execute(
+                """
+                UPDATE transaction_entries
+                SET line_item_id = ?,
+                    source = 'manual',
+                    reviewed = 1,
+                    corrected_from_line_item_id = ?,
+                    corrected_at = ?
+                WHERE transaction_id = ?
+                """,
+                (line_item_id, old_line_item_id, now, transaction_id),
+            )
+        else:
+            # No entry yet — insert one.
+            conn.execute(
+                """
+                INSERT INTO transaction_entries
+                    (id, transaction_id, line_item_id, amount, source, reviewed, corrected_at)
+                SELECT ?, t.id, ?, t.amount, 'manual', 1, ?
+                FROM transactions t WHERE t.id = ?
+                """,
+                (str(uuid.uuid4()), line_item_id, now, transaction_id),
+            )
+
+        conn.commit()
+    finally:
+        conn.close()
+
+    rule_created = False
+    if create_rule:
+        desc = rule_description or (
+            f"Transactions from {merchant!r} should be classified under this line item"
+        )
+        add_rule(
+            name=f"Custom: {merchant}",
+            description=desc,
+            rule_type="spending",
+            line_item_id=line_item_id,
+            priority=80,
+        )
+        rule_created = True
+
+    return {
+        "status": "ok",
+        "transaction_id": transaction_id,
+        "new_line_item_id": line_item_id,
+        "rule_created": rule_created,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Entrypoint
 # ---------------------------------------------------------------------------
 

--- a/tests/test_corrections.py
+++ b/tests/test_corrections.py
@@ -1,0 +1,440 @@
+"""
+tests/test_corrections.py — Tests for natural-language transaction corrections (#173).
+
+Covers:
+  - Schema migrations apply (source, corrected_from_line_item_id, corrected_at)
+  - find_transactions(merchant=...) returns matching transactions
+  - find_transactions(amount=...) returns transactions within ±$0.50 tolerance
+  - find_transactions(date=..., days_window=...) returns transactions within window
+  - find_transactions(account=...) filters by account/institution name
+  - correct_transaction() updates line_item_id, source, reviewed, corrected_from
+  - corrected_from_line_item_id is preserved in the entry
+  - correct_transaction(create_rule=True) calls add_rule with proper args
+  - Invalid transaction_id → error response
+  - No authenticated user → graceful error
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import server.paths
+from server.db import get_db, init_db
+from ui.auth import create_session, create_user
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _uid() -> str:
+    return str(uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path, monkeypatch) -> Path:
+    """Fresh temp DB; monkeypatch server.paths.DB_PATH."""
+    path = tmp_path / "test_corrections.db"
+    init_db(path)
+    monkeypatch.setattr(server.paths, "DB_PATH", path)
+    return path
+
+
+@pytest.fixture()
+def authed_user(db_path: Path) -> dict:
+    """Create a test user + session so get_active_user_id() returns a real ID."""
+    user_id = create_user(db_path, "testuser", "testpass123")
+    token = create_session(db_path, user_id=user_id)
+    return {"user_id": user_id, "token": token}
+
+
+def _seed_full(db_path: Path, user_id: str) -> dict:
+    """Seed a complete set of fixtures: connection, account, ledger, line items, transactions.
+
+    Returns a dict with all important IDs.
+    """
+    conn = get_db(db_path)
+    try:
+        # Bank connection + account
+        conn_id = _uid()
+        account_id = _uid()
+        conn.execute(
+            "INSERT INTO bank_connections (id, plaid_access_token_encrypted, status, user_id, institution_name) "
+            "VALUES (?, ?, 'active', ?, ?)",
+            (conn_id, "enc:fake", user_id, "Test Bank"),
+        )
+        conn.execute(
+            "INSERT INTO bank_accounts (id, connection_id, name) VALUES (?, ?, ?)",
+            (account_id, conn_id, "Chequing"),
+        )
+
+        # Ledger + line items
+        ledger_id = _uid()
+        li_coffee = _uid()
+        li_travel = _uid()
+        conn.execute(
+            "INSERT INTO ledgers (id, name, user_id) VALUES (?, ?, ?)",
+            (ledger_id, "Personal", user_id),
+        )
+        conn.execute(
+            "INSERT INTO line_items (id, ledger_id, name, item_type) VALUES (?, ?, ?, ?)",
+            (li_coffee, ledger_id, "Coffee", "expense"),
+        )
+        conn.execute(
+            "INSERT INTO line_items (id, ledger_id, name, item_type) VALUES (?, ?, ?, ?)",
+            (li_travel, ledger_id, "Travel", "expense"),
+        )
+
+        # Transactions
+        tx_coffee = _uid()
+        tx_ride = _uid()
+        tx_exact = _uid()
+
+        conn.execute(
+            "INSERT INTO transactions (id, date, merchant, amount, bank_account_id) VALUES (?, ?, ?, ?, ?)",
+            (tx_coffee, "2026-05-20", "Tim Hortons Coffee", 3.50, account_id),
+        )
+        conn.execute(
+            "INSERT INTO transactions (id, date, merchant, amount, bank_account_id) VALUES (?, ?, ?, ?, ?)",
+            (tx_ride, "2026-05-18", "Uber Ride", 42.50, account_id),
+        )
+        conn.execute(
+            "INSERT INTO transactions (id, date, merchant, amount, bank_account_id) VALUES (?, ?, ?, ?, ?)",
+            (tx_exact, "2026-05-15", "Amazon", 99.99, account_id),
+        )
+
+        # Existing entry for tx_coffee (classified as coffee)
+        entry_coffee_id = _uid()
+        conn.execute(
+            "INSERT INTO transaction_entries "
+            "(id, transaction_id, ledger_id, line_item_id, amount, source, reviewed) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (entry_coffee_id, tx_coffee, ledger_id, li_coffee, 3.50, "rule", 0),
+        )
+
+        conn.commit()
+    finally:
+        conn.close()
+
+    return {
+        "conn_id": conn_id,
+        "account_id": account_id,
+        "ledger_id": ledger_id,
+        "li_coffee": li_coffee,
+        "li_travel": li_travel,
+        "tx_coffee": tx_coffee,
+        "tx_ride": tx_ride,
+        "tx_exact": tx_exact,
+        "entry_coffee_id": entry_coffee_id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Schema migration tests
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaMigrations:
+    def test_source_column_exists(self, db_path):
+        """transaction_entries.source column must exist after init_db."""
+        conn = get_db(db_path)
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(transaction_entries)")}
+        conn.close()
+        assert "source" in cols
+
+    def test_corrected_from_line_item_id_column_exists(self, db_path):
+        """transaction_entries.corrected_from_line_item_id must exist after init_db."""
+        conn = get_db(db_path)
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(transaction_entries)")}
+        conn.close()
+        assert "corrected_from_line_item_id" in cols
+
+    def test_corrected_at_column_exists(self, db_path):
+        """transaction_entries.corrected_at must exist after init_db."""
+        conn = get_db(db_path)
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(transaction_entries)")}
+        conn.close()
+        assert "corrected_at" in cols
+
+    def test_migration_idempotent(self, db_path):
+        """Calling init_db twice must not raise and columns are still present."""
+        init_db(db_path)  # second call
+        conn = get_db(db_path)
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(transaction_entries)")}
+        conn.close()
+        assert "corrected_from_line_item_id" in cols
+        assert "corrected_at" in cols
+
+
+# ---------------------------------------------------------------------------
+# find_transactions tests
+# ---------------------------------------------------------------------------
+
+
+class TestFindTransactions:
+    def test_find_by_merchant(self, db_path, authed_user):
+        """find_transactions(merchant='Coffee') returns matching transactions."""
+        from server.main import find_transactions
+
+        ids = _seed_full(db_path, authed_user["user_id"])
+        result = find_transactions(merchant="Coffee")
+
+        assert "transactions" in result
+        assert len(result["transactions"]) == 1
+        assert result["transactions"][0]["id"] == ids["tx_coffee"]
+        assert "Coffee" in result["transactions"][0]["merchant"]
+
+    def test_find_by_merchant_case_insensitive(self, db_path, authed_user):
+        """Merchant matching should be case-insensitive."""
+        from server.main import find_transactions
+
+        _seed_full(db_path, authed_user["user_id"])
+        result = find_transactions(merchant="coffee")
+        assert len(result["transactions"]) == 1
+
+    def test_find_by_amount_exact(self, db_path, authed_user):
+        """find_transactions(amount=42.50) returns the ride transaction."""
+        from server.main import find_transactions
+
+        ids = _seed_full(db_path, authed_user["user_id"])
+        result = find_transactions(amount=42.50)
+
+        assert len(result["transactions"]) == 1
+        assert result["transactions"][0]["id"] == ids["tx_ride"]
+
+    def test_find_by_amount_within_tolerance(self, db_path, authed_user):
+        """Transactions within ±$0.50 of given amount are included."""
+        from server.main import find_transactions
+
+        ids = _seed_full(db_path, authed_user["user_id"])
+        # 42.50 ± 0.50 → 42.00–43.00, ride is 42.50 ✓
+        result = find_transactions(amount=42.75)
+        assert any(t["id"] == ids["tx_ride"] for t in result["transactions"])
+
+    def test_find_by_amount_outside_tolerance_excluded(self, db_path, authed_user):
+        """Transactions more than $0.50 away are excluded."""
+        from server.main import find_transactions
+
+        _seed_full(db_path, authed_user["user_id"])
+        result = find_transactions(amount=50.00)
+        assert len(result["transactions"]) == 0
+
+    def test_find_by_date_window(self, db_path, authed_user):
+        """find_transactions(date='2026-05-20', days_window=3) returns within ±3 days."""
+        from server.main import find_transactions
+
+        ids = _seed_full(db_path, authed_user["user_id"])
+        # 2026-05-20 ± 3 days = 2026-05-17 to 2026-05-23
+        # tx_coffee: 2026-05-20 ✓, tx_ride: 2026-05-18 ✓, tx_exact: 2026-05-15 ✗
+        result = find_transactions(date="2026-05-20", days_window=3)
+        returned_ids = {t["id"] for t in result["transactions"]}
+        assert ids["tx_coffee"] in returned_ids
+        assert ids["tx_ride"] in returned_ids
+        assert ids["tx_exact"] not in returned_ids
+
+    def test_find_by_date_window_excludes_outside(self, db_path, authed_user):
+        """Transactions outside the date window are excluded."""
+        from server.main import find_transactions
+
+        ids = _seed_full(db_path, authed_user["user_id"])
+        # Pivot far in the future
+        result = find_transactions(date="2026-06-01", days_window=3)
+        assert len(result["transactions"]) == 0
+
+    def test_find_by_account_name(self, db_path, authed_user):
+        """find_transactions(account='Chequing') filters by account name."""
+        from server.main import find_transactions
+
+        _seed_full(db_path, authed_user["user_id"])
+        result = find_transactions(account="Chequing")
+        assert len(result["transactions"]) > 0
+
+    def test_find_by_institution_name(self, db_path, authed_user):
+        """find_transactions(account='Test Bank') filters by institution name."""
+        from server.main import find_transactions
+
+        _seed_full(db_path, authed_user["user_id"])
+        result = find_transactions(account="Test Bank")
+        assert len(result["transactions"]) > 0
+
+    def test_find_returns_classification(self, db_path, authed_user):
+        """find_transactions should include line_item_id and current_classification."""
+        from server.main import find_transactions
+
+        ids = _seed_full(db_path, authed_user["user_id"])
+        result = find_transactions(merchant="Tim Hortons")
+        assert len(result["transactions"]) == 1
+        tx = result["transactions"][0]
+        assert tx["line_item_id"] == ids["li_coffee"]
+        assert tx["current_classification"] is not None
+
+    def test_find_no_match_returns_empty(self, db_path, authed_user):
+        """No matching transactions → empty list, no error."""
+        from server.main import find_transactions
+
+        _seed_full(db_path, authed_user["user_id"])
+        result = find_transactions(merchant="ZZZNonexistent")
+        assert result["transactions"] == []
+
+    def test_find_not_authenticated(self, db_path):
+        """No active session → graceful error response."""
+        from server.main import find_transactions
+
+        # No user or session created
+        result = find_transactions(merchant="Coffee")
+        assert result.get("error") == "not_authenticated"
+        assert result["transactions"] == []
+
+    def test_find_invalid_date_returns_error(self, db_path, authed_user):
+        """Invalid date string returns an error dict."""
+        from server.main import find_transactions
+
+        _seed_full(db_path, authed_user["user_id"])
+        result = find_transactions(date="not-a-date")
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# correct_transaction tests
+# ---------------------------------------------------------------------------
+
+
+class TestCorrectTransaction:
+    def test_correct_updates_line_item(self, db_path, authed_user):
+        """correct_transaction() changes line_item_id on the entry."""
+        from server.main import correct_transaction
+
+        ids = _seed_full(db_path, authed_user["user_id"])
+        result = correct_transaction(ids["tx_coffee"], ids["li_travel"])
+
+        assert result["status"] == "ok"
+        assert result["new_line_item_id"] == ids["li_travel"]
+
+        conn = get_db(db_path)
+        entry = conn.execute(
+            "SELECT line_item_id, source, reviewed FROM transaction_entries WHERE transaction_id = ?",
+            (ids["tx_coffee"],),
+        ).fetchone()
+        conn.close()
+        assert entry["line_item_id"] == ids["li_travel"]
+        assert entry["source"] == "manual"
+        assert entry["reviewed"] == 1
+
+    def test_correct_preserves_corrected_from(self, db_path, authed_user):
+        """corrected_from_line_item_id must be set to the original line_item_id."""
+        from server.main import correct_transaction
+
+        ids = _seed_full(db_path, authed_user["user_id"])
+        correct_transaction(ids["tx_coffee"], ids["li_travel"])
+
+        conn = get_db(db_path)
+        entry = conn.execute(
+            "SELECT corrected_from_line_item_id, corrected_at FROM transaction_entries WHERE transaction_id = ?",
+            (ids["tx_coffee"],),
+        ).fetchone()
+        conn.close()
+        assert entry["corrected_from_line_item_id"] == ids["li_coffee"]
+        assert entry["corrected_at"] is not None
+
+    def test_correct_inserts_entry_when_missing(self, db_path, authed_user):
+        """If no existing entry, correct_transaction inserts one with source='manual'."""
+        from server.main import correct_transaction
+
+        ids = _seed_full(db_path, authed_user["user_id"])
+        # tx_ride has no entry
+        result = correct_transaction(ids["tx_ride"], ids["li_travel"])
+
+        assert result["status"] == "ok"
+
+        conn = get_db(db_path)
+        entry = conn.execute(
+            "SELECT line_item_id, source, reviewed FROM transaction_entries WHERE transaction_id = ?",
+            (ids["tx_ride"],),
+        ).fetchone()
+        conn.close()
+        assert entry is not None
+        assert entry["line_item_id"] == ids["li_travel"]
+        assert entry["source"] == "manual"
+        assert entry["reviewed"] == 1
+
+    def test_correct_with_create_rule(self, db_path, authed_user):
+        """correct_transaction(create_rule=True) invokes add_rule with priority=80."""
+        from server.main import correct_transaction
+
+        ids = _seed_full(db_path, authed_user["user_id"])
+
+        with patch("server.main.add_rule") as mock_add_rule:
+            mock_add_rule.return_value = {"status": "ok", "rule_id": _uid()}
+            result = correct_transaction(
+                ids["tx_coffee"],
+                ids["li_travel"],
+                create_rule=True,
+                rule_description="Coffee shops are travel expenses",
+            )
+
+        assert result["rule_created"] is True
+        mock_add_rule.assert_called_once()
+        call_kwargs = mock_add_rule.call_args
+        # Check priority=80 and the custom description
+        assert call_kwargs.kwargs.get("priority") == 80 or (
+            len(call_kwargs.args) > 4 and call_kwargs.args[4] == 80
+        )
+        assert "Coffee shops are travel expenses" in (
+            call_kwargs.kwargs.get("description", "") or call_kwargs.args[1]
+        )
+
+    def test_correct_with_create_rule_auto_description(self, db_path, authed_user):
+        """When rule_description is None, an auto-generated description is used."""
+        from server.main import correct_transaction
+
+        ids = _seed_full(db_path, authed_user["user_id"])
+
+        with patch("server.main.add_rule") as mock_add_rule:
+            mock_add_rule.return_value = {"status": "ok", "rule_id": _uid()}
+            result = correct_transaction(ids["tx_coffee"], ids["li_travel"], create_rule=True)
+
+        assert result["rule_created"] is True
+        mock_add_rule.assert_called_once()
+        # Description should be auto-generated and non-empty
+        desc = mock_add_rule.call_args.kwargs.get("description", "")
+        assert len(desc) > 0
+
+    def test_correct_invalid_transaction_id(self, db_path, authed_user):
+        """Non-existent transaction_id returns error response."""
+        from server.main import correct_transaction
+
+        ids = _seed_full(db_path, authed_user["user_id"])
+        result = correct_transaction("nonexistent-id", ids["li_travel"])
+
+        assert result["status"] == "error"
+        assert "not found" in result["error"]
+
+    def test_correct_not_authenticated(self, db_path):
+        """No active session → graceful error response."""
+        from server.main import correct_transaction
+
+        # No user or session
+        result = correct_transaction("any-id", "any-line-item")
+        assert result["status"] == "error"
+        assert result["error"] == "not_authenticated"
+
+    def test_correct_without_create_rule(self, db_path, authed_user):
+        """create_rule=False (default) does not call add_rule."""
+        from server.main import correct_transaction
+
+        ids = _seed_full(db_path, authed_user["user_id"])
+
+        with patch("server.main.add_rule") as mock_add_rule:
+            result = correct_transaction(ids["tx_coffee"], ids["li_travel"])
+
+        assert result["rule_created"] is False
+        mock_add_rule.assert_not_called()


### PR DESCRIPTION
Closes #173

## Summary

Adds two new MCP tools that enable natural-language transaction reclassification via chat:

### New MCP tools
- **`find_transactions(merchant?, date?, amount?, account?, days_window?)`** — Fuzzy-search for transactions by merchant substring, ISO date (±window days), amount (±$0.50), or account/institution name. Returns up to 10 matches with current classification.
- **`correct_transaction(transaction_id, line_item_id, create_rule?, rule_description?)`** — Reclassify a transaction, preserving full audit trail (`corrected_from_line_item_id`, `corrected_at`, `source='manual'`). Optionally creates a priority-80 classification rule for future auto-classification.

### Schema migrations
- `_add_col_if_missing` guards added to `init_db()` for `transaction_entries.source`, `corrected_from_line_item_id`, and `corrected_at` (columns already in schema.sql for fresh DBs, migrations handle existing DBs).

### Tests (25 new)
- Schema migration idempotency
- `find_transactions`: merchant, amount (tolerance), date window, account, case-insensitivity, unauthenticated, invalid date
- `correct_transaction`: update, audit trail preservation, insert-when-missing, create_rule, auto-description, invalid ID, unauthenticated

### Docs
- README.md: "Correcting Classifications via Chat" section with example conversation
- ARCHITECTURE.md: corrections audit trail + `find_transactions`/`correct_transaction` tool entries
- SKILL.md: new Corrections section

## What's deferred
Retroactive bulk corrections (e.g. "all my Uber rides over $40 are airport trips") are scoped to a follow-up issue to keep this PR focused.

## Interactive check
```
find_transactions result: {'transactions': [{'id': 'c82872fa...', 'merchant': 'Starbucks Coffee', 'date': '2026-05-20', 'amount': 6.75, 'account_name': 'Chequing', 'entry_id': '46d5c2fc...', 'line_item_id': 'fcec5f0b...', 'current_classification': 'spending'}]}
  → Found: Starbucks Coffee | 2026-05-20 | $6.75 | classified as: spending
correct_transaction result: {'status': 'ok', 'transaction_id': 'c82872fa...', 'new_line_item_id': '16249b87...', 'rule_created': False}
  → DB entry: line_item_id=16249b87... source=manual reviewed=1
  → corrected_from=fcec5f0b... corrected_at=1779675206

✅ Interactive check passed!
```

**CI:** 853 passed, 7 skipped, 0 failures