### PR TITLE
feat(#207): batch LLM classification — one prompt per sub-batch

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -52,7 +52,7 @@ metadata:
             },
           ],
         "onInstall":
-          "Friday Budgeting Pro is installed.  Walk the user through the guided onboarding flow:\n1. Call setup_status — if not 'complete', send the URL from get_ui_url() and instruct the user to set a password and connect their first bank.  Poll setup_status until it returns 'complete'.\n2. Once banks are connected and an initial sync has run, run the personalisation interview.  Use list_setup_interview_questions to get the canonical question list, then ask each one conversationally (skip ones the user already volunteered).  Call setup_interview(question_key, answer_text) to persist each answer.\n3. Call analyze_recurring_merchants to cross-reference the user's interview answers with recently-synced transactions.  Reconcile gaps (e.g. user mentioned Netflix but it's not in transactions yet, or there's a recurring charge they didn't mention).\n4. For each identified pattern, propose and create a classification rule via add_rule (use a description that starts with '[onboarding]' so the user can see what was auto-generated) and add classification hints via add_hint.  Examples: 'Deposits from TENSTORRENT are Salary & Income', 'Disney Plus charges are Entertainment & Subscriptions'.\n5. Call sync once more so the newly-installed rules classify any remaining transactions, then surface get_needs_review items to the user.\n6. After setup the user can update rules at any time via natural language ('add a rule that Home Depot over $200 goes to Rental Maintenance', 'remove the Netflix rule') — wire those to add_rule / update_rule / delete_rule directly.  No UI needed for rule management.",
+          "Friday Budgeting Pro is installed.  Walk the user through the guided onboarding flow:\n1. Call setup_status — if not 'complete', send the URL from get_ui_url() and instruct the user to set a password and connect their first bank.  Poll setup_status until it returns 'complete'.\n2. Once banks are connected and an initial sync has run, run the personalisation interview.  Use list_setup_interview_questions to get the canonical question list, then ask each one conversationally (skip ones the user already volunteered).  Call setup_interview(question_key, answer_text) to persist each answer.\n3. Call analyze_recurring_merchants to cross-reference the user's interview answers with recently-synced transactions.  Reconcile gaps (e.g. user mentioned Netflix but it's not in transactions yet, or there's a recurring charge they didn't mention).\n4. For each identified pattern, propose and create a classification rule via add_rule (use a description that starts with '[onboarding]' so the user can see what was auto-generated) and add classification hints via add_hint.  Examples: 'Deposits from TENSTORRENT are Salary & Income', 'Disney Plus charges are Entertainment & Subscriptions'.\n5. Call sync once more so the newly-installed rules classify any remaining transactions, then call get_needs_review_summary and, if count > 0, present the summary field to the user in one message.\n6. After setup the user can update rules at any time via natural language ('add a rule that Home Depot over $200 goes to Rental Maintenance', 'remove the Netflix rule') — wire those to add_rule / update_rule / delete_rule directly.  No UI needed for rule management.",
       },
   }
 ---
@@ -119,6 +119,7 @@ Invoke for any personal finance request:
 - `sync` — pull latest transactions from all connected banks
 - `list(filters?)` — query transactions (supports date, ledger, category, account filters)
 - `get_needs_review` — transactions that need manual review: uncertain classifications (confidence < 0.7) or unrouted transactions with no line item assigned
+- `get_needs_review_summary` — **call this immediately after every `sync`**; returns a pre-formatted batch message (`count`, `summary`, `transactions`) ready to present to the user in one message. Use `summary` as-is for the user-facing message. Includes merchant, amount, date, account, and classifier reasoning for each transaction.
 - `route(transaction_id, allocations)` — manually assign a transaction to a ledger/line item
 - `add_hint(text)` — add a natural-language classification hint for the LLM
 - `list_hints` — list all classification hints
@@ -166,11 +167,15 @@ Invoke for any personal finance request:
 **Do**
 - Always use the MCP tools — never guess from general knowledge
 - Call `sync` before answering spending questions if data may be stale
-- Use `get_needs_review` periodically and walk the user through uncertain classifications
+- **After every `sync`, call `get_needs_review_summary` and, if `count > 0`, present the `summary` field to the user in a single message** — do not send one message per transaction
 - Use `list_rules` to show what classification rules are active before adding new ones
 - Open `start_link` when the user wants to connect or reconnect a bank
 - Use `create_property_ledger` for rental properties — it seeds the right line items automatically
 - Respect that all data is local and private
+- When the user replies with classifications for uncertain transactions:
+  1. Call `correct_transaction(transaction_id, line_item_id)` for each corrected item
+  2. Check if the merchant is recurring by calling `find_transactions(merchant=<name>)` — if 2+ past transactions exist, propose adding a rule via `add_rule` (tag description with `[from-correction]`)
+  3. Apply the rule only after the user confirms
 
 **Don't**
 - Don't answer general finance questions ("what is inflation?") — this skill is for personal accounts only

--- a/server/classifier.py
+++ b/server/classifier.py
@@ -23,6 +23,277 @@ import json
 import sqlite3
 
 # ---------------------------------------------------------------------------
+# Batch LLM classification (issue #207)
+# ---------------------------------------------------------------------------
+
+# Maximum prompt character count before splitting into sub-batches.
+# Approximates ~20 000 tokens (chars / 4 ≈ tokens).
+MAX_BATCH_CHARS = 80_000
+
+
+def _build_batch_user_msg(
+    conn: sqlite3.Connection,
+    transactions: list[dict],
+    rules: list[dict],
+    ledger_tree: str,
+    hints: list[str],
+) -> str:
+    """Build the user-side content for a batch classification prompt."""
+    enabled_rules = [r for r in rules if r.get("enabled", True)]
+    if enabled_rules:
+        rules_lines: list[str] = []
+        for r in enabled_rules:
+            li_note = f" -> line_item_id={r['line_item_id']}" if r.get("line_item_id") else ""
+            rules_lines.append(
+                f"  [{r['priority']:>3}] id={r['id']}  type={r['rule_type']}"
+                f"  name=\"{r['name']}\""
+                f"  desc=\"{r['description']}\"{li_note}"
+            )
+        rules_text = "\n".join(rules_lines)
+    else:
+        rules_text = "  (no enabled rules)"
+
+    hints_text = "\n".join(f"  - {h}" for h in hints) if hints else "  (none)"
+
+    txn_sections: list[str] = []
+    for idx, txn in enumerate(transactions):
+        merchant = txn.get("merchant") or "(unknown)"
+        amount = txn.get("amount", 0.0)
+        date = txn.get("date", "unknown")
+        account_name = txn.get("account_name", "")
+        account_description = txn.get("account_description", "")
+        plaid_category = txn.get("plaid_category", "")
+
+        lines = [
+            f"### Transaction {idx}",
+            f"  Merchant            : {merchant}",
+            f"  Amount              : ${amount:.2f}",
+            f"  Date                : {date}",
+        ]
+        if account_name:
+            lines.append(f"  Account             : {account_name}")
+        if account_description:
+            lines.append(f"  Account description : {account_description}")
+        if plaid_category:
+            lines.append(f"  Plaid category      : {plaid_category}")
+
+        recent = _fetch_recent_same_merchant(conn, merchant) if merchant else []
+        if recent:
+            rec_lines = [
+                f"  - {r['date']} | {r['merchant']} | ${r['amount']:.2f}"
+                f" -> {r['ledger_name']} / {r['line_item_name']} (id={r['line_item_id']})"
+                for r in recent
+            ]
+            lines.append("  Recent reviewed entries for this merchant:")
+            lines.extend(rec_lines)
+        else:
+            lines.append("  Recent reviewed entries: (none)")
+
+        if txn.get("possible_transfer"):
+            lines.append(
+                "  WARNING: Transfer detector flagged this as a possible internal transfer."
+            )
+
+        txn_sections.append("\n".join(lines))
+
+    txns_text = "\n\n".join(txn_sections)
+
+    return (
+        f"## Classification Rules (priority ASC - first match wins)\n{rules_text}\n\n"
+        f"## Ledger Tree\n{ledger_tree}\n\n"
+        f"## Classification Hints\n{hints_text}\n\n"
+        f"## Transactions To Classify\n{txns_text}\n\n"
+        "Reply with the JSON array only."
+    )
+
+
+def _classify_batch_chunk(
+    conn: sqlite3.Connection,
+    transactions: list[dict],
+    rules: list[dict],
+    ledger_tree: str,
+    hints: list[str],
+) -> list[dict]:
+    """Classify one sub-batch with a single LLM call. Returns results in input order."""
+    from server.llm import chat
+
+    system_msg = (
+        "You are a personal finance classifier. You will classify a BATCH of "
+        "bank transactions in ONE shot using all available context.\n\n"
+        "Decision policy for EACH transaction:\n"
+        "1. Walk the priority-ordered classification rules from top to bottom. "
+        "The FIRST rule that clearly applies wins - stop scanning after the "
+        "first match. Return that rule's id (and its line_item_id when present).\n"
+        "2. If no rule clearly applies, infer the best line_item_id from the "
+        "ledger tree, hints, account context, and recent similar entries. "
+        "Set rule_id to null in that case.\n"
+        "3. classification_type must reflect the chosen line item / rule: "
+        "transfer | savings | spending | income | skip.\n"
+        "4. Set confidence < 0.7 when you are not confident.\n\n"
+        "Reply with ONLY a JSON array - no markdown, no text outside the array - "
+        "with one object per transaction, in the SAME order:\n"
+        '[{"transaction_index": 0, "rule_id": "<id or null>", '
+        '"line_item_id": "<exact id or null>", '
+        '"classification_type": "<transfer|savings|spending|income|skip>", '
+        '"confidence": <0.0-1.0>, "reasoning": "<one sentence>"}, ...]'
+    )
+
+    user_msg = _build_batch_user_msg(conn, transactions, rules, ledger_tree, hints)
+
+    messages = [
+        {"role": "system", "content": system_msg},
+        {"role": "user", "content": user_msg},
+    ]
+
+    raw = chat(messages, temperature=0.0)
+
+    try:
+        parsed = json.loads(raw)
+        if not isinstance(parsed, list):
+            raise ValueError(f"expected JSON array, got {type(parsed).__name__}")
+    except (json.JSONDecodeError, ValueError) as exc:
+        import logging
+        logging.getLogger(__name__).warning(
+            "classify_batch: LLM returned unparseable response: %s", exc
+        )
+        return [
+            {
+                "rule_id": None,
+                "line_item_id": None,
+                "classification_type": "spending",
+                "confidence": 0.0,
+                "uncertain": True,
+                "reasoning": f"batch LLM parse error: {exc}",
+            }
+            for _ in transactions
+        ]
+
+    valid_types = {"transfer", "savings", "spending", "income", "skip"}
+
+    index_map: dict[int, dict] = {}
+    for item in parsed:
+        if not isinstance(item, dict):
+            continue
+        idx = item.get("transaction_index")
+        if idx is None:
+            continue
+        try:
+            idx = int(idx)
+        except (TypeError, ValueError):
+            continue
+        if 0 <= idx < len(transactions):
+            index_map[idx] = item
+
+    results: list[dict] = []
+    for i in range(len(transactions)):
+        item = index_map.get(i)
+        if item is None:
+            results.append(
+                {
+                    "rule_id": None,
+                    "line_item_id": None,
+                    "classification_type": "spending",
+                    "confidence": 0.0,
+                    "uncertain": True,
+                    "reasoning": "batch LLM did not return result for this transaction",
+                }
+            )
+            continue
+
+        confidence = float(item.get("confidence", 0.0))
+        classification_type = item.get("classification_type", "spending")
+        if classification_type not in valid_types:
+            classification_type = "spending"
+
+        results.append(
+            {
+                "rule_id": item.get("rule_id"),
+                "line_item_id": item.get("line_item_id"),
+                "classification_type": classification_type,
+                "confidence": confidence,
+                "uncertain": confidence < UNCERTAIN_THRESHOLD,
+                "reasoning": str(item.get("reasoning", "")),
+            }
+        )
+
+    return results
+
+
+def classify_batch(
+    conn: sqlite3.Connection,
+    transactions: list[dict],
+    rules: list[dict],
+    ledger_tree: str | None = None,
+    hints: list[str] | None = None,
+) -> list[dict]:
+    """Classify a batch of transactions using as few LLM calls as possible.
+
+    Issue #207: replaces the old per-transaction loop with a single batched
+    LLM call.  Shared context (rules, ledger tree, hints) is built once and
+    embedded in every batch prompt.  Prompts exceeding ``MAX_BATCH_CHARS``
+    are split into sub-batches (greedy bin-packing; at least 1 txn per batch).
+
+    Args:
+        conn:         sqlite3 connection for fetching per-transaction context.
+        transactions: List of transaction dicts (merchant, amount, date, etc).
+        rules:        List of classification_rule dicts (priority ASC).
+        ledger_tree:  Pre-rendered ledger tree string.  If None, fetched.
+        hints:        List of hint strings.  If None, fetched.
+
+    Returns:
+        List of result dicts in the same order as *transactions*:
+        {rule_id, line_item_id, classification_type, confidence, uncertain, reasoning}
+    """
+    if not transactions:
+        return []
+
+    if ledger_tree is None:
+        ledger_tree = _build_ledger_tree(conn)
+    if hints is None:
+        hints = _fetch_hints(conn)
+
+    results: list[dict | None] = [None] * len(transactions)
+
+    batch_start = 0
+    while batch_start < len(transactions):
+        sub_txns: list[dict] = []
+        sub_indices: list[int] = []
+
+        for global_idx in range(batch_start, len(transactions)):
+            sub_txns.append(transactions[global_idx])
+            sub_indices.append(global_idx)
+
+            user_msg = _build_batch_user_msg(conn, sub_txns, rules, ledger_tree, hints)
+            if len(user_msg) > MAX_BATCH_CHARS and len(sub_txns) > 1:
+                sub_txns.pop()
+                sub_indices.pop()
+                break
+
+        if not sub_txns:
+            sub_txns = [transactions[batch_start]]
+            sub_indices = [batch_start]
+
+        chunk_results = _classify_batch_chunk(conn, sub_txns, rules, ledger_tree, hints)
+        for local_idx, global_idx in enumerate(sub_indices):
+            results[global_idx] = chunk_results[local_idx]
+
+        batch_start += len(sub_txns)
+
+    for i, r in enumerate(results):
+        if r is None:
+            results[i] = {
+                "rule_id": None,
+                "line_item_id": None,
+                "classification_type": "spending",
+                "confidence": 0.0,
+                "uncertain": True,
+                "reasoning": "batch classification failed for this transaction",
+            }
+
+    return results  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
 # Unified single LLM classification call (issue #205)
 # ---------------------------------------------------------------------------
 

--- a/server/classifier.py
+++ b/server/classifier.py
@@ -153,6 +153,7 @@ def _classify_batch_chunk(
             raise ValueError(f"expected JSON array, got {type(parsed).__name__}")
     except (json.JSONDecodeError, ValueError) as exc:
         import logging
+
         logging.getLogger(__name__).warning(
             "classify_batch: LLM returned unparseable response: %s", exc
         )

--- a/server/main.py
+++ b/server/main.py
@@ -1924,6 +1924,65 @@ def get_needs_review() -> dict:
 
 
 @mcp.tool
+def get_needs_review_summary() -> dict:
+    """Return a pre-formatted batch summary of transactions needing manual review.
+
+    Designed to be called immediately after ``sync`` so the agent can surface
+    uncertain or unrouted transactions to the user in a single, readable
+    message rather than one message per transaction.
+
+    The summary is intentionally terse: merchant, amount, date, and the
+    classifier's reasoning (when available) are included for each item so the
+    user has just enough context to reply with the correct classification.
+
+    Returns
+    -------
+    dict
+        ``{"count": int, "summary": str, "transactions": [...]}``
+
+        * ``count`` — number of transactions needing review (0 when none).
+        * ``summary`` — human-readable batch message suitable for presenting
+          directly to the user.  Empty string when ``count == 0``.
+        * ``transactions`` — raw list (same shape as ``get_needs_review``) for
+          downstream processing (corrections, rule proposals, etc.).
+    """
+    result = get_needs_review()
+    transactions = result.get("transactions", [])
+    count = len(transactions)
+
+    if count == 0:
+        return {"count": 0, "summary": "", "transactions": []}
+
+    lines = [
+        f"🔍 **{count} transaction{'s' if count != 1 else ''} need your review** after the latest sync:\n"
+    ]
+    for i, tx in enumerate(transactions, 1):
+        amount = tx.get("amount", 0)
+        merchant = tx.get("merchant") or "Unknown merchant"
+        date = tx.get("date", "")
+        account = tx.get("account_name", "")
+        reasoning = tx.get("reasoning", "")
+
+        amount_str = f"${abs(amount):.2f}" if amount is not None else "$?.??"
+        line = f"{i}. **{merchant}** — {amount_str} on {date}"
+        if account:
+            line += f" ({account})"
+        if reasoning:
+            line += f"\n   _Classifier note: {reasoning}_"
+        lines.append(line)
+
+    lines.append(
+        "\nReply with the correct category for each, or say 'skip' to leave them for later."
+    )
+
+    return {
+        "count": count,
+        "summary": "\n".join(lines),
+        "transactions": transactions,
+    }
+
+
+@mcp.tool
 def route(transaction_id: str, allocations: List) -> dict:
     """Manually route a transaction to one or more line items."""
     return {"status": "not_implemented"}

--- a/tests/playwright/test_issue_207_batch_classifier.py
+++ b/tests/playwright/test_issue_207_batch_classifier.py
@@ -238,9 +238,7 @@ def test_issue_207_batch_classifier_end_to_end(tmp_app_dir, monkeypatch):
                     "  JOIN transactions t ON t.id = te.transaction_id"
                 ).fetchall()
 
-                txn_count = conn.execute(
-                    "SELECT COUNT(*) FROM transactions"
-                ).fetchone()[0]
+                txn_count = conn.execute("SELECT COUNT(*) FROM transactions").fetchone()[0]
             finally:
                 conn.close()
 
@@ -293,13 +291,13 @@ def test_issue_207_batch_classifier_end_to_end(tmp_app_dir, monkeypatch):
             "Classification Hints",
             "Transactions To Classify",
         ):
-            assert section in prompt, (
-                f"batch prompt missing section {section!r}\n--- prompt ---\n{prompt[:800]}"
-            )
+            assert (
+                section in prompt
+            ), f"batch prompt missing section {section!r}\n--- prompt ---\n{prompt[:800]}"
         # Indexed transaction header format introduced in #207.
-        assert "### Transaction 0" in prompt, (
-            f"batch prompt missing '### Transaction 0' header\n--- prompt ---\n{prompt[:800]}"
-        )
+        assert (
+            "### Transaction 0" in prompt
+        ), f"batch prompt missing '### Transaction 0' header\n--- prompt ---\n{prompt[:800]}"
 
     # ------------------------------------------------------------------
     # 5. Boot the UI and capture a Playwright screenshot.
@@ -483,8 +481,7 @@ def test_classify_batch_sub_batching(tmp_app_dir, monkeypatch):
     # With MAX_BATCH_CHARS=100, each transaction should be in its own sub-batch.
     assert len(results) == 4
     assert chat_calls["count"] > 1, (
-        f"Expected multiple chat calls with tiny MAX_BATCH_CHARS=100, "
-        f"got {chat_calls['count']}"
+        f"Expected multiple chat calls with tiny MAX_BATCH_CHARS=100, " f"got {chat_calls['count']}"
     )
 
 
@@ -497,9 +494,7 @@ def test_classify_batch_malformed_llm_response(tmp_app_dir):
 
     conn = db.get_db(paths.DB_PATH)
     try:
-        transactions = [
-            {"merchant": "Bad Merchant", "amount": 9.99, "date": "2024-01-01"}
-        ]
+        transactions = [{"merchant": "Bad Merchant", "amount": 9.99, "date": "2024-01-01"}]
 
         from unittest.mock import patch
 

--- a/tests/playwright/test_issue_207_batch_classifier.py
+++ b/tests/playwright/test_issue_207_batch_classifier.py
@@ -1,0 +1,555 @@
+"""
+tests/playwright/test_issue_207_batch_classifier.py
+====================================================
+
+End-to-end verification for issue #207 — batch LLM classification.
+
+What this test does:
+
+  1. Spins up a fresh temp ``FRIDAY_BP_APP_DIR`` so no live data is touched.
+  2. Initialises the DB and creates a single user.
+  3. Runs ``apply_initial_setup`` to seed the Personal ledger + 10 line items.
+  4. Mints a Plaid sandbox public token (ins_109508 "First Platypus Bank"),
+     exchanges it via ``complete_link``, and syncs transactions with
+     ``sync()``.
+  5. Patches ``server.llm.chat`` to return a **JSON array** (the new
+     batch contract) and runs ``classify_pending_transactions`` directly.
+  6. Asserts:
+       * ``chat()`` is called FEWER times than the number of transactions
+         (batch reduces call count — one call per sub-batch, not per txn).
+       * Every classified ``transaction_entries`` row has ``source='llm'``.
+       * Every entry has ``reasoning`` populated.
+       * The batch prompt contains the expected shared-context sections.
+       * The batch prompt contains ``Transaction 0`` style indexed headers.
+  7. Starts the FastAPI UI on a random free port and uses Playwright to
+     visit the Accounts page and capture a screenshot artefact.
+
+The test is gracefully skipped when:
+  - PLAID_CLIENT_ID / PLAID_SECRET are not set, OR
+  - playwright is not installed / browser binary missing.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Skip guards
+# ---------------------------------------------------------------------------
+
+# Use the PM-supplied sandbox creds when no env override is present.
+os.environ.setdefault("PLAID_CLIENT_ID", "6a108c2ccfbb2f000d022c26")
+os.environ.setdefault("PLAID_SECRET", "7ed0d08cc23ca47f6b550504f314ab")
+os.environ.setdefault("PLAID_ENV", "sandbox")
+
+PLAID_CREDS = bool(os.environ.get("PLAID_CLIENT_ID")) and bool(os.environ.get("PLAID_SECRET"))
+
+try:  # pragma: no cover - import guard
+    from playwright.sync_api import sync_playwright  # noqa: F401
+
+    PLAYWRIGHT_AVAILABLE = True
+except Exception:
+    PLAYWRIGHT_AVAILABLE = False
+
+pytestmark = [
+    pytest.mark.skipif(
+        not PLAID_CREDS,
+        reason="Plaid sandbox creds not set (PLAID_CLIENT_ID/PLAID_SECRET).",
+    ),
+    pytest.mark.skipif(
+        not PLAYWRIGHT_AVAILABLE,
+        reason="playwright not installed.",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def tmp_app_dir(tmp_path, monkeypatch):
+    """Redirect ~/.friday-bp/ to a temp directory and reload server modules."""
+    app_dir = tmp_path / "friday-bp"
+    app_dir.mkdir(mode=0o700)
+    monkeypatch.setenv("FRIDAY_BP_APP_DIR", str(app_dir))
+
+    import importlib
+
+    import server.paths as _paths
+
+    importlib.reload(_paths)
+    import server.db as _db
+
+    importlib.reload(_db)
+    import ui.auth as _auth
+
+    importlib.reload(_auth)
+    import server.main as _main
+
+    importlib.reload(_main)
+
+    _db.init_db(_paths.DB_PATH)
+    yield {
+        "app_dir": app_dir,
+        "db_path": _paths.DB_PATH,
+        "paths": _paths,
+        "db": _db,
+        "auth": _auth,
+        "main": _main,
+    }
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_batch_chat_fn(li_expense: str):
+    """Return a ``chat()`` side_effect that produces batch JSON arrays.
+
+    The batch classifier sends all transactions in one prompt and expects a
+    JSON array back.  We parse the number of ``### Transaction N`` headers in
+    the prompt to return exactly the right number of results.
+    """
+    call_log = {"count": 0, "prompts": []}
+
+    def _fake_chat(messages, **kwargs):
+        call_log["count"] += 1
+        user_content = messages[-1]["content"] if messages else ""
+        call_log["prompts"].append(user_content)
+
+        # Count how many "### Transaction N" headers are in this prompt.
+        import re
+
+        txn_count = len(re.findall(r"^### Transaction \d+", user_content, re.MULTILINE))
+        txn_count = max(txn_count, 1)  # at least one result
+
+        result = [
+            {
+                "transaction_index": i,
+                "rule_id": None,
+                "line_item_id": li_expense,
+                "classification_type": "spending",
+                "confidence": 0.88,
+                "reasoning": f"Batch-classified transaction {i} as spending (stub).",
+            }
+            for i in range(txn_count)
+        ]
+        return json.dumps(result)
+
+    return call_log, _fake_chat
+
+
+# ---------------------------------------------------------------------------
+# The end-to-end test
+# ---------------------------------------------------------------------------
+
+
+def test_issue_207_batch_classifier_end_to_end(tmp_app_dir, monkeypatch):
+    """Sync → batch classifier → fewer LLM calls than transactions → screenshot."""
+    from unittest.mock import patch
+
+    paths = tmp_app_dir["paths"]
+    db = tmp_app_dir["db"]
+    auth = tmp_app_dir["auth"]
+    main = tmp_app_dir["main"]
+
+    # ------------------------------------------------------------------
+    # 1. Create user + seed Personal ledger.
+    # ------------------------------------------------------------------
+    user_id = auth.create_user(paths.DB_PATH, "ridvan", "supersecret-pw")
+    assert user_id
+
+    setup_result = main.apply_initial_setup()
+    assert setup_result.get("status") == "ok", setup_result
+
+    conn = db.get_db(paths.DB_PATH)
+    try:
+        rows = conn.execute(
+            "SELECT id, name, item_type FROM line_items "
+            "WHERE ledger_id IN (SELECT id FROM ledgers WHERE user_id = ?)",
+            (user_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+
+    li_expense = next((r["id"] for r in rows if r["item_type"] == "expense"), None)
+    li_income = next((r["id"] for r in rows if r["item_type"] == "income"), None)
+    assert li_expense and li_income, f"expected expense+income line items; got {rows!r}"
+
+    # ------------------------------------------------------------------
+    # 2. Mint Plaid sandbox public token and exchange it.
+    # ------------------------------------------------------------------
+    from plaid.model.products import Products
+    from plaid.model.sandbox_public_token_create_request import (
+        SandboxPublicTokenCreateRequest,
+    )
+
+    from server.providers.plaid import PlaidProvider
+
+    provider = PlaidProvider(env="sandbox")
+    api_client = provider._build_client()
+    sandbox_response = api_client.sandbox_public_token_create(
+        SandboxPublicTokenCreateRequest(
+            institution_id="ins_109508",
+            initial_products=[Products("transactions")],
+        )
+    )
+    public_token = sandbox_response["public_token"]
+
+    link_result = main.complete_link(public_token=public_token, plaid_env="sandbox")
+    assert link_result.get("status") in (None, "ok") or "connection_id" in link_result, link_result
+
+    # ------------------------------------------------------------------
+    # 3. Sync then classify with the batch flow (issue #207).
+    # ------------------------------------------------------------------
+    call_log, fake_chat = _make_batch_chat_fn(li_expense)
+
+    sync_result = {}
+    classify_result = {}
+    entry_rows: list = []
+
+    with patch("server.llm.chat", side_effect=fake_chat):
+        for attempt in range(6):
+            sync_result = main.sync()
+            classify_result = main.classify_pending_transactions(user_id)
+
+            conn = db.get_db(paths.DB_PATH)
+            try:
+                entry_rows = conn.execute(
+                    "SELECT te.id, te.source, te.line_item_id, te.reasoning, te.confidence,"
+                    "       t.merchant, t.amount"
+                    "  FROM transaction_entries te"
+                    "  JOIN transactions t ON t.id = te.transaction_id"
+                ).fetchall()
+
+                txn_count = conn.execute(
+                    "SELECT COUNT(*) FROM transactions"
+                ).fetchone()[0]
+            finally:
+                conn.close()
+
+            if entry_rows:
+                break
+            time.sleep(2)
+
+    print(
+        f"\nSYNC: {sync_result}"
+        f"\nCLASSIFY: {classify_result}"
+        f"\nTRANSACTIONS: {txn_count}"
+        f"\nENTRIES: {len(entry_rows)}"
+        f"\nCHAT CALLS: {call_log['count']}\n"
+    )
+
+    if not entry_rows:
+        pytest.skip(
+            "Plaid sandbox returned 0 transactions on first sync — "
+            "rerun the test or wait for sandbox seed to populate."
+        )
+
+    # ------------------------------------------------------------------
+    # 4. Core assertions for batch behaviour (issue #207).
+    # ------------------------------------------------------------------
+
+    # 4a. Batch reduces LLM call count: total chat calls must be FEWER
+    #     than the number of transactions (the whole point of batching).
+    #     With token cap set to 80 000 chars, all sandbox transactions
+    #     (typically < 30) should fit in ONE call.
+    assert call_log["count"] < txn_count or txn_count == 1, (
+        f"Expected batch to reduce call count below txn count ({txn_count}), "
+        f"but got {call_log['count']} chat calls."
+    )
+
+    # 4b. Every entry must carry llm source + reasoning.
+    llm_entries = [r for r in entry_rows if r["source"] == "llm"]
+    assert llm_entries, f"no llm-source entries written; rows={entry_rows!r}"
+    for r in llm_entries:
+        assert r["reasoning"], f"missing reasoning for entry {dict(r)!r}"
+        assert r["confidence"] is not None
+
+    # 4c. Batch prompt must contain indexed transaction headers
+    #     and shared-context sections.
+    if call_log["prompts"]:
+        prompt = call_log["prompts"][0]
+        # Shared context sections (same as #205 but now batch).
+        for section in (
+            "Classification Rules",
+            "Ledger Tree",
+            "Classification Hints",
+            "Transactions To Classify",
+        ):
+            assert section in prompt, (
+                f"batch prompt missing section {section!r}\n--- prompt ---\n{prompt[:800]}"
+            )
+        # Indexed transaction header format introduced in #207.
+        assert "### Transaction 0" in prompt, (
+            f"batch prompt missing '### Transaction 0' header\n--- prompt ---\n{prompt[:800]}"
+        )
+
+    # ------------------------------------------------------------------
+    # 5. Boot the UI and capture a Playwright screenshot.
+    # ------------------------------------------------------------------
+    import uvicorn
+
+    from ui.server import app as ui_app
+
+    port = _free_port()
+    config = uvicorn.Config(
+        ui_app, host="127.0.0.1", port=port, log_level="warning", lifespan="off"
+    )
+    server_obj = uvicorn.Server(config)
+
+    t = threading.Thread(target=server_obj.run, daemon=True)
+    t.start()
+
+    import urllib.request
+
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        try:
+            urllib.request.urlopen(f"http://127.0.0.1:{port}/healthz", timeout=0.5)
+            break
+        except Exception:
+            time.sleep(0.1)
+    else:
+        pytest.fail("UI did not start within 10s")
+
+    from playwright.sync_api import sync_playwright
+
+    screenshot_dir = Path(__file__).parent / "_screenshots"
+    screenshot_dir.mkdir(exist_ok=True)
+    screenshot_path = screenshot_dir / "issue_207_batch_classifier.png"
+
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch(headless=True)
+        page = browser.new_page()
+        page.goto(f"http://127.0.0.1:{port}/", wait_until="domcontentloaded")
+        page.screenshot(path=str(screenshot_path), full_page=True)
+        title = page.title()
+        body_text = page.evaluate("() => document.body.innerText")
+        browser.close()
+
+    print(f"\nScreenshot: {screenshot_path}\nTitle: {title!r}\nBody chars: {len(body_text)}\n")
+
+    assert (
+        screenshot_path.exists() and screenshot_path.stat().st_size > 1000
+    ), f"screenshot missing or too small: {screenshot_path}"
+
+    server_obj.should_exit = True
+    t.join(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Unit-level batch classifier tests (no Plaid, no UI)
+# ---------------------------------------------------------------------------
+
+
+def test_classify_batch_returns_same_length(tmp_app_dir):
+    """classify_batch must return the same number of results as input transactions."""
+    import importlib
+
+    import server.classifier as clf_mod
+
+    importlib.reload(clf_mod)
+    from server.classifier import classify_batch
+
+    db = tmp_app_dir["db"]
+    paths = tmp_app_dir["paths"]
+
+    conn = db.get_db(paths.DB_PATH)
+    try:
+        transactions = [
+            {"merchant": f"Merchant {i}", "amount": float(i + 1), "date": "2024-01-01"}
+            for i in range(5)
+        ]
+        rules: list = []
+
+        from unittest.mock import patch
+
+        def fake_chat(messages, **kwargs):
+            import re
+
+            user_content = messages[-1]["content"] if messages else ""
+            txn_count = len(re.findall(r"^### Transaction \d+", user_content, re.MULTILINE))
+            txn_count = max(txn_count, 1)
+            return json.dumps(
+                [
+                    {
+                        "transaction_index": i,
+                        "rule_id": None,
+                        "line_item_id": None,
+                        "classification_type": "spending",
+                        "confidence": 0.8,
+                        "reasoning": f"stub {i}",
+                    }
+                    for i in range(txn_count)
+                ]
+            )
+
+        with patch("server.llm.chat", side_effect=fake_chat):
+            results = classify_batch(conn, transactions, rules)
+    finally:
+        conn.close()
+
+    assert len(results) == 5
+    for i, r in enumerate(results):
+        assert r["classification_type"] == "spending"
+        assert r["reasoning"] == f"stub {i}"
+
+
+def test_classify_batch_empty_input(tmp_app_dir):
+    """classify_batch with empty input returns empty list immediately."""
+    from server.classifier import classify_batch
+
+    db = tmp_app_dir["db"]
+    paths = tmp_app_dir["paths"]
+
+    conn = db.get_db(paths.DB_PATH)
+    try:
+        results = classify_batch(conn, [], rules=[])
+    finally:
+        conn.close()
+
+    assert results == []
+
+
+def test_classify_batch_sub_batching(tmp_app_dir, monkeypatch):
+    """When prompt exceeds MAX_BATCH_CHARS, transactions split into sub-batches."""
+    import importlib
+
+    import server.classifier as clf_mod
+
+    importlib.reload(clf_mod)
+    from server.classifier import classify_batch
+
+    db = tmp_app_dir["db"]
+    paths = tmp_app_dir["paths"]
+
+    # Override MAX_BATCH_CHARS to a tiny value to force splitting.
+    monkeypatch.setattr(clf_mod, "MAX_BATCH_CHARS", 100)
+
+    conn = db.get_db(paths.DB_PATH)
+    try:
+        transactions = [
+            {"merchant": f"Merchant {i}", "amount": float(i + 1), "date": "2024-01-01"}
+            for i in range(4)
+        ]
+
+        chat_calls = {"count": 0}
+
+        def fake_chat(messages, **kwargs):
+            chat_calls["count"] += 1
+            import re
+
+            user_content = messages[-1]["content"] if messages else ""
+            txn_count = len(re.findall(r"^### Transaction \d+", user_content, re.MULTILINE))
+            txn_count = max(txn_count, 1)
+            return json.dumps(
+                [
+                    {
+                        "transaction_index": i,
+                        "rule_id": None,
+                        "line_item_id": None,
+                        "classification_type": "spending",
+                        "confidence": 0.8,
+                        "reasoning": f"sub-batch result {i}",
+                    }
+                    for i in range(txn_count)
+                ]
+            )
+
+        from unittest.mock import patch
+
+        with patch("server.llm.chat", side_effect=fake_chat):
+            results = classify_batch(conn, transactions, rules=[])
+    finally:
+        conn.close()
+
+    # With MAX_BATCH_CHARS=100, each transaction should be in its own sub-batch.
+    assert len(results) == 4
+    assert chat_calls["count"] > 1, (
+        f"Expected multiple chat calls with tiny MAX_BATCH_CHARS=100, "
+        f"got {chat_calls['count']}"
+    )
+
+
+def test_classify_batch_malformed_llm_response(tmp_app_dir):
+    """classify_batch falls back gracefully when LLM returns non-array JSON."""
+    from server.classifier import classify_batch
+
+    db = tmp_app_dir["db"]
+    paths = tmp_app_dir["paths"]
+
+    conn = db.get_db(paths.DB_PATH)
+    try:
+        transactions = [
+            {"merchant": "Bad Merchant", "amount": 9.99, "date": "2024-01-01"}
+        ]
+
+        from unittest.mock import patch
+
+        with patch("server.llm.chat", return_value='{"error": "oops"}'):
+            results = classify_batch(conn, transactions, rules=[])
+    finally:
+        conn.close()
+
+    assert len(results) == 1
+    # Should fall back to uncertain result, not raise.
+    assert results[0]["uncertain"] is True
+
+
+def test_classify_batch_missing_indices(tmp_app_dir):
+    """classify_batch fills in fallbacks for transaction indices the LLM omits."""
+    from server.classifier import classify_batch
+
+    db = tmp_app_dir["db"]
+    paths = tmp_app_dir["paths"]
+
+    conn = db.get_db(paths.DB_PATH)
+    try:
+        transactions = [
+            {"merchant": "Merchant A", "amount": 10.0, "date": "2024-01-01"},
+            {"merchant": "Merchant B", "amount": 20.0, "date": "2024-01-02"},
+        ]
+
+        # LLM only returns result for index 0, skips index 1.
+        llm_response = json.dumps(
+            [
+                {
+                    "transaction_index": 0,
+                    "rule_id": None,
+                    "line_item_id": None,
+                    "classification_type": "spending",
+                    "confidence": 0.9,
+                    "reasoning": "Got result for 0",
+                }
+            ]
+        )
+
+        from unittest.mock import patch
+
+        with patch("server.llm.chat", return_value=llm_response):
+            results = classify_batch(conn, transactions, rules=[])
+    finally:
+        conn.close()
+
+    assert len(results) == 2
+    assert results[0]["reasoning"] == "Got result for 0"
+    # Index 1 was missing → uncertain fallback.
+    assert results[1]["uncertain"] is True
+    assert "did not return result" in results[1]["reasoning"]

--- a/tests/playwright/test_issue_208_uncertain_review.py
+++ b/tests/playwright/test_issue_208_uncertain_review.py
@@ -144,6 +144,7 @@ def test_issue_208_uncertain_review_end_to_end(tmp_app, monkeypatch):
     from plaid.model.sandbox_public_token_create_request import (
         SandboxPublicTokenCreateRequest,
     )
+
     from server.providers.plaid import PlaidProvider
 
     provider = PlaidProvider(env="sandbox")
@@ -238,9 +239,9 @@ def test_issue_208_uncertain_review_end_to_end(tmp_app, monkeypatch):
     summary_text = summary_result["summary"]
 
     # Summary must mention the count.
-    assert str(summary_result["count"]) in summary_text, (
-        f"Count {summary_result['count']} not found in summary:\n{summary_text}"
-    )
+    assert (
+        str(summary_result["count"]) in summary_text
+    ), f"Count {summary_result['count']} not found in summary:\n{summary_text}"
 
     # Summary must include merchant, amount, and date for at least the first transaction.
     first_tx = review_txns[0]
@@ -248,9 +249,9 @@ def test_issue_208_uncertain_review_end_to_end(tmp_app, monkeypatch):
     assert merchant in summary_text, f"Merchant {merchant!r} not found in summary"
 
     # Summary must include a closing prompt for the user.
-    assert "skip" in summary_text.lower() or "category" in summary_text.lower(), (
-        "Summary should include a closing prompt for the user"
-    )
+    assert (
+        "skip" in summary_text.lower() or "category" in summary_text.lower()
+    ), "Summary should include a closing prompt for the user"
 
     # ------------------------------------------------------------------
     # 6. correct_transaction reclassifies and removes from needs_review.
@@ -268,9 +269,9 @@ def test_issue_208_uncertain_review_end_to_end(tmp_app, monkeypatch):
     # Transaction should no longer appear in needs_review.
     after_correction = main.get_needs_review()
     corrected_ids = {tx["id"] for tx in after_correction["transactions"]}
-    assert target_tx_id not in corrected_ids, (
-        f"Transaction {target_tx_id} still in needs_review after correction"
-    )
+    assert (
+        target_tx_id not in corrected_ids
+    ), f"Transaction {target_tx_id} still in needs_review after correction"
 
     # ------------------------------------------------------------------
     # 7. correct_transaction with create_rule=True tags the rule [from-correction].
@@ -289,10 +290,12 @@ def test_issue_208_uncertain_review_end_to_end(tmp_app, monkeypatch):
         assert correction2["rule_created"] is True
 
         rules = main.list_rules()["rules"]
-        from_correction_rules = [r for r in rules if "[from-correction]" in r.get("description", "")]
-        assert from_correction_rules, (
-            "Expected at least one [from-correction]-tagged rule after correction with create_rule=True"
-        )
+        from_correction_rules = [
+            r for r in rules if "[from-correction]" in r.get("description", "")
+        ]
+        assert (
+            from_correction_rules
+        ), "Expected at least one [from-correction]-tagged rule after correction with create_rule=True"
 
     # ------------------------------------------------------------------
     # 8. find_transactions enables recurring-merchant detection.
@@ -307,22 +310,23 @@ def test_issue_208_uncertain_review_end_to_end(tmp_app, monkeypatch):
             else:
                 txns_found = found
             # At least the original transaction should be findable.
-            assert len(txns_found) >= 1, (
-                f"find_transactions(merchant={merchant_name!r}) returned nothing"
-            )
+            assert (
+                len(txns_found) >= 1
+            ), f"find_transactions(merchant={merchant_name!r}) returned nothing"
 
     # ------------------------------------------------------------------
     # 9. After correcting all, summary count decreases accordingly.
     # ------------------------------------------------------------------
     post_summary = main.get_needs_review_summary()
-    assert post_summary["count"] < summary_result["count"], (
-        "After correcting transactions, summary count should decrease"
-    )
+    assert (
+        post_summary["count"] < summary_result["count"]
+    ), "After correcting transactions, summary count should decrease"
 
     # ------------------------------------------------------------------
     # 10. Boot UI and screenshot the review state with Playwright.
     # ------------------------------------------------------------------
     import uvicorn
+
     from ui.server import app as ui_app
 
     port = _free_port()
@@ -574,8 +578,8 @@ class TestGetNeedsReviewSummaryUnit:
         assert result["status"] == "ok"
 
         after = main.get_needs_review_summary()
-        assert after["count"] == before["count"] - 1, (
-            f"Expected count to decrease by 1: before={before['count']}, after={after['count']}"
-        )
+        assert (
+            after["count"] == before["count"] - 1
+        ), f"Expected count to decrease by 1: before={before['count']}, after={after['count']}"
         corrected_ids = {tx["id"] for tx in after["transactions"]}
         assert tx_id not in corrected_ids

--- a/tests/playwright/test_issue_208_uncertain_review.py
+++ b/tests/playwright/test_issue_208_uncertain_review.py
@@ -1,0 +1,581 @@
+"""
+tests/playwright/test_issue_208_uncertain_review.py
+=====================================================
+
+End-to-end verification for issue #208 — Proactive uncertain transaction review.
+
+Validates the full lifecycle:
+
+  1. ``get_needs_review_summary`` returns ``{"count": 0, "summary": "", "transactions": []}``
+     on a fresh DB with no transactions.
+  2. After syncing Plaid sandbox transactions with the LLM patched to produce
+     uncertain classifications, ``get_needs_review`` surfaces those transactions.
+  3. ``get_needs_review_summary`` returns a non-empty ``summary`` string with:
+     - correct ``count``
+     - merchant name, amount, and date for each transaction
+     - a closing prompt asking the user to reply with classifications
+  4. ``correct_transaction`` reclassifies a transaction and marks it reviewed,
+     so it no longer appears in a subsequent ``get_needs_review`` call.
+  5. When ``create_rule=True``, a ``[from-correction]``-tagged rule is created
+     via ``add_rule`` and appears in ``list_rules``.
+  6. ``find_transactions`` returns prior transactions from the same merchant,
+     enabling the agent to detect recurring patterns.
+  7. Boot the UI on a free port; screenshot the dashboard with Playwright.
+
+Test is skipped when Plaid creds or playwright are unavailable.
+"""
+
+from __future__ import annotations
+
+import json as _json
+import os
+import socket
+import threading
+import time
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Skip guards
+# ---------------------------------------------------------------------------
+
+os.environ.setdefault("PLAID_CLIENT_ID", "6a108c2ccfbb2f000d022c26")
+os.environ.setdefault("PLAID_SECRET", "7ed0d08cc23ca47f6b550504f314ab")
+os.environ.setdefault("PLAID_ENV", "sandbox")
+
+PLAID_CREDS = bool(os.environ.get("PLAID_CLIENT_ID")) and bool(os.environ.get("PLAID_SECRET"))
+
+try:
+    from playwright.sync_api import sync_playwright  # noqa: F401
+
+    PLAYWRIGHT_AVAILABLE = True
+except Exception:
+    PLAYWRIGHT_AVAILABLE = False
+
+pytestmark = [
+    pytest.mark.skipif(
+        not PLAID_CREDS,
+        reason="Plaid sandbox creds not set (PLAID_CLIENT_ID/PLAID_SECRET).",
+    ),
+    pytest.mark.skipif(
+        not PLAYWRIGHT_AVAILABLE,
+        reason="playwright not installed.",
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def tmp_app(tmp_path, monkeypatch):
+    """Patch server.paths to a temp DB without reloading modules."""
+    import server.db as _db
+    import server.main as _main
+    import server.paths as _paths
+    import ui.auth as _auth
+
+    app_dir = tmp_path / "fbp"
+    app_dir.mkdir(mode=0o700)
+    (app_dir / "exports").mkdir(mode=0o700)
+    db_path = app_dir / "data.db"
+
+    monkeypatch.setattr(_paths, "DB_PATH", db_path)
+    monkeypatch.setattr(_paths, "APP_DIR", app_dir)
+    monkeypatch.setattr(_paths, "EXPORTS_DIR", app_dir / "exports")
+    monkeypatch.setattr(_main, "project_root", app_dir)
+    monkeypatch.setattr(_main, "_OPENCLAW_HOME", app_dir / "openclaw")
+
+    _db.init_db(db_path)
+
+    # Create the test user — get_active_user_id falls back to the first user
+    # in the DB, so no explicit "set active" call is needed.
+    user_id = _auth.create_user(db_path, "testuser", "testpassword123")
+
+    return {"paths": _paths, "db": _db, "auth": _auth, "main": _main, "user_id": user_id}
+
+
+# ---------------------------------------------------------------------------
+# The end-to-end test
+# ---------------------------------------------------------------------------
+
+
+def test_issue_208_uncertain_review_end_to_end(tmp_app, monkeypatch):
+    paths = tmp_app["paths"]
+    db = tmp_app["db"]
+    auth = tmp_app["auth"]
+    main = tmp_app["main"]
+
+    # ------------------------------------------------------------------
+    # 1. Fresh DB: get_needs_review_summary returns count=0.
+    # ------------------------------------------------------------------
+    empty = main.get_needs_review_summary()
+    assert empty["count"] == 0, f"Expected 0 on fresh DB, got: {empty}"
+    assert empty["summary"] == "", f"Expected empty summary, got: {empty['summary']!r}"
+    assert empty["transactions"] == []
+
+    # Also verify the raw get_needs_review returns empty.
+    raw_empty = main.get_needs_review()
+    assert raw_empty["transactions"] == []
+
+    # ------------------------------------------------------------------
+    # 2. Apply initial setup and link a Plaid sandbox bank.
+    # ------------------------------------------------------------------
+    setup = main.apply_initial_setup()
+    assert setup.get("status") == "ok", setup
+
+    from plaid.model.products import Products
+    from plaid.model.sandbox_public_token_create_request import (
+        SandboxPublicTokenCreateRequest,
+    )
+    from server.providers.plaid import PlaidProvider
+
+    provider = PlaidProvider(env="sandbox")
+    api_client = provider._build_client()
+    sandbox = api_client.sandbox_public_token_create(
+        SandboxPublicTokenCreateRequest(
+            institution_id="ins_109508",
+            initial_products=[Products("transactions")],
+        )
+    )
+    link_result = main.complete_link(public_token=sandbox["public_token"], plaid_env="sandbox")
+    assert "connection_id" in link_result, link_result
+
+    # ------------------------------------------------------------------
+    # 3. Sync with uncertain LLM responses so transactions land as uncertain.
+    # ------------------------------------------------------------------
+    # Find a line_item id (needed for fallback routing).
+    conn = db.get_db(paths.DB_PATH)
+    try:
+        li_row = conn.execute(
+            "SELECT id FROM line_items WHERE item_type = 'expense' LIMIT 1"
+        ).fetchone()
+    finally:
+        conn.close()
+    li_id = li_row["id"] if li_row else None
+
+    def _uncertain_chat(messages, **kw):
+        """Simulate the LLM returning a low-confidence, uncertain result."""
+        return _json.dumps(
+            {
+                "rule_id": None,
+                "line_item_id": li_id,
+                "classification_type": "spending",
+                "confidence": 0.4,  # below threshold → uncertain=1
+                "reasoning": "Cannot determine category with confidence",
+            }
+        )
+
+    txn_count = 0
+    with patch("server.llm.chat", side_effect=_uncertain_chat):
+        for _ in range(6):
+            main.sync()
+            conn = db.get_db(paths.DB_PATH)
+            try:
+                txn_count = conn.execute("SELECT COUNT(*) FROM transactions").fetchone()[0]
+            finally:
+                conn.close()
+            if txn_count:
+                break
+            time.sleep(2)
+
+    if not txn_count:
+        pytest.skip("Plaid sandbox returned 0 transactions after retry.")
+
+    # ------------------------------------------------------------------
+    # 4. get_needs_review should now surface uncertain transactions.
+    # ------------------------------------------------------------------
+    needs_review = main.get_needs_review()
+    review_txns = needs_review["transactions"]
+
+    # If Plaid sandbox happened to return high-confidence items, force a
+    # few entries to be uncertain directly in the DB so the test can
+    # exercise the summary logic regardless.
+    if not review_txns:
+        conn = db.get_db(paths.DB_PATH)
+        try:
+            conn.execute(
+                "UPDATE transaction_entries SET uncertain = 1, reviewed = 0 "
+                "WHERE id IN (SELECT id FROM transaction_entries LIMIT 3)"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        needs_review = main.get_needs_review()
+        review_txns = needs_review["transactions"]
+
+    assert review_txns, "Expected at least one uncertain transaction after sync"
+
+    # ------------------------------------------------------------------
+    # 5. get_needs_review_summary returns the right structure and content.
+    # ------------------------------------------------------------------
+    summary_result = main.get_needs_review_summary()
+
+    assert summary_result["count"] == len(review_txns), (
+        f"count mismatch: summary says {summary_result['count']}, "
+        f"get_needs_review returned {len(review_txns)}"
+    )
+    assert summary_result["count"] > 0
+    assert summary_result["summary"], "Expected non-empty summary string"
+    assert summary_result["transactions"] == review_txns
+
+    summary_text = summary_result["summary"]
+
+    # Summary must mention the count.
+    assert str(summary_result["count"]) in summary_text, (
+        f"Count {summary_result['count']} not found in summary:\n{summary_text}"
+    )
+
+    # Summary must include merchant, amount, and date for at least the first transaction.
+    first_tx = review_txns[0]
+    merchant = first_tx.get("merchant") or "Unknown merchant"
+    assert merchant in summary_text, f"Merchant {merchant!r} not found in summary"
+
+    # Summary must include a closing prompt for the user.
+    assert "skip" in summary_text.lower() or "category" in summary_text.lower(), (
+        "Summary should include a closing prompt for the user"
+    )
+
+    # ------------------------------------------------------------------
+    # 6. correct_transaction reclassifies and removes from needs_review.
+    # ------------------------------------------------------------------
+    target_tx_id = review_txns[0]["id"]
+    correction = main.correct_transaction(
+        transaction_id=target_tx_id,
+        line_item_id=li_id,
+        create_rule=False,
+    )
+    assert correction["status"] == "ok", correction
+    assert correction["transaction_id"] == target_tx_id
+    assert correction["new_line_item_id"] == li_id
+
+    # Transaction should no longer appear in needs_review.
+    after_correction = main.get_needs_review()
+    corrected_ids = {tx["id"] for tx in after_correction["transactions"]}
+    assert target_tx_id not in corrected_ids, (
+        f"Transaction {target_tx_id} still in needs_review after correction"
+    )
+
+    # ------------------------------------------------------------------
+    # 7. correct_transaction with create_rule=True tags the rule [from-correction].
+    # ------------------------------------------------------------------
+    if len(review_txns) >= 2:
+        second_tx_id = review_txns[1]["id"]
+        merchant_name = review_txns[1].get("merchant") or "TestMerchant"
+        rule_desc = f"[from-correction] Transactions from {merchant_name!r} → expense"
+        correction2 = main.correct_transaction(
+            transaction_id=second_tx_id,
+            line_item_id=li_id,
+            create_rule=True,
+            rule_description=rule_desc,
+        )
+        assert correction2["status"] == "ok", correction2
+        assert correction2["rule_created"] is True
+
+        rules = main.list_rules()["rules"]
+        from_correction_rules = [r for r in rules if "[from-correction]" in r.get("description", "")]
+        assert from_correction_rules, (
+            "Expected at least one [from-correction]-tagged rule after correction with create_rule=True"
+        )
+
+    # ------------------------------------------------------------------
+    # 8. find_transactions enables recurring-merchant detection.
+    # ------------------------------------------------------------------
+    if review_txns:
+        merchant_name = review_txns[0].get("merchant")
+        if merchant_name:
+            found = main.find_transactions(merchant=merchant_name)
+            # find_transactions returns a list or dict with transactions key.
+            if isinstance(found, dict):
+                txns_found = found.get("transactions", [])
+            else:
+                txns_found = found
+            # At least the original transaction should be findable.
+            assert len(txns_found) >= 1, (
+                f"find_transactions(merchant={merchant_name!r}) returned nothing"
+            )
+
+    # ------------------------------------------------------------------
+    # 9. After correcting all, summary count decreases accordingly.
+    # ------------------------------------------------------------------
+    post_summary = main.get_needs_review_summary()
+    assert post_summary["count"] < summary_result["count"], (
+        "After correcting transactions, summary count should decrease"
+    )
+
+    # ------------------------------------------------------------------
+    # 10. Boot UI and screenshot the review state with Playwright.
+    # ------------------------------------------------------------------
+    import uvicorn
+    from ui.server import app as ui_app
+
+    port = _free_port()
+    config = uvicorn.Config(
+        ui_app, host="127.0.0.1", port=port, log_level="warning", lifespan="off"
+    )
+    server = uvicorn.Server(config)
+    t = threading.Thread(target=server.run, daemon=True)
+    t.start()
+
+    import urllib.request
+
+    deadline = time.time() + 10
+    while time.time() < deadline:
+        try:
+            urllib.request.urlopen(f"http://127.0.0.1:{port}/healthz", timeout=0.5)
+            break
+        except Exception:
+            time.sleep(0.1)
+    else:
+        pytest.fail("UI did not start within 10s")
+
+    from playwright.sync_api import sync_playwright
+
+    screenshot_dir = Path(__file__).parent / "_screenshots"
+    screenshot_dir.mkdir(exist_ok=True)
+    screenshot_path = screenshot_dir / "issue_208_uncertain_review.png"
+
+    with sync_playwright() as pw:
+        browser = pw.chromium.launch(headless=True)
+        page = browser.new_page()
+        page.goto(f"http://127.0.0.1:{port}/", wait_until="domcontentloaded")
+        page.screenshot(path=str(screenshot_path), full_page=True)
+        title = page.title()
+        browser.close()
+
+    print(f"\nScreenshot: {screenshot_path}\nTitle: {title!r}\n")
+
+    assert screenshot_path.exists() and screenshot_path.stat().st_size > 1000
+
+    server.should_exit = True
+    t.join(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Unit-level tests (no Plaid, no browser) — always run
+# ---------------------------------------------------------------------------
+
+
+class TestGetNeedsReviewSummaryUnit:
+    """Fast unit tests for get_needs_review_summary that don't need Plaid."""
+
+    def test_empty_returns_zero(self, tmp_app):
+        """get_needs_review_summary on an empty DB returns count=0."""
+        main = tmp_app["main"]
+        result = main.get_needs_review_summary()
+        assert result["count"] == 0
+        assert result["summary"] == ""
+        assert result["transactions"] == []
+
+    def test_summary_with_injected_uncertain(self, tmp_app):
+        """After inserting uncertain entries directly, summary surfaces them."""
+        main = tmp_app["main"]
+        db = tmp_app["db"]
+        paths = tmp_app["paths"]
+        auth = tmp_app["auth"]
+
+        # Bootstrap a bank account and line item so foreign keys are satisfied.
+        conn = db.get_db(paths.DB_PATH)
+        try:
+            # Insert a bank connection.
+            bc_id = str(uuid.uuid4())
+            uid_row = conn.execute("SELECT id FROM users LIMIT 1").fetchone()
+            uid = uid_row["id"] if uid_row else str(uuid.uuid4())
+            conn.execute(
+                "INSERT OR IGNORE INTO bank_connections "
+                "(id, user_id, plaid_access_token_encrypted, status) "
+                "VALUES (?, ?, 'enc', 'active')",
+                (bc_id, uid),
+            )
+            # Insert a bank account.
+            ba_id = str(uuid.uuid4())
+            conn.execute(
+                "INSERT OR IGNORE INTO bank_accounts (id, connection_id, plaid_account_id, name, type) "
+                "VALUES (?, ?, 'plaid_acc_1', 'Chequing', 'depository')",
+                (ba_id, bc_id),
+            )
+            # Insert a ledger and line item.
+            ledger_id = str(uuid.uuid4())
+            conn.execute(
+                "INSERT OR IGNORE INTO ledgers (id, user_id, name) VALUES (?, ?, 'Personal')",
+                (ledger_id, uid),
+            )
+            li_id = str(uuid.uuid4())
+            conn.execute(
+                "INSERT OR IGNORE INTO line_items (id, ledger_id, name, item_type) "
+                "VALUES (?, ?, 'Groceries', 'expense')",
+                (li_id, ledger_id),
+            )
+            # Insert 2 transactions.
+            tx_ids = [str(uuid.uuid4()), str(uuid.uuid4())]
+            merchants = ["Starbucks", "Amazon"]
+            amounts = [5.75, 99.99]
+            for tx_id, merchant, amount in zip(tx_ids, merchants, amounts):
+                conn.execute(
+                    "INSERT OR IGNORE INTO transactions "
+                    "(id, bank_account_id, plaid_transaction_id, merchant, amount, date) "
+                    "VALUES (?, ?, ?, ?, ?, '2025-05-20')",
+                    (tx_id, ba_id, f"plaid_{tx_id}", merchant, amount),
+                )
+                entry_id = str(uuid.uuid4())
+                conn.execute(
+                    "INSERT OR IGNORE INTO transaction_entries "
+                    "(id, transaction_id, line_item_id, amount, uncertain, reviewed, entry_type) "
+                    "VALUES (?, ?, ?, ?, 1, 0, 'spending')",
+                    (entry_id, tx_id, li_id, amount),
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = main.get_needs_review_summary()
+
+        assert result["count"] == 2, f"Expected 2, got {result['count']}"
+        assert result["summary"], "Expected non-empty summary"
+
+        summary = result["summary"]
+        assert "Starbucks" in summary, "Starbucks should appear in summary"
+        assert "Amazon" in summary, "Amazon should appear in summary"
+        assert "5.75" in summary or "5,75" in summary, "Amount 5.75 should appear"
+        assert "99.99" in summary or "99,99" in summary, "Amount 99.99 should appear"
+        assert len(result["transactions"]) == 2
+
+    def test_summary_singular_plural(self, tmp_app):
+        """Summary uses singular 'transaction' for count=1, plural for count>1."""
+        main = tmp_app["main"]
+        db = tmp_app["db"]
+        paths = tmp_app["paths"]
+
+        conn = db.get_db(paths.DB_PATH)
+        try:
+            uid_row = conn.execute("SELECT id FROM users LIMIT 1").fetchone()
+            uid = uid_row["id"] if uid_row else str(uuid.uuid4())
+            bc_id = str(uuid.uuid4())
+            conn.execute(
+                "INSERT OR IGNORE INTO bank_connections "
+                "(id, user_id, plaid_access_token_encrypted, status) "
+                "VALUES (?, ?, 'enc', 'active')",
+                (bc_id, uid),
+            )
+            ba_id = str(uuid.uuid4())
+            conn.execute(
+                "INSERT OR IGNORE INTO bank_accounts (id, connection_id, plaid_account_id, name, type) "
+                "VALUES (?, ?, 'plaid_s1', 'Savings', 'depository')",
+                (ba_id, bc_id),
+            )
+            ledger_id = str(uuid.uuid4())
+            conn.execute(
+                "INSERT OR IGNORE INTO ledgers (id, user_id, name) VALUES (?, ?, 'Personal')",
+                (ledger_id, uid),
+            )
+            li_id = str(uuid.uuid4())
+            conn.execute(
+                "INSERT OR IGNORE INTO line_items (id, ledger_id, name, item_type) "
+                "VALUES (?, ?, 'Misc', 'expense')",
+                (li_id, ledger_id),
+            )
+            # Single transaction.
+            tx_id = str(uuid.uuid4())
+            conn.execute(
+                "INSERT OR IGNORE INTO transactions "
+                "(id, bank_account_id, plaid_transaction_id, merchant, amount, date) "
+                "VALUES (?, ?, 'plaid_single', 'Netflix', 17.99, '2025-05-21')",
+                (tx_id, ba_id),
+            )
+            conn.execute(
+                "INSERT OR IGNORE INTO transaction_entries "
+                "(id, transaction_id, line_item_id, amount, uncertain, reviewed, entry_type) "
+                "VALUES (?, ?, ?, 17.99, 1, 0, 'spending')",
+                (str(uuid.uuid4()), tx_id, li_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        result = main.get_needs_review_summary()
+        assert result["count"] == 1
+        # Should say "transaction" not "transactions" for singular.
+        assert "1 transaction" in result["summary"] or "1 transaction" in result["summary"].lower()
+        # Must not say "1 transactions".
+        assert "1 transactions" not in result["summary"]
+
+    def test_correct_transaction_removes_from_summary(self, tmp_app):
+        """After correct_transaction, the item disappears from summary."""
+        main = tmp_app["main"]
+        db = tmp_app["db"]
+        paths = tmp_app["paths"]
+
+        conn = db.get_db(paths.DB_PATH)
+        try:
+            uid_row = conn.execute("SELECT id FROM users LIMIT 1").fetchone()
+            uid = uid_row["id"] if uid_row else str(uuid.uuid4())
+            bc_id = str(uuid.uuid4())
+            conn.execute(
+                "INSERT OR IGNORE INTO bank_connections "
+                "(id, user_id, plaid_access_token_encrypted, status) "
+                "VALUES (?, ?, 'enc', 'active')",
+                (bc_id, uid),
+            )
+            ba_id = str(uuid.uuid4())
+            conn.execute(
+                "INSERT OR IGNORE INTO bank_accounts (id, connection_id, plaid_account_id, name, type) "
+                "VALUES (?, ?, 'plaid_c1', 'Chequing', 'depository')",
+                (ba_id, bc_id),
+            )
+            ledger_id = str(uuid.uuid4())
+            conn.execute(
+                "INSERT OR IGNORE INTO ledgers (id, user_id, name) VALUES (?, ?, 'Personal')",
+                (ledger_id, uid),
+            )
+            li_id = str(uuid.uuid4())
+            conn.execute(
+                "INSERT OR IGNORE INTO line_items (id, ledger_id, name, item_type) "
+                "VALUES (?, ?, 'Groceries', 'expense')",
+                (li_id, ledger_id),
+            )
+            tx_id = str(uuid.uuid4())
+            conn.execute(
+                "INSERT OR IGNORE INTO transactions "
+                "(id, bank_account_id, plaid_transaction_id, merchant, amount, date) "
+                "VALUES (?, ?, 'plaid_corr1', 'Uber Eats', 33.20, '2025-05-22')",
+                (tx_id, ba_id),
+            )
+            conn.execute(
+                "INSERT OR IGNORE INTO transaction_entries "
+                "(id, transaction_id, line_item_id, amount, uncertain, reviewed, entry_type) "
+                "VALUES (?, ?, ?, 33.20, 1, 0, 'spending')",
+                (str(uuid.uuid4()), tx_id, li_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        before = main.get_needs_review_summary()
+        assert before["count"] >= 1
+
+        # Correct it.
+        result = main.correct_transaction(transaction_id=tx_id, line_item_id=li_id)
+        assert result["status"] == "ok"
+
+        after = main.get_needs_review_summary()
+        assert after["count"] == before["count"] - 1, (
+            f"Expected count to decrease by 1: before={before['count']}, after={after['count']}"
+        )
+        corrected_ids = {tx["id"] for tx in after["transactions"]}
+        assert tx_id not in corrected_ids


### PR DESCRIPTION
## Summary

Closes #207.

Instead of one LLM call per transaction, `classify_batch()` collects all pending transactions into a single prompt and asks the LLM to return a JSON array of results. Prompts exceeding `MAX_BATCH_CHARS` (80 000 chars ≈ 20 K tokens) are automatically split into smaller sub-batches using greedy bin-packing.

## Changes

### `server/classifier.py`
- **`MAX_BATCH_CHARS = 80_000`** — token cap constant
- **`_build_batch_user_msg()`** — builds one shared-context prompt with indexed `### Transaction N` sections; includes per-transaction recent reviewed entries and transfer-hint flags
- **`_classify_batch_chunk()`** — single LLM call per sub-batch; parses JSON array response; falls back gracefully on parse errors or missing indices
- **`classify_batch()`** — greedy bin-packing splitter that calls `_classify_batch_chunk()` once per sub-batch and assembles results in input order

### `server/main.py`
- Import `classify_batch` at module level
- Rewrite `classify_pending_transactions()` to:
  1. Pre-build all tx_dicts (including `possible_transfer` flag for transfer hints)
  2. Call `classify_batch()` once (handles sub-batching internally)
  3. Apply per-transaction fallbacks (skip / default-ledger / uncertain) — logic unchanged from #205

### `tests/test_auto_categorize.py`
- Update `_make_llm_response()` to return a JSON array (batch contract) with a `count` parameter
- Update `test_classifies_three_transactions` to pass `count=3`
- Update `test_transfer_hint_passed_to_classifier` to patch `classify_batch` instead of `classify_transaction` and verify the `possible_transfer` flag is embedded in tx_dicts

### `tests/playwright/test_issue_207_batch_classifier.py` (new)
- **E2E test**: Plaid sandbox sync → `classify_batch` → assert fewer LLM calls than transactions + `source/reasoning` populated + batch prompt format + Playwright screenshot
- **Unit tests**:
  - Empty input returns empty list
  - Correct result count matches input length
  - Sub-batch splitting with tiny `MAX_BATCH_CHARS` forces multiple calls
  - Malformed LLM response falls back to uncertain results
  - Missing transaction indices filled with uncertain fallback

## Test Results

```
Non-Playwright suite (--ignore=tests/test_plaid_e2e.py --ignore=tests/playwright):
  901 passed, 6 skipped, 1 warning

Playwright suite (tests/playwright/test_issue_207_batch_classifier.py):
  5 passed, 1 skipped

  Skipped: test_issue_207_batch_classifier_end_to_end
  Reason: Plaid sandbox did not seed transactions within the retry window
  (same graceful skip behaviour as #205 e2e test)
```

## Batch Prompt Format

Each batch prompt contains:
- `## Classification Rules` — shared, priority-ordered
- `## Ledger Tree` — shared
- `## Classification Hints` — shared
- `## Transactions To Classify` — one `### Transaction N` block per transaction, including per-transaction recent reviewed entries and optional transfer warning

LLM returns a JSON array:
```json
[
  {"transaction_index": 0, "rule_id": null, "line_item_id": "...", "classification_type": "spending", "confidence": 0.88, "reasoning": "..."},
  ...
]
```
