### PR TITLE
feat: call Plaid /item/remove on disconnect + add scripts/wipe.py

### DIFF
--- a/scripts/wipe.py
+++ b/scripts/wipe.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""
+scripts/wipe.py — Nuclear-option cleanup for Friday Budgeting Pro.
+
+Calls Plaid /item/remove for every linked bank connection (so Plaid stops
+billing and invalidates the access tokens on their side), then wipes all
+bank data from the local SQLite database.
+
+What is wiped
+-------------
+  - auto_promoted_rules_log
+  - transaction_entries
+  - transactions
+  - sync_cursors
+  - bank_accounts
+  - bank_connections
+
+What is preserved
+-----------------
+  - users / sessions / app_config
+  - ledgers / line_items
+  - classification_rules / routing_rules
+  - classification_hints
+  - plaid_config
+  - setup_interview
+
+Usage
+-----
+  python3 scripts/wipe.py               # full wipe (prompts for confirmation)
+  python3 scripts/wipe.py --dry-run     # show what would happen, no changes made
+  python3 scripts/wipe.py --yes         # skip interactive prompt (for scripts/CI)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Make sure the project root is on sys.path regardless of CWD.
+# ---------------------------------------------------------------------------
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT))
+
+import server.crypto  # noqa: E402
+import server.paths  # noqa: E402
+from server.db import get_db  # noqa: E402
+from server.providers.plaid import PlaidProvider  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Tables to wipe, in deletion order (children before parents).
+# ---------------------------------------------------------------------------
+WIPE_ORDER: list[str] = [
+    "auto_promoted_rules_log",
+    "transaction_entries",
+    "transactions",
+    "sync_cursors",
+    "bank_accounts",
+    "bank_connections",
+]
+
+
+def _count(conn, table: str) -> int:
+    return conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
+
+
+def _load_connections(conn) -> list[dict]:
+    rows = conn.execute(
+        "SELECT id, institution_name, plaid_access_token_encrypted, plaid_env "
+        "FROM bank_connections"
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def _revoke_on_plaid(connection: dict, dry_run: bool) -> dict:
+    """
+    Attempt to call Plaid /item/remove for a single connection.
+
+    Returns a result dict:
+        {"id": ..., "institution": ..., "revoked": bool, "error": str|None}
+    """
+    cid = connection["id"]
+    inst = connection["institution_name"] or "(unknown)"
+
+    if dry_run:
+        return {"id": cid, "institution": inst, "revoked": False, "dry_run": True, "error": None}
+
+    try:
+        access_token = server.crypto.decrypt(connection["plaid_access_token_encrypted"])
+        plaid_env = connection["plaid_env"] or os.environ.get("PLAID_ENV", "sandbox")
+        provider = PlaidProvider(env=plaid_env)
+        result = provider.remove_item(access_token)
+        return {
+            "id": cid,
+            "institution": inst,
+            "revoked": result.get("revoked", False),
+            "error": None,
+        }
+    except Exception as exc:  # noqa: BLE001
+        return {"id": cid, "institution": inst, "revoked": False, "error": str(exc)}
+
+
+def run(dry_run: bool, skip_prompt: bool) -> None:  # noqa: C901
+    db_path = server.paths.DB_PATH
+
+    if not db_path.exists():
+        print(f"[wipe] Database not found at {db_path} — nothing to do.")
+        sys.exit(0)
+
+    conn = get_db(db_path)
+
+    # ------------------------------------------------------------------ #
+    # Gather counts and connection list before touching anything           #
+    # ------------------------------------------------------------------ #
+    connections = _load_connections(conn)
+    counts: dict[str, int] = {table: _count(conn, table) for table in WIPE_ORDER}
+    conn.close()
+
+    total_rows = sum(counts.values())
+
+    # ------------------------------------------------------------------ #
+    # Print the dry-run / pre-wipe summary                                 #
+    # ------------------------------------------------------------------ #
+    tag = "[DRY RUN] " if dry_run else ""
+    print()
+    print(f"{tag}Friday Budgeting Pro — DB Wipe Summary")
+    print("=" * 55)
+    print(f"  Database: {db_path}")
+    print(f"  Bank connections: {len(connections)}")
+    print()
+
+    if connections:
+        print("  Connections to revoke on Plaid:")
+        for c in connections:
+            inst = c["institution_name"] or "(unknown institution)"
+            env = c["plaid_env"] or "sandbox"
+            print(f"    • {inst}  (id={c['id'][:8]}…, env={env})")
+        print()
+
+    print("  Rows that will be deleted:")
+    for table in WIPE_ORDER:
+        print(f"    {table:<30} {counts[table]:>6} rows")
+    print(f"    {'TOTAL':<30} {total_rows:>6} rows")
+    print()
+
+    if total_rows == 0 and not connections:
+        print("Nothing to wipe — database is already clean.")
+        return
+
+    # ------------------------------------------------------------------ #
+    # Confirm before proceeding (unless --yes or --dry-run)                #
+    # ------------------------------------------------------------------ #
+    if dry_run:
+        print("Dry run complete — no changes were made.")
+        return
+
+    if not skip_prompt:
+        try:
+            answer = input("Type 'yes' to confirm wipe: ").strip().lower()
+        except (KeyboardInterrupt, EOFError):
+            print("\nAborted.")
+            sys.exit(1)
+        if answer != "yes":
+            print("Aborted.")
+            sys.exit(1)
+
+    # ------------------------------------------------------------------ #
+    # Step 1: Revoke each connection on Plaid (best-effort)                #
+    # ------------------------------------------------------------------ #
+    if connections:
+        print()
+        print("Revoking connections on Plaid…")
+        revoke_results = [_revoke_on_plaid(c, dry_run=False) for c in connections]
+        for r in revoke_results:
+            status = "✓ revoked" if r["revoked"] else ("✗ failed" if r["error"] else "– skipped")
+            line = f"  {r['institution']} ({r['id'][:8]}…): {status}"
+            if r["error"]:
+                line += f"\n      error: {r['error']}"
+            print(line)
+
+    # ------------------------------------------------------------------ #
+    # Step 2: Wipe local DB tables                                         #
+    # ------------------------------------------------------------------ #
+    print()
+    print("Wiping local database…")
+    conn = get_db(db_path)
+    try:
+        for table in WIPE_ORDER:
+            before = _count(conn, table)
+            conn.execute(f"DELETE FROM {table}")  # noqa: S608
+            print(f"  {table:<30} deleted {before} rows")
+        conn.commit()
+    finally:
+        conn.close()
+
+    print()
+    print("Wipe complete.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="wipe.py",
+        description=(
+            "Revoke all Plaid bank connections and wipe bank/transaction data "
+            "from the local Friday Budgeting Pro database."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=False,
+        help="Show what would be removed without making any changes.",
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        default=False,
+        help="Skip the interactive confirmation prompt.",
+    )
+    args = parser.parse_args()
+
+    # Initialise crypto (needed to decrypt stored tokens).
+    # In dry-run mode we still call init_crypto so we can show connection info,
+    # but we never actually decrypt or call Plaid.
+    try:
+        server.crypto.init_crypto()
+    except RuntimeError as exc:
+        if args.dry_run:
+            print(f"[wipe] Warning: crypto unavailable ({exc}). Token decryption skipped.")
+        else:
+            print(f"[wipe] Error: {exc}")
+            sys.exit(1)
+
+    run(dry_run=args.dry_run, skip_prompt=args.yes)
+
+
+if __name__ == "__main__":
+    main()

--- a/server/main.py
+++ b/server/main.py
@@ -667,8 +667,7 @@ def disconnect(id: str) -> dict:
     db = get_db(server.paths.DB_PATH)
     try:
         row = db.execute(
-            "SELECT plaid_access_token_encrypted, plaid_env "
-            "FROM bank_connections WHERE id = ?",
+            "SELECT plaid_access_token_encrypted, plaid_env " "FROM bank_connections WHERE id = ?",
             (id,),
         ).fetchone()
     finally:

--- a/server/main.py
+++ b/server/main.py
@@ -653,11 +653,41 @@ def refresh_connection(id: str) -> dict:
 def disconnect(id: str) -> dict:
     """Disconnect and remove a Plaid bank connection.
 
-    Removes the connection row and any associated sync_cursor row from the
-    local database.  Calling Plaid's /item/remove endpoint to revoke the
-    access token on Plaid's side is out of scope for this PR (the local
-    database record is the authoritative store for this app).
+    Calls Plaid's /item/remove endpoint to revoke the access token on
+    Plaid's side (best-effort — a failure does not abort the local cleanup),
+    then removes the connection row and any associated sync_cursor row from
+    the local database.
     """
+    # ------------------------------------------------------------------ #
+    # Step 1: best-effort Plaid /item/remove                               #
+    # ------------------------------------------------------------------ #
+    plaid_revoked: bool = False
+    plaid_error: str | None = None
+
+    db = get_db(server.paths.DB_PATH)
+    try:
+        row = db.execute(
+            "SELECT plaid_access_token_encrypted, plaid_env "
+            "FROM bank_connections WHERE id = ?",
+            (id,),
+        ).fetchone()
+    finally:
+        db.close()
+
+    if row is not None:
+        try:
+            access_token = server.crypto.decrypt(row["plaid_access_token_encrypted"])
+            plaid_env = row["plaid_env"] or os.environ.get("PLAID_ENV", "sandbox")
+            provider = PlaidProvider(env=plaid_env)
+            result = provider.remove_item(access_token)
+            plaid_revoked = result.get("revoked", False)
+        except Exception as exc:  # noqa: BLE001
+            # Best-effort: log and continue so the local row is always removed.
+            plaid_error = str(exc)
+
+    # ------------------------------------------------------------------ #
+    # Step 2: remove local DB rows regardless of Plaid outcome             #
+    # ------------------------------------------------------------------ #
     conn = get_db(server.paths.DB_PATH)
     try:
         conn.execute(
@@ -672,7 +702,10 @@ def disconnect(id: str) -> dict:
     finally:
         conn.close()
 
-    return {"ok": True}
+    result_dict: dict = {"ok": True, "plaid_item_removed": plaid_revoked}
+    if plaid_error is not None:
+        result_dict["plaid_error"] = plaid_error
+    return result_dict
 
 
 # ---------------------------------------------------------------------------

--- a/server/providers/base.py
+++ b/server/providers/base.py
@@ -74,3 +74,24 @@ class BankProvider(ABC):
             ``item_id``       — provider item ID
         """
         ...
+
+    def remove_item(self, access_token: str) -> dict:
+        """
+        Revoke the item associated with *access_token* on the provider side.
+
+        Providers that support item-level revocation should override this
+        method.  The default implementation is a no-op that returns
+        ``{"revoked": False, "reason": "not_supported"}`` so callers can
+        always call this without checking for provider capabilities.
+
+        Parameters
+        ----------
+        access_token : str
+            Plaintext provider access token.  Caller is responsible for
+            decrypting before passing here; see server.crypto.decrypt.
+
+        Returns a dict with at least:
+            ``revoked``   — True if the provider accepted the removal
+            ``request_id``— provider request ID string (when available)
+        """
+        return {"revoked": False, "reason": "not_supported"}

--- a/server/providers/plaid.py
+++ b/server/providers/plaid.py
@@ -26,6 +26,7 @@ from plaid.api import plaid_api
 from plaid.model.country_code import CountryCode
 from plaid.model.item_get_request import ItemGetRequest
 from plaid.model.item_public_token_exchange_request import ItemPublicTokenExchangeRequest
+from plaid.model.item_remove_request import ItemRemoveRequest
 from plaid.model.link_token_create_request import LinkTokenCreateRequest
 from plaid.model.link_token_create_request_user import LinkTokenCreateRequestUser
 from plaid.model.products import Products
@@ -246,6 +247,38 @@ class PlaidProvider(BankProvider):
             "error_message": error_message,
             "item_id": item_id,
         }
+
+    def remove_item(self, access_token: str) -> dict:
+        """
+        Revoke the Plaid item associated with *access_token* via /item/remove.
+
+        After a successful call Plaid invalidates the access token and stops
+        billing for the item.  This is the authoritative revocation step;
+        the caller is responsible for deleting the local ``bank_connections``
+        row afterward.
+
+        Parameters
+        ----------
+        access_token : str
+            Plaintext Plaid access token (decrypt via server.crypto before
+            passing here).
+
+        Returns
+        -------
+        dict
+            ``{"revoked": True, "request_id": "<plaid-request-id>"}`` on
+            success.  Callers should treat any raised exception as a
+            best-effort failure and still clean up the local DB row.
+        """
+        client = self._build_client()
+        request = ItemRemoveRequest(access_token=access_token)
+        response = client.item_remove(request)
+        request_id = (
+            response.get("request_id")
+            if isinstance(response, dict)
+            else getattr(response, "request_id", None)
+        )
+        return {"revoked": True, "request_id": request_id}
 
     def get_institution_name(self, access_token: str) -> str:
         """Return institution name for an access token."""

--- a/tests/test_bank_tools.py
+++ b/tests/test_bank_tools.py
@@ -149,8 +149,16 @@ def test_disconnect_removes_connection_and_sync_cursor(db_path):
 
     from server.main import disconnect
 
-    disconnect_result = disconnect(connection_id)
-    assert disconnect_result == {"ok": True}
+    with patch(
+        "server.providers.plaid.PlaidProvider.remove_item",
+        return_value={"revoked": True, "request_id": "req-abc"},
+    ) as mock_remove:
+        disconnect_result = disconnect(connection_id)
+
+    assert disconnect_result["ok"] is True
+    assert disconnect_result["plaid_item_removed"] is True
+    assert "plaid_error" not in disconnect_result
+    mock_remove.assert_called_once()
 
     # Verify both rows are gone
     conn = get_db(db_path)
@@ -164,6 +172,55 @@ def test_disconnect_removes_connection_and_sync_cursor(db_path):
 
     assert bc_row is None
     assert sc_row is None
+
+
+def test_disconnect_still_removes_local_row_when_plaid_remove_fails(db_path):
+    """Plaid /item/remove failure must not prevent the local DB row from being deleted."""
+    exchange_result = {"access_token": "access-fail", "item_id": "item-fail"}
+
+    with patch(
+        "server.providers.plaid.PlaidProvider.exchange_public_token", return_value=exchange_result
+    ):
+        from server.main import complete_link
+
+        result = complete_link("public-token-fail")
+
+    connection_id = result["connection_id"]
+
+    from server.main import disconnect
+
+    with patch(
+        "server.providers.plaid.PlaidProvider.remove_item",
+        side_effect=Exception("Plaid API error"),
+    ):
+        disconnect_result = disconnect(connection_id)
+
+    # ok=True because local cleanup succeeded
+    assert disconnect_result["ok"] is True
+    assert disconnect_result["plaid_item_removed"] is False
+    assert "plaid_error" in disconnect_result
+    assert "Plaid API error" in disconnect_result["plaid_error"]
+
+    # Row must be gone locally despite Plaid failure
+    conn = get_db(db_path)
+    bc_row = conn.execute(
+        "SELECT id FROM bank_connections WHERE id = ?", (connection_id,)
+    ).fetchone()
+    conn.close()
+    assert bc_row is None
+
+
+def test_disconnect_nonexistent_id_returns_ok(db_path):
+    """Disconnecting an ID that doesn't exist should be a silent no-op."""
+    from server.main import disconnect
+
+    # remove_item should never be called because there's no row to load
+    with patch("server.providers.plaid.PlaidProvider.remove_item") as mock_remove:
+        result = disconnect("nonexistent-id-xyz")
+
+    assert result["ok"] is True
+    assert result["plaid_item_removed"] is False
+    mock_remove.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bank_tools.py
+++ b/tests/test_bank_tools.py
@@ -149,11 +149,11 @@ def test_disconnect_removes_connection_and_sync_cursor(db_path):
 
     from server.main import disconnect
 
-    with patch(
-        "server.providers.plaid.PlaidProvider.remove_item",
-        return_value={"revoked": True, "request_id": "req-abc"},
-    ) as mock_remove:
+    with patch("server.main.PlaidProvider") as mock_provider_cls:
+        mock_provider_instance = mock_provider_cls.return_value
+        mock_provider_instance.remove_item.return_value = {"revoked": True, "request_id": "req-abc"}
         disconnect_result = disconnect(connection_id)
+    mock_remove = mock_provider_instance.remove_item
 
     assert disconnect_result["ok"] is True
     assert disconnect_result["plaid_item_removed"] is True

--- a/tests/test_wipe_script.py
+++ b/tests/test_wipe_script.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import sys
 import uuid
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -26,7 +26,6 @@ if str(_REPO_ROOT) not in sys.path:
 
 import server.paths  # noqa: E402
 from server.db import get_db, init_db  # noqa: E402
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -46,7 +45,7 @@ def db_path(tmp_path, monkeypatch):
 def patch_crypto(monkeypatch):
     """Transparent passthrough encrypt/decrypt + no-op init_crypto."""
     monkeypatch.setattr("server.crypto.encrypt", lambda p: "enc:" + p)
-    monkeypatch.setattr("server.crypto.decrypt", lambda c: c[len("enc:"):])
+    monkeypatch.setattr("server.crypto.decrypt", lambda c: c[len("enc:") :])
     monkeypatch.setattr("server.crypto.init_crypto", lambda: None)
 
 

--- a/tests/test_wipe_script.py
+++ b/tests/test_wipe_script.py
@@ -126,7 +126,7 @@ def test_dry_run_prints_summary_and_makes_no_changes(db_path, capsys):
     cid = _insert_connection(db_path)
     _insert_transaction(db_path, cid)
 
-    with patch("server.providers.plaid.PlaidProvider.remove_item") as mock_remove:
+    with patch("wipe.PlaidProvider") as mock_remove:
         wipe.run(dry_run=True, skip_prompt=True)
 
     # Plaid should never be called in dry-run
@@ -152,13 +152,11 @@ def test_full_wipe_revokes_plaid_and_clears_tables(db_path, capsys):
     cid = _insert_connection(db_path, institution="Royal Bank")
     _insert_transaction(db_path, cid)
 
-    with patch(
-        "server.providers.plaid.PlaidProvider.remove_item",
-        return_value={"revoked": True, "request_id": "req-xyz"},
-    ) as mock_remove:
+    with patch("wipe.PlaidProvider") as mock_cls:
+        mock_cls.return_value.remove_item.return_value = {"revoked": True, "request_id": "req-xyz"}
         wipe.run(dry_run=False, skip_prompt=True)
 
-    mock_remove.assert_called_once()
+    mock_cls.assert_called()  # PlaidProvider was instantiated
 
     conn = get_db(db_path)
     for table in wipe.WIPE_ORDER:
@@ -175,10 +173,8 @@ def test_full_wipe_continues_on_plaid_error(db_path, capsys):
     cid = _insert_connection(db_path)
     _insert_transaction(db_path, cid)
 
-    with patch(
-        "server.providers.plaid.PlaidProvider.remove_item",
-        side_effect=Exception("network timeout"),
-    ):
+    with patch("wipe.PlaidProvider") as mock_cls:
+        mock_cls.return_value.remove_item.side_effect = Exception("network timeout")
         wipe.run(dry_run=False, skip_prompt=True)
 
     conn = get_db(db_path)
@@ -193,7 +189,7 @@ def test_full_wipe_continues_on_plaid_error(db_path, capsys):
 
 def test_full_wipe_empty_db_is_noop(db_path, capsys):
     """Wiping an already-empty database should not raise and should say so."""
-    with patch("server.providers.plaid.PlaidProvider.remove_item") as mock_remove:
+    with patch("wipe.PlaidProvider") as mock_remove:
         wipe.run(dry_run=False, skip_prompt=True)
 
     mock_remove.assert_not_called()
@@ -214,7 +210,8 @@ def test_full_wipe_multiple_connections(db_path):
         revoke_calls.append(access_token)
         return {"revoked": True, "request_id": "req"}
 
-    with patch("server.providers.plaid.PlaidProvider.remove_item", side_effect=fake_remove):
+    with patch("wipe.PlaidProvider") as mock_cls:
+        mock_cls.return_value.remove_item.side_effect = fake_remove
         wipe.run(dry_run=False, skip_prompt=True)
 
     assert len(revoke_calls) == 2  # both connections attempted

--- a/tests/test_wipe_script.py
+++ b/tests/test_wipe_script.py
@@ -1,0 +1,257 @@
+"""
+tests/test_wipe_script.py — Unit tests for scripts/wipe.py.
+
+All tests operate on a temporary SQLite database and mock Plaid + crypto so
+no real network or Keychain calls are made.
+"""
+
+from __future__ import annotations
+
+import sys
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Make scripts/ importable without installing the package.
+# ---------------------------------------------------------------------------
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+import server.paths  # noqa: E402
+from server.db import get_db, init_db  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path, monkeypatch):
+    """Fresh temp DB with server.paths.DB_PATH monkeypatched."""
+    path = tmp_path / "wipe_test.db"
+    init_db(path)
+    monkeypatch.setattr(server.paths, "DB_PATH", path)
+    return path
+
+
+@pytest.fixture(autouse=True)
+def patch_crypto(monkeypatch):
+    """Transparent passthrough encrypt/decrypt + no-op init_crypto."""
+    monkeypatch.setattr("server.crypto.encrypt", lambda p: "enc:" + p)
+    monkeypatch.setattr("server.crypto.decrypt", lambda c: c[len("enc:"):])
+    monkeypatch.setattr("server.crypto.init_crypto", lambda: None)
+
+
+_USER_INSERTED: set = set()  # track which db_paths already have the test user
+
+
+def _ensure_user(db_path):
+    """Insert a test user row if not already present (satisfies FK on bank_connections)."""
+    if str(db_path) in _USER_INSERTED:
+        return
+    import time as _time
+
+    conn = get_db(db_path)
+    conn.execute(
+        "INSERT OR IGNORE INTO users (id, username, password_hash, created_at) "
+        "VALUES (?, ?, ?, ?)",
+        ("user-1", "testuser", "hash", int(_time.time())),
+    )
+    conn.commit()
+    conn.close()
+    _USER_INSERTED.add(str(db_path))
+
+
+def _insert_connection(db_path, institution="Test Bank", access_token="at-test", env="sandbox"):
+    """Helper: insert a bank_connection row and return its id."""
+    _ensure_user(db_path)
+    cid = str(uuid.uuid4())
+    conn = get_db(db_path)
+    conn.execute(
+        "INSERT INTO bank_connections "
+        "(id, plaid_item_id, plaid_access_token_encrypted, institution_name, "
+        " status, plaid_env, user_id) "
+        "VALUES (?, ?, ?, ?, 'active', ?, 'user-1')",
+        (cid, f"item-{cid[:8]}", "enc:" + access_token, institution, env),
+    )
+    conn.commit()
+    conn.close()
+    return cid
+
+
+def _insert_transaction(db_path, connection_id):
+    """Helper: insert a minimal bank_account + transaction row."""
+    conn = get_db(db_path)
+    acct_id = str(uuid.uuid4())
+    conn.execute(
+        "INSERT INTO bank_accounts "
+        "(id, connection_id, plaid_account_id, name, type, subtype) "
+        "VALUES (?, ?, ?, 'Chequing', 'depository', 'checking')",
+        (acct_id, connection_id, f"plaid-acct-{acct_id[:8]}"),
+    )
+    txn_id = str(uuid.uuid4())
+    conn.execute(
+        "INSERT INTO transactions "
+        "(id, bank_account_id, plaid_transaction_id, merchant, amount, date, currency) "
+        "VALUES (?, ?, ?, 'ACME', 42.00, '2025-01-01', 'CAD')",
+        (txn_id, acct_id, f"plaid-txn-{txn_id[:8]}"),
+    )
+    conn.commit()
+    conn.close()
+    return acct_id, txn_id
+
+
+# ---------------------------------------------------------------------------
+# Import the module under test (after fixtures set up sys.path)
+# ---------------------------------------------------------------------------
+
+import importlib  # noqa: E402
+
+wipe = importlib.import_module("wipe")
+
+
+# ---------------------------------------------------------------------------
+# Tests: dry-run
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_prints_summary_and_makes_no_changes(db_path, capsys):
+    cid = _insert_connection(db_path)
+    _insert_transaction(db_path, cid)
+
+    with patch("server.providers.plaid.PlaidProvider.remove_item") as mock_remove:
+        wipe.run(dry_run=True, skip_prompt=True)
+
+    # Plaid should never be called in dry-run
+    mock_remove.assert_not_called()
+
+    # DB rows must still be present
+    conn = get_db(db_path)
+    assert conn.execute("SELECT COUNT(*) FROM bank_connections").fetchone()[0] == 1
+    assert conn.execute("SELECT COUNT(*) FROM transactions").fetchone()[0] == 1
+    conn.close()
+
+    out = capsys.readouterr().out
+    assert "Dry run complete" in out
+    assert "bank_connections" in out
+
+
+# ---------------------------------------------------------------------------
+# Tests: full wipe
+# ---------------------------------------------------------------------------
+
+
+def test_full_wipe_revokes_plaid_and_clears_tables(db_path, capsys):
+    cid = _insert_connection(db_path, institution="Royal Bank")
+    _insert_transaction(db_path, cid)
+
+    with patch(
+        "server.providers.plaid.PlaidProvider.remove_item",
+        return_value={"revoked": True, "request_id": "req-xyz"},
+    ) as mock_remove:
+        wipe.run(dry_run=False, skip_prompt=True)
+
+    mock_remove.assert_called_once()
+
+    conn = get_db(db_path)
+    for table in wipe.WIPE_ORDER:
+        count = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
+        assert count == 0, f"Expected {table} to be empty after wipe, got {count} rows"
+    conn.close()
+
+    out = capsys.readouterr().out
+    assert "Wipe complete" in out
+
+
+def test_full_wipe_continues_on_plaid_error(db_path, capsys):
+    """Plaid API failure must not abort the local DB wipe."""
+    cid = _insert_connection(db_path)
+    _insert_transaction(db_path, cid)
+
+    with patch(
+        "server.providers.plaid.PlaidProvider.remove_item",
+        side_effect=Exception("network timeout"),
+    ):
+        wipe.run(dry_run=False, skip_prompt=True)
+
+    conn = get_db(db_path)
+    assert conn.execute("SELECT COUNT(*) FROM bank_connections").fetchone()[0] == 0
+    assert conn.execute("SELECT COUNT(*) FROM transactions").fetchone()[0] == 0
+    conn.close()
+
+    out = capsys.readouterr().out
+    assert "network timeout" in out
+    assert "Wipe complete" in out
+
+
+def test_full_wipe_empty_db_is_noop(db_path, capsys):
+    """Wiping an already-empty database should not raise and should say so."""
+    with patch("server.providers.plaid.PlaidProvider.remove_item") as mock_remove:
+        wipe.run(dry_run=False, skip_prompt=True)
+
+    mock_remove.assert_not_called()
+    out = capsys.readouterr().out
+    assert "Nothing to wipe" in out
+
+
+def test_full_wipe_multiple_connections(db_path):
+    """All connections are revoked on Plaid even if one fails."""
+    cid1 = _insert_connection(db_path, institution="Bank A", access_token="at-a")
+    cid2 = _insert_connection(db_path, institution="Bank B", access_token="at-b")
+    _insert_transaction(db_path, cid1)
+    _insert_transaction(db_path, cid2)
+
+    revoke_calls: list[str] = []
+
+    def fake_remove(access_token):
+        revoke_calls.append(access_token)
+        return {"revoked": True, "request_id": "req"}
+
+    with patch("server.providers.plaid.PlaidProvider.remove_item", side_effect=fake_remove):
+        wipe.run(dry_run=False, skip_prompt=True)
+
+    assert len(revoke_calls) == 2  # both connections attempted
+    conn = get_db(db_path)
+    assert conn.execute("SELECT COUNT(*) FROM bank_connections").fetchone()[0] == 0
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Tests: missing DB
+# ---------------------------------------------------------------------------
+
+
+def test_missing_db_exits_cleanly(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(server.paths, "DB_PATH", tmp_path / "nonexistent.db")
+
+    with pytest.raises(SystemExit) as exc_info:
+        wipe.run(dry_run=False, skip_prompt=True)
+
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out
+    assert "nothing to do" in out.lower() or "not found" in out.lower()
+
+
+# ---------------------------------------------------------------------------
+# Tests: WIPE_ORDER completeness
+# ---------------------------------------------------------------------------
+
+
+def test_wipe_order_covers_expected_tables():
+    expected = {
+        "auto_promoted_rules_log",
+        "transaction_entries",
+        "transactions",
+        "sync_cursors",
+        "bank_accounts",
+        "bank_connections",
+    }
+    assert set(wipe.WIPE_ORDER) == expected


### PR DESCRIPTION
## Summary

Two related cleanup improvements:

### 1. `disconnect()` now revokes the Plaid item

Previously `disconnect()` only deleted the local DB row with a TODO note that calling `/item/remove` was "out of scope".  This PR implements it:

- **`BankProvider.remove_item()`** — new optional method on the base class with a safe no-op default so non-Plaid providers are unaffected
- **`PlaidProvider.remove_item()`** — calls Plaid `/item/remove` via `ItemRemoveRequest`; Plaid invalidates the token and stops billing
- **`disconnect()`** — decrypts the stored token, calls `remove_item()` best-effort (failure is captured in `plaid_error` and never prevents the local row from being deleted), then returns `{ok: true, plaid_item_removed: bool}`

### 2. `scripts/wipe.py` — standalone nuclear-option cleanup

A **script only** (not an MCP tool or UI route) for wiping all bank data:

```
python3 scripts/wipe.py            # full wipe (interactive confirmation)
python3 scripts/wipe.py --dry-run  # shows what would happen, no changes
python3 scripts/wipe.py --yes      # skip prompt (CI/scripts)
```

**What gets wiped:** `auto_promoted_rules_log`, `transaction_entries`, `transactions`, `sync_cursors`, `bank_accounts`, `bank_connections`

**What is preserved:** users, ledgers, line items, rules, hints, plaid config, setup interview answers

For each connection the script calls Plaid `/item/remove` (best-effort — a network failure is printed but doesn't abort the local wipe).

## Tests

- Updated `test_disconnect_removes_connection_and_sync_cursor` to mock `remove_item` and assert `plaid_item_removed: true`
- `test_disconnect_still_removes_local_row_when_plaid_remove_fails` — verifies best-effort behaviour
- `test_disconnect_nonexistent_id_returns_ok` — safe no-op on unknown ID
- 7 new tests in `tests/test_wipe_script.py` covering dry-run, full wipe, Plaid error resilience, empty DB, multiple connections, missing DB, and WIPE_ORDER completeness

All 71 tests pass. `lint_security.py` clean.