### PR TITLE
fix: health monitor uses DB credentials instead of module-level _plaid singleton (issue #259)

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -1561,9 +1561,14 @@ def sync() -> dict:
             db_conn = get_db(server.paths.DB_PATH)
             try:
                 # Run health check first so stale/expired connections are
-                # updated before we attempt to sync them.
+                # updated before we attempt to sync them.  Pass
+                # plaid_provider=None so the monitor builds per-connection
+                # providers from DB credentials (same pattern as the sync
+                # loop below).  Passing the module-level _plaid singleton
+                # would use env-var credentials only, which breaks ClawHub
+                # installs where credentials are stored in plaid_config.
                 health_check_result = server.health_monitor.check_all_connections(
-                    db_conn, plaid_provider=_plaid
+                    db_conn, plaid_provider=None
                 )
 
                 active_conns = db_conn.execute(

--- a/tests/test_health_monitor.py
+++ b/tests/test_health_monitor.py
@@ -330,7 +330,7 @@ def test_db_credentials_used_when_no_provider_passed(tmp_path, monkeypatch):
     plaid_config rows would fail with INVALID_API_KEYS on every health check.
     """
     import sqlite3
-    from unittest.mock import MagicMock, patch
+    from unittest.mock import patch
 
     db = tmp_path / "data.db"
     monkeypatch.setattr("server.paths.DB_PATH", db)
@@ -344,7 +344,9 @@ def test_db_credentials_used_when_no_provider_passed(tmp_path, monkeypatch):
     conn.row_factory = sqlite3.Row
     try:
         # Insert user
-        conn.execute("INSERT OR IGNORE INTO users (id, username) VALUES (?, ?)", (user_id, "testuser"))
+        conn.execute(
+            "INSERT OR IGNORE INTO users (id, username) VALUES (?, ?)", (user_id, "testuser")
+        )
         # Insert plaid_config with DB-only credentials
         conn.execute(
             "INSERT INTO plaid_config (user_id, client_id, secret, plaid_env) VALUES (?, ?, ?, ?)",
@@ -388,12 +390,12 @@ def test_db_credentials_used_when_no_provider_passed(tmp_path, monkeypatch):
 
     # A PlaidProvider should have been built with the DB credentials, not empty ones
     assert len(built_providers) == 1, "expected exactly one PlaidProvider to be built"
-    assert built_providers[0]["client_id"] == "db-client-id", (
-        "health monitor should use DB client_id, not env var / empty string"
-    )
-    assert built_providers[0]["secret"] == "db-secret", (
-        "health monitor should use DB secret, not env var / empty string"
-    )
+    assert (
+        built_providers[0]["client_id"] == "db-client-id"
+    ), "health monitor should use DB client_id, not env var / empty string"
+    assert (
+        built_providers[0]["secret"] == "db-secret"
+    ), "health monitor should use DB secret, not env var / empty string"
 
 
 def test_sync_passes_none_not_module_singleton_to_health_monitor(monkeypatch):
@@ -401,12 +403,13 @@ def test_sync_passes_none_not_module_singleton_to_health_monitor(monkeypatch):
     to check_all_connections so the health monitor uses DB credentials
     instead of the module-level _plaid singleton (which has no DB creds).
     """
-    from unittest.mock import call, patch
     import server.main as _sm
 
     captured_provider_arg = []
 
-    original_check = __import__("server.health_monitor", fromlist=["check_all_connections"]).check_all_connections
+    original_check = __import__(
+        "server.health_monitor", fromlist=["check_all_connections"]
+    ).check_all_connections
 
     def _spy_check(db_conn, plaid_provider=None):
         captured_provider_arg.append(plaid_provider)
@@ -416,7 +419,9 @@ def test_sync_passes_none_not_module_singleton_to_health_monitor(monkeypatch):
     # Prevent actual sync work — we only care about what sync() passes to
     # check_all_connections.
     monkeypatch.setattr("server.health_monitor.check_all_connections", _spy_check)
-    monkeypatch.setattr(_sm, "sync_lock", lambda timeout=0.0: __import__("contextlib").nullcontext())
+    monkeypatch.setattr(
+        _sm, "sync_lock", lambda timeout=0.0: __import__("contextlib").nullcontext()
+    )
 
     # Fake get_db so no real DB is needed
     class _FakeConn:
@@ -424,11 +429,15 @@ def test_sync_passes_none_not_module_singleton_to_health_monitor(monkeypatch):
             class _Result:
                 def fetchall(self):
                     return []
+
                 def fetchone(self):
                     return None
+
             return _Result()
+
         def close(self):
             pass
+
         def commit(self):
             pass
 

--- a/tests/test_health_monitor.py
+++ b/tests/test_health_monitor.py
@@ -318,3 +318,126 @@ def test_no_active_connections_returns_zero_counts(db_env, monkeypatch):
         db.close()
 
     assert result == {"checked": 0, "active": 0, "needs_reauth": 0, "pending_expiration": 0}
+
+
+def test_db_credentials_used_when_no_provider_passed(tmp_path, monkeypatch):
+    """When plaid_provider=None the monitor builds a per-connection PlaidProvider
+    from DB credentials (get_plaid_credentials) rather than relying on env vars.
+
+    This is the regression test for the bug fixed in issue #259: sync() was
+    passing the module-level _plaid singleton (created at import time, before
+    DB credentials are loaded) so ClawHub installs with no env vars but valid
+    plaid_config rows would fail with INVALID_API_KEYS on every health check.
+    """
+    import sqlite3
+    from unittest.mock import MagicMock, patch
+
+    db = tmp_path / "data.db"
+    monkeypatch.setattr("server.paths.DB_PATH", db)
+    init_db(db)
+
+    # Insert a connection with a known user_id so we can verify which
+    # credentials were passed to PlaidProvider.
+    user_id = str(uuid.uuid4())
+    connection_id = str(uuid.uuid4())
+    conn = sqlite3.connect(str(db))
+    conn.row_factory = sqlite3.Row
+    try:
+        # Insert user
+        conn.execute("INSERT OR IGNORE INTO users (id, username) VALUES (?, ?)", (user_id, "testuser"))
+        # Insert plaid_config with DB-only credentials
+        conn.execute(
+            "INSERT INTO plaid_config (user_id, client_id, secret, plaid_env) VALUES (?, ?, ?, ?)",
+            (user_id, "db-client-id", "db-secret", "sandbox"),
+        )
+        # Insert active bank_connection for that user
+        conn.execute(
+            "INSERT INTO bank_connections "
+            "(id, plaid_item_id, plaid_access_token_encrypted, status, user_id, plaid_env) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (connection_id, "item-123", "enc_tok", "active", user_id, "sandbox"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Decrypt stub
+    monkeypatch.setattr("server.crypto.decrypt", lambda x: "plain-token")
+
+    # Clear env vars to simulate ClawHub install with no env vars set
+    monkeypatch.delenv("PLAID_CLIENT_ID", raising=False)
+    monkeypatch.delenv("PLAID_SECRET", raising=False)
+
+    built_providers = []
+
+    class _CapturingProvider:
+        def __init__(self, env=None, client_id=None, secret=None):
+            built_providers.append({"client_id": client_id, "secret": secret, "env": env})
+            self._env = env
+
+        def get_item_status(self, access_token):
+            # Return healthy status so no DB update fails
+            return {}
+
+    db_conn = get_db(db)
+    try:
+        with patch("server.providers.plaid.PlaidProvider", _CapturingProvider):
+            check_all_connections(db_conn, plaid_provider=None)
+    finally:
+        db_conn.close()
+
+    # A PlaidProvider should have been built with the DB credentials, not empty ones
+    assert len(built_providers) == 1, "expected exactly one PlaidProvider to be built"
+    assert built_providers[0]["client_id"] == "db-client-id", (
+        "health monitor should use DB client_id, not env var / empty string"
+    )
+    assert built_providers[0]["secret"] == "db-secret", (
+        "health monitor should use DB secret, not env var / empty string"
+    )
+
+
+def test_sync_passes_none_not_module_singleton_to_health_monitor(monkeypatch):
+    """Regression test for issue #259: sync() must pass plaid_provider=None
+    to check_all_connections so the health monitor uses DB credentials
+    instead of the module-level _plaid singleton (which has no DB creds).
+    """
+    from unittest.mock import call, patch
+    import server.main as _sm
+
+    captured_provider_arg = []
+
+    original_check = __import__("server.health_monitor", fromlist=["check_all_connections"]).check_all_connections
+
+    def _spy_check(db_conn, plaid_provider=None):
+        captured_provider_arg.append(plaid_provider)
+        # Return a minimal result so sync() doesn't break on the dict
+        return {"checked": 0, "active": 0, "needs_reauth": 0, "pending_expiration": 0}
+
+    # Prevent actual sync work — we only care about what sync() passes to
+    # check_all_connections.
+    monkeypatch.setattr("server.health_monitor.check_all_connections", _spy_check)
+    monkeypatch.setattr(_sm, "sync_lock", lambda timeout=0.0: __import__("contextlib").nullcontext())
+
+    # Fake get_db so no real DB is needed
+    class _FakeConn:
+        def execute(self, *a, **kw):
+            class _Result:
+                def fetchall(self):
+                    return []
+                def fetchone(self):
+                    return None
+            return _Result()
+        def close(self):
+            pass
+        def commit(self):
+            pass
+
+    monkeypatch.setattr(_sm, "get_db", lambda *a, **kw: _FakeConn())
+
+    _sm.sync()
+
+    assert len(captured_provider_arg) == 1
+    assert captured_provider_arg[0] is None, (
+        "sync() must pass plaid_provider=None to check_all_connections "
+        "(not the module-level _plaid singleton) so DB credentials are used"
+    )


### PR DESCRIPTION
## Problem

Closes #259.

`sync()` was calling `check_all_connections(db_conn, plaid_provider=_plaid)` where `_plaid` is the module-level `PlaidProvider()` singleton. This singleton is created at **import time** — before `_load_plaid_config_from_db()` in `daemon.main()` has had a chance to populate `os.environ` with DB-stored credentials.

In a ClawHub install (no `PLAID_CLIENT_ID`/`PLAID_SECRET` env vars in the LaunchAgent), the singleton has `_client_id=None` and `_secret=None`. `_build_client()` falls back to `os.environ` at call time, which partly masked the issue, but this is fragile and wrong in multi-user setups where each connection has its own `plaid_config` row.

**Root cause confirmed:**
```
_plaid._client_id at import time: None
_plaid._secret at import time: None
```

Symptoms (from daemon.log):
```
WARNING server.health_monitor — health_monitor: Plaid error for connection <id>: Status Code: 400
INVALID_API_KEYS: invalid client_id or secret provided
```

The health monitor was silently failing to detect stale/expiring connections on every health check cycle.

## Fix

Pass `plaid_provider=None` to `check_all_connections()` so the health monitor builds a **per-connection** `PlaidProvider` from `get_plaid_credentials(user_id)` (DB lookup → env var fallback) for each `bank_connections` row. This is exactly the same credential-resolution pattern the sync loop uses for actual transaction fetching.

```python
# Before (broken for ClawHub installs / multi-user):
health_check_result = server.health_monitor.check_all_connections(
    db_conn, plaid_provider=_plaid
)

# After (correct — DB creds per connection):
health_check_result = server.health_monitor.check_all_connections(
    db_conn, plaid_provider=None
)
```

## Tests

Two new regression tests in `tests/test_health_monitor.py`:

- `test_db_credentials_used_when_no_provider_passed` — verifies that when `plaid_provider=None` and no env vars are set, the health monitor builds a `PlaidProvider` with credentials read from `plaid_config` DB rows.
- `test_sync_passes_none_not_module_singleton_to_health_monitor` — regression guard asserting `sync()` passes `plaid_provider=None` (not `_plaid`) to `check_all_connections()`.

All 9 health monitor tests pass.