### PR TITLE
feat: add copy access token button to accounts page

### DIFF
--- a/ui/server.py
+++ b/ui/server.py
@@ -953,6 +953,36 @@ def account_transactions_get(request: Request, account_id: str, limit: int = 50)
         conn.close()
 
 
+@app.get("/accounts/{connection_id}/access-token")
+def accounts_access_token_get(request: Request, connection_id: str):
+    """Return the decrypted Plaid access token for a bank connection.
+
+    Requires authentication.  Intended for personal use only — this is a
+    local single-user app and the token is needed for direct Plaid API calls.
+
+    Returns JSON: {"access_token": "access-production-..."}
+    """
+    if not _is_authenticated(request):
+        return JSONResponse({"error": "not authenticated"}, status_code=401)
+    conn = get_db(_db_path())
+    try:
+        row = conn.execute(
+            "SELECT plaid_access_token_encrypted FROM bank_connections WHERE id = ?",
+            (connection_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    if row is None:
+        return JSONResponse({"error": "connection not found"}, status_code=404)
+    try:
+        import server.crypto
+
+        access_token = server.crypto.decrypt(row["plaid_access_token_encrypted"])
+    except Exception as exc:
+        return JSONResponse({"error": f"decrypt failed: {exc}"}, status_code=500)
+    return JSONResponse({"access_token": access_token})
+
+
 @app.patch("/accounts/{account_id}/name")
 async def accounts_name_patch(request: Request, account_id: str):
     """Update the display name for a bank account (inline rename).  Requires auth.

--- a/ui/templates/accounts.html
+++ b/ui/templates/accounts.html
@@ -16,14 +16,20 @@
   <section class="institution-group" style="margin-bottom:2rem">
     <div class="institution-header" style="display:flex;justify-content:space-between;align-items:center;border-bottom:2px solid #e2e8f0;padding-bottom:0.5rem;margin-bottom:0.75rem">
       <h2 style="margin:0;font-size:1.1rem;font-weight:600">── {{ institution }}</h2>
-      <form method="post" action="/profile" style="display:inline;margin:0">
-        <input type="hidden" name="action" value="disconnect_bank">
-        <input type="hidden" name="bank_id" value="{{ data.connection_id }}">
-        <button type="submit" class="btn btn-sm btn-danger"
-          onclick="return confirm('Disconnect {{ institution }}? This will remove all linked accounts.')">
-          Disconnect
+      <div style="display:flex;gap:0.4rem;align-items:center">
+        <button type="button" class="btn btn-sm btn-secondary copy-token-btn"
+          data-connection-id="{{ data.connection_id }}">
+          Copy token
         </button>
-      </form>
+        <form method="post" action="/profile" style="display:inline;margin:0">
+          <input type="hidden" name="action" value="disconnect_bank">
+          <input type="hidden" name="bank_id" value="{{ data.connection_id }}">
+          <button type="submit" class="btn btn-sm btn-danger"
+            onclick="return confirm('Disconnect {{ institution }}? This will remove all linked accounts.')">
+            Disconnect
+          </button>
+        </form>
+      </div>
     </div>
     <table style="width:100%;border-collapse:collapse">
       <thead>
@@ -266,6 +272,26 @@ document.querySelectorAll('.rename-btn').forEach(btn => {
         delete btn.dataset.editing;
       }
     }, { once: true });
+  });
+});
+
+// ── Copy access token ──────────────────────────────────────────────────────────────────────────────────────────────
+document.querySelectorAll('.copy-token-btn').forEach(btn => {
+  btn.addEventListener('click', async function(event) {
+    const connectionId = btn.dataset.connectionId;
+    try {
+      const resp = await fetch(`/accounts/${connectionId}/access-token`);
+      if (!resp.ok) {
+        throw new Error(`HTTP ${resp.status}`);
+      }
+      const data = await resp.json();
+      await navigator.clipboard.writeText(data.access_token);
+      btn.textContent = 'Copied!';
+      setTimeout(() => { btn.textContent = 'Copy token'; }, 2000);
+    } catch (e) {
+      btn.textContent = 'Failed!';
+      setTimeout(() => { btn.textContent = 'Copy token'; }, 2000);
+    }
   });
 });
 </script>


### PR DESCRIPTION
## Summary

Adds a way to easily retrieve the Plaid access token for any connected bank directly from the UI.

## Changes

### New API endpoint
- `GET /accounts/{connection_id}/access-token` — auth-protected, decrypts `plaid_access_token_encrypted` from `bank_connections`, returns `{"access_token": "access-production-..."}`

### UI (accounts page)
- Added a **Copy token** button next to each institution's Disconnect button
- On click: fetches the token from the new endpoint, copies to clipboard, shows brief **Copied!** feedback (reverts to **Copy token** after 2 seconds)
- Falls back to **Failed!** feedback on error

## Notes
- Local personal app — exposing the token in the UI is intentional
- No modal, just clipboard copy with brief feedback as requested