### PR TITLE
feat: deduplicate shared/joint bank accounts across connections (#269)

### DIFF
--- a/server/db.py
+++ b/server/db.py
@@ -191,6 +191,11 @@ def init_db(path: str | Path) -> None:
             """)
         conn.commit()
 
+        # Migration: bank_accounts deduplication (#269 — joint/shared account dedup)
+        _add_col_if_missing(conn, "bank_accounts", "is_duplicate", "INTEGER NOT NULL DEFAULT 0")
+        _add_col_if_missing(conn, "bank_accounts", "primary_account_id", "TEXT")
+        conn.commit()
+
         # Migration: plaid_revocation_log (#265 — durable revocation audit log).
         # Mirrors every access token inserted via complete_link so that
         # wipe.py and retry_pending_revocations() can revoke tokens even

--- a/server/main.py
+++ b/server/main.py
@@ -1615,6 +1615,116 @@ def classify_pending_transactions(user_id: str, limit: int | None = None) -> dic
     return {"classified": classified, "skipped": skipped, "uncertain": uncertain}
 
 
+def _deduplicate_accounts(conn: "sqlite3.Connection", user_id: str) -> None:
+    """Mark duplicate bank_accounts for a user (issue #269).
+
+    Two accounts are considered the same shared/joint account when:
+
+    * **Pass 1 — mask-based (strict):** same (mask, name, type, subtype) and
+      mask is non-NULL / non-empty.  Works across any connections.
+
+    * **Pass 2 — cross-connection name match (mask-less):** same
+      (name, type, subtype) and mask is NULL/empty, but the rows belong to
+      *different* connections.  This handles banks (e.g. RBC) that never
+      return a mask from Plaid yet appear twice because the same institution
+      was linked through two Plaid items.  Accounts sharing a connection are
+      *never* collapsed in this pass (too risky — they may genuinely be
+      distinct sub-accounts).
+
+    Within each duplicate group the row with the lexicographically smallest
+    ``id`` is kept as the primary; all others get ``is_duplicate=1`` and
+    ``primary_account_id`` pointing at the primary.
+    """
+    if not user_id:
+        return
+
+    def _apply_groups(groups: "dict[tuple, list[str]]") -> None:
+        """Mark duplicates within each group; single-entry groups → not-duplicate."""
+        for ids in groups.values():
+            if len(ids) > 1:
+                primary_id = min(ids)
+                for acct_id in ids:
+                    if acct_id == primary_id:
+                        conn.execute(
+                            "UPDATE bank_accounts SET is_duplicate=0, primary_account_id=NULL WHERE id=?",
+                            (acct_id,),
+                        )
+                    else:
+                        conn.execute(
+                            "UPDATE bank_accounts SET is_duplicate=1, primary_account_id=? WHERE id=?",
+                            (primary_id, acct_id),
+                        )
+            else:
+                conn.execute(
+                    "UPDATE bank_accounts SET is_duplicate=0, primary_account_id=NULL WHERE id=?",
+                    (ids[0],),
+                )
+
+    # ------------------------------------------------------------------
+    # Pass 1: mask-based dedup (accounts with a non-empty mask)
+    # ------------------------------------------------------------------
+    rows_with_mask = conn.execute(
+        """
+        SELECT ba.id, ba.mask, ba.name, ba.type, ba.subtype
+          FROM bank_accounts ba
+          JOIN bank_connections bc ON bc.id = ba.connection_id
+         WHERE bc.user_id = ?
+           AND ba.mask IS NOT NULL
+           AND ba.mask != ''
+         ORDER BY ba.id
+        """,
+        (user_id,),
+    ).fetchall()
+
+    groups1: dict[tuple, list[str]] = {}
+    for r in rows_with_mask:
+        key = (r["mask"], r["name"], r["type"], r["subtype"])
+        if key not in groups1:
+            groups1[key] = []
+        groups1[key].append(r["id"])
+    _apply_groups(groups1)
+
+    # ------------------------------------------------------------------
+    # Pass 2: cross-connection name dedup (mask is NULL/empty)
+    # ------------------------------------------------------------------
+    rows_no_mask = conn.execute(
+        """
+        SELECT ba.id, ba.name, ba.type, ba.subtype, ba.connection_id
+          FROM bank_accounts ba
+          JOIN bank_connections bc ON bc.id = ba.connection_id
+         WHERE bc.user_id = ?
+           AND (ba.mask IS NULL OR ba.mask = '')
+         ORDER BY ba.id
+        """,
+        (user_id,),
+    ).fetchall()
+
+    # Group by (name, type, subtype) — but track connection_id per entry so
+    # we can verify the group spans more than one connection before flagging.
+    from collections import defaultdict as _dd
+    pre_groups: dict[tuple, list[dict]] = {}
+    for r in rows_no_mask:
+        key = (r["name"], r["type"], r["subtype"])
+        if key not in pre_groups:
+            pre_groups[key] = []
+        pre_groups[key].append({"id": r["id"], "connection_id": r["connection_id"]})
+
+    groups2: dict[tuple, list[str]] = {}
+    for key, entries in pre_groups.items():
+        conn_ids = {e["connection_id"] for e in entries}
+        if len(conn_ids) > 1:
+            # Spans multiple connections → genuine cross-connection duplicate
+            groups2[key] = [e["id"] for e in entries]
+        else:
+            # All in same connection → reset each to non-duplicate
+            for e in entries:
+                conn.execute(
+                    "UPDATE bank_accounts SET is_duplicate=0, primary_account_id=NULL WHERE id=?",
+                    (e["id"],),
+                )
+    _apply_groups(groups2)
+
+
 @mcp.tool
 def sync() -> dict:
     """Pull new transactions from Plaid, classify them, and return a summary."""
@@ -1771,10 +1881,42 @@ def sync() -> dict:
                                 ),
                             )
 
+                    # Deduplicate shared/joint accounts after each connection's
+                    # accounts are upserted (issue #269).  This is idempotent.
+                    if conn_user_id:
+                        with db_txn(db_conn):
+                            _deduplicate_accounts(db_conn, conn_user_id)
+
+                    # Build a user-scoped set of plaid_account_ids that are
+                    # marked as duplicates so we can skip their transactions.
+                    # Scoped to user (not connection) so that accounts owned
+                    # by other connections of the same user are also excluded.
+                    _dup_plaid_ids: set[str] = set()
+                    if conn_user_id:
+                        _dup_plaid_ids = set(
+                            r[0]
+                            for r in db_conn.execute(
+                                """
+                                SELECT ba.plaid_account_id
+                                  FROM bank_accounts ba
+                                  JOIN bank_connections bc ON bc.id = ba.connection_id
+                                 WHERE ba.is_duplicate = 1
+                                   AND bc.user_id = ?
+                                """,
+                                (conn_user_id,),
+                            ).fetchall()
+                        )
+
                     with db_txn(db_conn):
                         # --- Added transactions ---
                         for txn in added_txns:
                             plaid_account_id = _get(txn, "account_id")
+
+                            # Skip transactions for accounts that are
+                            # duplicates of another account (issue #269).
+                            if plaid_account_id in _dup_plaid_ids:
+                                continue
+
                             plaid_txn_id = _get(txn, "transaction_id")
                             date = _get(txn, "date")
                             # authorized_datetime is an ISO-8601 string with time (e.g.

--- a/server/main.py
+++ b/server/main.py
@@ -1615,7 +1615,7 @@ def classify_pending_transactions(user_id: str, limit: int | None = None) -> dic
     return {"classified": classified, "skipped": skipped, "uncertain": uncertain}
 
 
-def _deduplicate_accounts(conn: "sqlite3.Connection", user_id: str) -> None:
+def _deduplicate_accounts(conn, user_id: str) -> None:  # conn: sqlite3.Connection
     """Mark duplicate bank_accounts for a user (issue #269).
 
     Two accounts are considered the same shared/joint account when:
@@ -1701,7 +1701,6 @@ def _deduplicate_accounts(conn: "sqlite3.Connection", user_id: str) -> None:
 
     # Group by (name, type, subtype) — but track connection_id per entry so
     # we can verify the group spans more than one connection before flagging.
-    from collections import defaultdict as _dd
     pre_groups: dict[tuple, list[dict]] = {}
     for r in rows_no_mask:
         key = (r["name"], r["type"], r["subtype"])

--- a/tests/test_dedup_accounts.py
+++ b/tests/test_dedup_accounts.py
@@ -1,0 +1,443 @@
+"""
+tests/test_dedup_accounts.py — Tests for duplicate-account detection (issue #269).
+
+Covers:
+  - _deduplicate_accounts() marks the correct rows is_duplicate=1 / 0
+  - The primary account (lexicographically smallest id) is kept
+  - Accounts with NULL / empty mask are never deduplicated
+  - Accounts from different users are not cross-contaminated
+  - sync() skips transactions for duplicate accounts
+  - _get_accounts_grouped() hides duplicates and reports hidden_count
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from server.db import get_db, init_db
+from server.main import _deduplicate_accounts
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mk_user(conn, user_id=None):
+    uid = user_id or str(uuid.uuid4())
+    import time
+    conn.execute(
+        "INSERT OR IGNORE INTO users (id, username, password_hash, created_at) VALUES (?, ?, ?, ?)",
+        (uid, uid[:8], "x", int(time.time())),
+    )
+    return uid
+
+
+def _mk_connection(conn, user_id, conn_id=None):
+    cid = conn_id or str(uuid.uuid4())
+    conn.execute(
+        "INSERT INTO bank_connections "
+        "(id, plaid_item_id, plaid_access_token_encrypted, status, user_id) "
+        "VALUES (?, ?, ?, 'active', ?)",
+        (cid, f"item-{cid[:8]}", "tok", user_id),
+    )
+    return cid
+
+
+def _mk_account(conn, connection_id, *, acct_id=None, name="Chequing",
+                 mask="1234", acct_type="depository", subtype="checking"):
+    aid = acct_id or str(uuid.uuid4())
+    conn.execute(
+        "INSERT INTO bank_accounts "
+        "(id, connection_id, plaid_account_id, name, mask, type, subtype) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (aid, connection_id, f"plaid-{aid[:8]}", name, mask, acct_type, subtype),
+    )
+    return aid
+
+
+@pytest.fixture()
+def db(tmp_path, monkeypatch):
+    db_path = tmp_path / "data.db"
+    monkeypatch.setattr("server.paths.DB_PATH", db_path)
+    init_db(db_path)
+    conn = get_db(db_path)
+    yield conn
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# _deduplicate_accounts unit tests
+# ---------------------------------------------------------------------------
+
+class TestDeduplicateAccounts:
+    def test_two_identical_accounts_one_marked_duplicate(self, db):
+        """Two connections for the same user with the same account → one duplicate."""
+        uid = _mk_user(db)
+        cid_a = _mk_connection(db, uid)
+        cid_b = _mk_connection(db, uid)
+        # Use fixed UUIDs so we know which is lexicographically smaller
+        aid_small = "00000000-0000-0000-0000-000000000001"
+        aid_large  = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+        _mk_account(db, cid_a, acct_id=aid_small, mask="9999", name="Savings", acct_type="depository", subtype="savings")
+        _mk_account(db, cid_b, acct_id=aid_large, mask="9999", name="Savings", acct_type="depository", subtype="savings")
+        db.commit()
+
+        _deduplicate_accounts(db, uid)
+        db.commit()
+
+        rows = {r["id"]: r for r in db.execute("SELECT id, is_duplicate, primary_account_id FROM bank_accounts").fetchall()}
+        assert rows[aid_small]["is_duplicate"] == 0
+        assert rows[aid_small]["primary_account_id"] is None
+        assert rows[aid_large]["is_duplicate"] == 1
+        assert rows[aid_large]["primary_account_id"] == aid_small
+
+    def test_no_duplicate_different_masks(self, db):
+        """Accounts with different masks are not considered duplicates."""
+        uid = _mk_user(db)
+        cid_a = _mk_connection(db, uid)
+        cid_b = _mk_connection(db, uid)
+        aid_a = _mk_account(db, cid_a, mask="1111", name="Chequing")
+        aid_b = _mk_account(db, cid_b, mask="2222", name="Chequing")
+        db.commit()
+
+        _deduplicate_accounts(db, uid)
+        db.commit()
+
+        rows = {r["id"]: r for r in db.execute("SELECT id, is_duplicate FROM bank_accounts").fetchall()}
+        assert rows[aid_a]["is_duplicate"] == 0
+        assert rows[aid_b]["is_duplicate"] == 0
+
+    def test_null_mask_same_connection_not_deduplicated(self, db):
+        """Accounts with NULL mask in the SAME connection are never flagged.
+
+        Two sub-accounts at the same institution (same connection) that share a
+        name but have no mask could be genuinely different — we leave them alone.
+        """
+        uid = _mk_user(db)
+        cid = _mk_connection(db, uid)   # same connection
+        aid_a = _mk_account(db, cid, mask=None, name="Mystery Account")  # type: ignore[arg-type]
+        aid_b = _mk_account(db, cid, mask=None, name="Mystery Account")  # type: ignore[arg-type]
+        db.execute("UPDATE bank_accounts SET mask = NULL")
+        db.commit()
+
+        _deduplicate_accounts(db, uid)
+        db.commit()
+
+        rows = {r["id"]: r for r in db.execute("SELECT id, is_duplicate FROM bank_accounts").fetchall()}
+        assert rows[aid_a]["is_duplicate"] == 0
+        assert rows[aid_b]["is_duplicate"] == 0
+
+    def test_null_mask_cross_connection_is_deduplicated(self, db):
+        """Accounts with NULL mask from DIFFERENT connections are deduplicated.
+
+        This is the “same bank linked twice” case (e.g. RBC returning no mask).
+        """
+        uid = _mk_user(db)
+        cid_a = _mk_connection(db, uid)
+        cid_b = _mk_connection(db, uid)
+        aid_small = "10000000-0000-0000-0000-000000000010"
+        aid_large  = "20000000-0000-0000-0000-000000000020"
+        _mk_account(db, cid_a, acct_id=aid_small, mask=None, name="Day to Day",  # type: ignore[arg-type]
+                    acct_type="depository", subtype="checking")
+        _mk_account(db, cid_b, acct_id=aid_large, mask=None, name="Day to Day",  # type: ignore[arg-type]
+                    acct_type="depository", subtype="checking")
+        db.execute("UPDATE bank_accounts SET mask = NULL")
+        db.commit()
+
+        _deduplicate_accounts(db, uid)
+        db.commit()
+
+        rows = {r["id"]: r for r in db.execute("SELECT id, is_duplicate, primary_account_id FROM bank_accounts").fetchall()}
+        assert rows[aid_small]["is_duplicate"] == 0
+        assert rows[aid_large]["is_duplicate"] == 1
+        assert rows[aid_large]["primary_account_id"] == aid_small
+
+    def test_user_isolation(self, db):
+        """Accounts belonging to different users are never cross-deduplicated."""
+        uid_a = _mk_user(db)
+        uid_b = _mk_user(db)
+        cid_a = _mk_connection(db, uid_a)
+        cid_b = _mk_connection(db, uid_b)
+        aid_a = _mk_account(db, cid_a, mask="7777", name="Chequing")
+        aid_b = _mk_account(db, cid_b, mask="7777", name="Chequing")
+        db.commit()
+
+        # Run dedup for user A only
+        _deduplicate_accounts(db, uid_a)
+        db.commit()
+
+        rows = {r["id"]: r for r in db.execute("SELECT id, is_duplicate FROM bank_accounts").fetchall()}
+        # user A has only one account → not a duplicate
+        assert rows[aid_a]["is_duplicate"] == 0
+        # user B's account was not touched
+        assert rows[aid_b]["is_duplicate"] == 0
+
+    def test_idempotent(self, db):
+        """Calling _deduplicate_accounts twice gives the same result."""
+        uid = _mk_user(db)
+        cid_a = _mk_connection(db, uid)
+        cid_b = _mk_connection(db, uid)
+        aid_small = "10000000-0000-0000-0000-000000000000"
+        aid_large  = "20000000-0000-0000-0000-000000000000"
+        _mk_account(db, cid_a, acct_id=aid_small, mask="5555", name="Card")
+        _mk_account(db, cid_b, acct_id=aid_large, mask="5555", name="Card")
+        db.commit()
+
+        _deduplicate_accounts(db, uid)
+        db.commit()
+        _deduplicate_accounts(db, uid)
+        db.commit()
+
+        rows = {r["id"]: r for r in db.execute("SELECT id, is_duplicate FROM bank_accounts").fetchall()}
+        assert rows[aid_small]["is_duplicate"] == 0
+        assert rows[aid_large]["is_duplicate"] == 1
+
+    def test_three_duplicates_only_one_primary(self, db):
+        """Three identical accounts → one primary, two duplicates."""
+        uid = _mk_user(db)
+        cids = [_mk_connection(db, uid) for _ in range(3)]
+        aid_1 = "10000000-0000-0000-0000-000000000001"
+        aid_2 = "20000000-0000-0000-0000-000000000002"
+        aid_3 = "30000000-0000-0000-0000-000000000003"
+        for aid, cid in zip([aid_1, aid_2, aid_3], cids):
+            _mk_account(db, cid, acct_id=aid, mask="3333", name="Joint", acct_type="depository", subtype="checking")
+        db.commit()
+
+        _deduplicate_accounts(db, uid)
+        db.commit()
+
+        rows = {r["id"]: r for r in db.execute("SELECT id, is_duplicate, primary_account_id FROM bank_accounts").fetchall()}
+        assert rows[aid_1]["is_duplicate"] == 0       # smallest → primary
+        assert rows[aid_2]["is_duplicate"] == 1
+        assert rows[aid_2]["primary_account_id"] == aid_1
+        assert rows[aid_3]["is_duplicate"] == 1
+        assert rows[aid_3]["primary_account_id"] == aid_1
+
+    def test_no_user_id_no_crash(self, db):
+        """Calling with empty user_id is a safe no-op."""
+        # Should not raise
+        _deduplicate_accounts(db, "")
+        _deduplicate_accounts(db, None)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# sync() integration test — duplicate account transactions are skipped
+# ---------------------------------------------------------------------------
+
+import json
+from server.main import sync
+from server.db import init_db as _init_db
+
+
+_HEALTH_NOOP = {"checked": 0, "active": 0, "needs_reauth": 0, "pending_expiration": 0}
+
+
+def _plaid_factory(sync_fn):
+    class _Mock:
+        def __init__(self, env=None, client_id=None, secret=None):
+            import os
+            self.env = (env or os.environ.get("PLAID_ENV", "sandbox")).lower()
+
+        def sync_transactions(self, access_token, cursor=None):
+            return sync_fn(access_token, cursor)
+
+    return _Mock
+
+
+class TestSyncSkipsDuplicates:
+    """sync() must not insert transactions for is_duplicate=1 accounts."""
+
+    @pytest.fixture()
+    def env(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "data.db"
+        lock = tmp_path / "sync.lock"
+        monkeypatch.setattr("server.paths.DB_PATH", db_path)
+        monkeypatch.setattr("server.paths.SYNC_LOCK_PATH", lock)
+        _init_db(db_path)
+
+        import time
+        conn = get_db(db_path)
+        uid = str(uuid.uuid4())
+        conn.execute(
+            "INSERT INTO users (id, username, password_hash, created_at) VALUES (?, 'u', 'x', ?)",
+            (uid, int(time.time())),
+        )
+
+        # Two connections for the same institution / account (e.g. joint account
+        # linked by both partners).
+        cid_primary = str(uuid.uuid4())
+        cid_dup = str(uuid.uuid4())
+        for cid in (cid_primary, cid_dup):
+            conn.execute(
+                "INSERT INTO bank_connections "
+                "(id, plaid_item_id, plaid_access_token_encrypted, status, user_id) "
+                "VALUES (?, ?, 'enc', 'active', ?)",
+                (cid, f"item-{cid[:6]}", uid),
+            )
+
+        # Pre-create bank_account rows with the same mask/name/type/subtype so
+        # _deduplicate_accounts will flag the one from cid_dup as a duplicate.
+        aid_primary = "10000000-0000-0000-0000-aaaaaaaaaaaa"
+        aid_dup     = "20000000-0000-0000-0000-bbbbbbbbbbbb"
+        PLAID_ACCT_PRIMARY = "plaid-acct-primary"
+        PLAID_ACCT_DUP     = "plaid-acct-dup"
+        conn.execute(
+            "INSERT INTO bank_accounts (id, connection_id, plaid_account_id, name, mask, type, subtype) "
+            "VALUES (?, ?, ?, 'Savings', '8888', 'depository', 'savings')",
+            (aid_primary, cid_primary, PLAID_ACCT_PRIMARY),
+        )
+        conn.execute(
+            "INSERT INTO bank_accounts (id, connection_id, plaid_account_id, name, mask, type, subtype) "
+            "VALUES (?, ?, ?, 'Savings', '8888', 'depository', 'savings')",
+            (aid_dup, cid_dup, PLAID_ACCT_DUP),
+        )
+        conn.commit()
+        conn.close()
+
+        return {
+            "db": db_path,
+            "uid": uid,
+            "cid_primary": cid_primary,
+            "cid_dup": cid_dup,
+            "aid_primary": aid_primary,
+            "aid_dup": aid_dup,
+            "plaid_acct_primary": PLAID_ACCT_PRIMARY,
+            "plaid_acct_dup": PLAID_ACCT_DUP,
+        }
+
+    def test_duplicate_account_transactions_not_inserted(self, env, monkeypatch):
+        """Transactions from the duplicate account must not appear in the DB."""
+        plaid_acct_primary = env["plaid_acct_primary"]
+        plaid_acct_dup     = env["plaid_acct_dup"]
+
+        def _mock_sync(access_token, cursor=None):
+            return {
+                "added": [
+                    {
+                        "transaction_id": "txn-primary-1",
+                        "account_id": plaid_acct_primary,
+                        "date": "2025-01-01",
+                        "name": "Coffee",
+                        "merchant_name": "Starbucks",
+                        "amount": 5.0,
+                        "pending": False,
+                        "accounts": [],
+                    },
+                    {
+                        "transaction_id": "txn-dup-1",
+                        "account_id": plaid_acct_dup,
+                        "date": "2025-01-01",
+                        "name": "Coffee",
+                        "merchant_name": "Starbucks",
+                        "amount": 5.0,
+                        "pending": False,
+                        "accounts": [],
+                    },
+                ],
+                "modified": [],
+                "removed": [],
+                "next_cursor": "c2",
+                "accounts": [
+                    {
+                        "account_id": plaid_acct_primary,
+                        "name": "Savings",
+                        "official_name": None,
+                        "type": "depository",
+                        "balances": {"iso_currency_code": "CAD", "current": 100.0, "available": 90.0},
+                    },
+                    {
+                        "account_id": plaid_acct_dup,
+                        "name": "Savings",
+                        "official_name": None,
+                        "type": "depository",
+                        "balances": {"iso_currency_code": "CAD", "current": 100.0, "available": 90.0},
+                    },
+                ],
+            }
+
+        monkeypatch.setattr("server.main.PlaidProvider", _plaid_factory(_mock_sync))
+        monkeypatch.setattr("server.crypto.decrypt", lambda x: x)
+        monkeypatch.setattr(
+            "server.health_monitor.check_all_connections",
+            lambda db, plaid_provider=None: _HEALTH_NOOP,
+        )
+
+        result = sync()
+        assert result["status"] == "ok"
+
+        conn = get_db(env["db"])
+        txns = conn.execute("SELECT plaid_transaction_id FROM transactions").fetchall()
+        plaid_ids = {r[0] for r in txns}
+        conn.close()
+
+        # Primary account's transaction must be present
+        assert "txn-primary-1" in plaid_ids
+        # Duplicate account's transaction must be absent
+        assert "txn-dup-1" not in plaid_ids
+
+
+# ---------------------------------------------------------------------------
+# _get_accounts_grouped UI helper test
+# ---------------------------------------------------------------------------
+
+import sys
+import importlib
+
+
+class TestGetAccountsGrouped:
+    """_get_accounts_grouped filters duplicates and reports hidden_count."""
+
+    @pytest.fixture()
+    def ui_env(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "data.db"
+        monkeypatch.setenv("FRIDAY_BP_APP_DIR", str(tmp_path))
+        _init_db(db_path)
+        conn = get_db(db_path)
+        import time
+        uid = str(uuid.uuid4())
+        conn.execute(
+            "INSERT INTO users (id, username, password_hash, created_at) VALUES (?, 'u', 'x', ?)",
+            (uid, int(time.time())),
+        )
+        cid = str(uuid.uuid4())
+        conn.execute(
+            "INSERT INTO bank_connections "
+            "(id, plaid_item_id, plaid_access_token_encrypted, status, user_id, institution_name) "
+            "VALUES (?, 'item', 'tok', 'active', ?, 'TestBank')",
+            (cid, uid),
+        )
+        # Primary account
+        aid_p = "10000000-aaaa-aaaa-aaaa-000000000001"
+        # Duplicate account
+        aid_d = "20000000-bbbb-bbbb-bbbb-000000000002"
+        conn.execute(
+            "INSERT INTO bank_accounts (id, connection_id, plaid_account_id, name, mask, type, subtype, is_duplicate) "
+            "VALUES (?, ?, 'p-acct-1', 'Chequing', '1111', 'depository', 'checking', 0)",
+            (aid_p, cid),
+        )
+        conn.execute(
+            "INSERT INTO bank_accounts (id, connection_id, plaid_account_id, name, mask, type, subtype, is_duplicate) "
+            "VALUES (?, ?, 'p-acct-2', 'Chequing', '1111', 'depository', 'checking', 1)",
+            (aid_d, cid),
+        )
+        conn.commit()
+        conn.close()
+        return {"db": db_path, "uid": uid, "aid_p": aid_p, "aid_d": aid_d}
+
+    def test_duplicate_hidden_and_counted(self, ui_env, monkeypatch):
+        monkeypatch.setattr("ui.server._db_path", lambda: str(ui_env["db"]))
+
+        # Import after patching
+        from ui.server import _get_accounts_grouped
+
+        grouped = _get_accounts_grouped(ui_env["uid"])
+        assert "TestBank" in grouped
+        data = grouped["TestBank"]
+        # Only the non-duplicate should appear in accounts list
+        ids_shown = [a["id"] for a in data["accounts"]]
+        assert ui_env["aid_p"] in ids_shown
+        assert ui_env["aid_d"] not in ids_shown
+        # hidden_count should be 1
+        assert data["hidden_count"] == 1

--- a/tests/test_dedup_accounts.py
+++ b/tests/test_dedup_accounts.py
@@ -17,16 +17,17 @@ import uuid
 import pytest
 
 from server.db import get_db, init_db
-from server.main import _deduplicate_accounts
-
+from server.main import _deduplicate_accounts  # noqa: E402
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _mk_user(conn, user_id=None):
     uid = user_id or str(uuid.uuid4())
     import time
+
     conn.execute(
         "INSERT OR IGNORE INTO users (id, username, password_hash, created_at) VALUES (?, ?, ?, ?)",
         (uid, uid[:8], "x", int(time.time())),
@@ -45,8 +46,16 @@ def _mk_connection(conn, user_id, conn_id=None):
     return cid
 
 
-def _mk_account(conn, connection_id, *, acct_id=None, name="Chequing",
-                 mask="1234", acct_type="depository", subtype="checking"):
+def _mk_account(
+    conn,
+    connection_id,
+    *,
+    acct_id=None,
+    name="Chequing",
+    mask="1234",
+    acct_type="depository",
+    subtype="checking",
+):
     aid = acct_id or str(uuid.uuid4())
     conn.execute(
         "INSERT INTO bank_accounts "
@@ -71,6 +80,7 @@ def db(tmp_path, monkeypatch):
 # _deduplicate_accounts unit tests
 # ---------------------------------------------------------------------------
 
+
 class TestDeduplicateAccounts:
     def test_two_identical_accounts_one_marked_duplicate(self, db):
         """Two connections for the same user with the same account → one duplicate."""
@@ -79,15 +89,36 @@ class TestDeduplicateAccounts:
         cid_b = _mk_connection(db, uid)
         # Use fixed UUIDs so we know which is lexicographically smaller
         aid_small = "00000000-0000-0000-0000-000000000001"
-        aid_large  = "ffffffff-ffff-ffff-ffff-ffffffffffff"
-        _mk_account(db, cid_a, acct_id=aid_small, mask="9999", name="Savings", acct_type="depository", subtype="savings")
-        _mk_account(db, cid_b, acct_id=aid_large, mask="9999", name="Savings", acct_type="depository", subtype="savings")
+        aid_large = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+        _mk_account(
+            db,
+            cid_a,
+            acct_id=aid_small,
+            mask="9999",
+            name="Savings",
+            acct_type="depository",
+            subtype="savings",
+        )
+        _mk_account(
+            db,
+            cid_b,
+            acct_id=aid_large,
+            mask="9999",
+            name="Savings",
+            acct_type="depository",
+            subtype="savings",
+        )
         db.commit()
 
         _deduplicate_accounts(db, uid)
         db.commit()
 
-        rows = {r["id"]: r for r in db.execute("SELECT id, is_duplicate, primary_account_id FROM bank_accounts").fetchall()}
+        rows = {
+            r["id"]: r
+            for r in db.execute(
+                "SELECT id, is_duplicate, primary_account_id FROM bank_accounts"
+            ).fetchall()
+        }
         assert rows[aid_small]["is_duplicate"] == 0
         assert rows[aid_small]["primary_account_id"] is None
         assert rows[aid_large]["is_duplicate"] == 1
@@ -105,7 +136,9 @@ class TestDeduplicateAccounts:
         _deduplicate_accounts(db, uid)
         db.commit()
 
-        rows = {r["id"]: r for r in db.execute("SELECT id, is_duplicate FROM bank_accounts").fetchall()}
+        rows = {
+            r["id"]: r for r in db.execute("SELECT id, is_duplicate FROM bank_accounts").fetchall()
+        }
         assert rows[aid_a]["is_duplicate"] == 0
         assert rows[aid_b]["is_duplicate"] == 0
 
@@ -116,7 +149,7 @@ class TestDeduplicateAccounts:
         name but have no mask could be genuinely different — we leave them alone.
         """
         uid = _mk_user(db)
-        cid = _mk_connection(db, uid)   # same connection
+        cid = _mk_connection(db, uid)  # same connection
         aid_a = _mk_account(db, cid, mask=None, name="Mystery Account")  # type: ignore[arg-type]
         aid_b = _mk_account(db, cid, mask=None, name="Mystery Account")  # type: ignore[arg-type]
         db.execute("UPDATE bank_accounts SET mask = NULL")
@@ -125,7 +158,9 @@ class TestDeduplicateAccounts:
         _deduplicate_accounts(db, uid)
         db.commit()
 
-        rows = {r["id"]: r for r in db.execute("SELECT id, is_duplicate FROM bank_accounts").fetchall()}
+        rows = {
+            r["id"]: r for r in db.execute("SELECT id, is_duplicate FROM bank_accounts").fetchall()
+        }
         assert rows[aid_a]["is_duplicate"] == 0
         assert rows[aid_b]["is_duplicate"] == 0
 
@@ -138,18 +173,37 @@ class TestDeduplicateAccounts:
         cid_a = _mk_connection(db, uid)
         cid_b = _mk_connection(db, uid)
         aid_small = "10000000-0000-0000-0000-000000000010"
-        aid_large  = "20000000-0000-0000-0000-000000000020"
-        _mk_account(db, cid_a, acct_id=aid_small, mask=None, name="Day to Day",  # type: ignore[arg-type]
-                    acct_type="depository", subtype="checking")
-        _mk_account(db, cid_b, acct_id=aid_large, mask=None, name="Day to Day",  # type: ignore[arg-type]
-                    acct_type="depository", subtype="checking")
+        aid_large = "20000000-0000-0000-0000-000000000020"
+        _mk_account(
+            db,
+            cid_a,
+            acct_id=aid_small,
+            mask=None,
+            name="Day to Day",  # type: ignore[arg-type]
+            acct_type="depository",
+            subtype="checking",
+        )
+        _mk_account(
+            db,
+            cid_b,
+            acct_id=aid_large,
+            mask=None,
+            name="Day to Day",  # type: ignore[arg-type]
+            acct_type="depository",
+            subtype="checking",
+        )
         db.execute("UPDATE bank_accounts SET mask = NULL")
         db.commit()
 
         _deduplicate_accounts(db, uid)
         db.commit()
 
-        rows = {r["id"]: r for r in db.execute("SELECT id, is_duplicate, primary_account_id FROM bank_accounts").fetchall()}
+        rows = {
+            r["id"]: r
+            for r in db.execute(
+                "SELECT id, is_duplicate, primary_account_id FROM bank_accounts"
+            ).fetchall()
+        }
         assert rows[aid_small]["is_duplicate"] == 0
         assert rows[aid_large]["is_duplicate"] == 1
         assert rows[aid_large]["primary_account_id"] == aid_small
@@ -168,7 +222,9 @@ class TestDeduplicateAccounts:
         _deduplicate_accounts(db, uid_a)
         db.commit()
 
-        rows = {r["id"]: r for r in db.execute("SELECT id, is_duplicate FROM bank_accounts").fetchall()}
+        rows = {
+            r["id"]: r for r in db.execute("SELECT id, is_duplicate FROM bank_accounts").fetchall()
+        }
         # user A has only one account → not a duplicate
         assert rows[aid_a]["is_duplicate"] == 0
         # user B's account was not touched
@@ -180,7 +236,7 @@ class TestDeduplicateAccounts:
         cid_a = _mk_connection(db, uid)
         cid_b = _mk_connection(db, uid)
         aid_small = "10000000-0000-0000-0000-000000000000"
-        aid_large  = "20000000-0000-0000-0000-000000000000"
+        aid_large = "20000000-0000-0000-0000-000000000000"
         _mk_account(db, cid_a, acct_id=aid_small, mask="5555", name="Card")
         _mk_account(db, cid_b, acct_id=aid_large, mask="5555", name="Card")
         db.commit()
@@ -190,7 +246,9 @@ class TestDeduplicateAccounts:
         _deduplicate_accounts(db, uid)
         db.commit()
 
-        rows = {r["id"]: r for r in db.execute("SELECT id, is_duplicate FROM bank_accounts").fetchall()}
+        rows = {
+            r["id"]: r for r in db.execute("SELECT id, is_duplicate FROM bank_accounts").fetchall()
+        }
         assert rows[aid_small]["is_duplicate"] == 0
         assert rows[aid_large]["is_duplicate"] == 1
 
@@ -202,14 +260,27 @@ class TestDeduplicateAccounts:
         aid_2 = "20000000-0000-0000-0000-000000000002"
         aid_3 = "30000000-0000-0000-0000-000000000003"
         for aid, cid in zip([aid_1, aid_2, aid_3], cids):
-            _mk_account(db, cid, acct_id=aid, mask="3333", name="Joint", acct_type="depository", subtype="checking")
+            _mk_account(
+                db,
+                cid,
+                acct_id=aid,
+                mask="3333",
+                name="Joint",
+                acct_type="depository",
+                subtype="checking",
+            )
         db.commit()
 
         _deduplicate_accounts(db, uid)
         db.commit()
 
-        rows = {r["id"]: r for r in db.execute("SELECT id, is_duplicate, primary_account_id FROM bank_accounts").fetchall()}
-        assert rows[aid_1]["is_duplicate"] == 0       # smallest → primary
+        rows = {
+            r["id"]: r
+            for r in db.execute(
+                "SELECT id, is_duplicate, primary_account_id FROM bank_accounts"
+            ).fetchall()
+        }
+        assert rows[aid_1]["is_duplicate"] == 0  # smallest → primary
         assert rows[aid_2]["is_duplicate"] == 1
         assert rows[aid_2]["primary_account_id"] == aid_1
         assert rows[aid_3]["is_duplicate"] == 1
@@ -226,10 +297,8 @@ class TestDeduplicateAccounts:
 # sync() integration test — duplicate account transactions are skipped
 # ---------------------------------------------------------------------------
 
-import json
-from server.main import sync
 from server.db import init_db as _init_db
-
+from server.main import sync
 
 _HEALTH_NOOP = {"checked": 0, "active": 0, "needs_reauth": 0, "pending_expiration": 0}
 
@@ -238,6 +307,7 @@ def _plaid_factory(sync_fn):
     class _Mock:
         def __init__(self, env=None, client_id=None, secret=None):
             import os
+
             self.env = (env or os.environ.get("PLAID_ENV", "sandbox")).lower()
 
         def sync_transactions(self, access_token, cursor=None):
@@ -258,6 +328,7 @@ class TestSyncSkipsDuplicates:
         _init_db(db_path)
 
         import time
+
         conn = get_db(db_path)
         uid = str(uuid.uuid4())
         conn.execute(
@@ -280,9 +351,9 @@ class TestSyncSkipsDuplicates:
         # Pre-create bank_account rows with the same mask/name/type/subtype so
         # _deduplicate_accounts will flag the one from cid_dup as a duplicate.
         aid_primary = "10000000-0000-0000-0000-aaaaaaaaaaaa"
-        aid_dup     = "20000000-0000-0000-0000-bbbbbbbbbbbb"
+        aid_dup = "20000000-0000-0000-0000-bbbbbbbbbbbb"
         PLAID_ACCT_PRIMARY = "plaid-acct-primary"
-        PLAID_ACCT_DUP     = "plaid-acct-dup"
+        PLAID_ACCT_DUP = "plaid-acct-dup"
         conn.execute(
             "INSERT INTO bank_accounts (id, connection_id, plaid_account_id, name, mask, type, subtype) "
             "VALUES (?, ?, ?, 'Savings', '8888', 'depository', 'savings')",
@@ -310,7 +381,7 @@ class TestSyncSkipsDuplicates:
     def test_duplicate_account_transactions_not_inserted(self, env, monkeypatch):
         """Transactions from the duplicate account must not appear in the DB."""
         plaid_acct_primary = env["plaid_acct_primary"]
-        plaid_acct_dup     = env["plaid_acct_dup"]
+        plaid_acct_dup = env["plaid_acct_dup"]
 
         def _mock_sync(access_token, cursor=None):
             return {
@@ -345,14 +416,22 @@ class TestSyncSkipsDuplicates:
                         "name": "Savings",
                         "official_name": None,
                         "type": "depository",
-                        "balances": {"iso_currency_code": "CAD", "current": 100.0, "available": 90.0},
+                        "balances": {
+                            "iso_currency_code": "CAD",
+                            "current": 100.0,
+                            "available": 90.0,
+                        },
                     },
                     {
                         "account_id": plaid_acct_dup,
                         "name": "Savings",
                         "official_name": None,
                         "type": "depository",
-                        "balances": {"iso_currency_code": "CAD", "current": 100.0, "available": 90.0},
+                        "balances": {
+                            "iso_currency_code": "CAD",
+                            "current": 100.0,
+                            "available": 90.0,
+                        },
                     },
                 ],
             }
@@ -382,9 +461,6 @@ class TestSyncSkipsDuplicates:
 # _get_accounts_grouped UI helper test
 # ---------------------------------------------------------------------------
 
-import sys
-import importlib
-
 
 class TestGetAccountsGrouped:
     """_get_accounts_grouped filters duplicates and reports hidden_count."""
@@ -396,6 +472,7 @@ class TestGetAccountsGrouped:
         _init_db(db_path)
         conn = get_db(db_path)
         import time
+
         uid = str(uuid.uuid4())
         conn.execute(
             "INSERT INTO users (id, username, password_hash, created_at) VALUES (?, 'u', 'x', ?)",

--- a/ui/server.py
+++ b/ui/server.py
@@ -860,7 +860,9 @@ def dashboard_get(request: Request):
 def _get_accounts_grouped(user_id: Optional[str] = None) -> dict:
     """Return bank accounts grouped by institution, with balances.
 
-    Returns a dict of {institution_name: {connection_id: str, accounts: [...]}}.
+    Returns a dict of {institution_name: {connection_id: str, accounts: [...],
+    hidden_count: int}}.  Accounts marked ``is_duplicate=1`` are excluded from
+    ``accounts`` and tallied in ``hidden_count`` so the UI can show a note.
     """
     conn = get_db(_db_path())
     try:
@@ -869,6 +871,7 @@ def _get_accounts_grouped(user_id: Optional[str] = None) -> dict:
                 "SELECT ba.id, ba.name, ba.mask, ba.type, ba.subtype,"
                 "       ba.balance_current, ba.balance_available, ba.description,"
                 "       COALESCE(ba.currency, 'CAD') AS currency,"
+                "       COALESCE(ba.is_duplicate, 0) AS is_duplicate,"
                 "       bc.id AS connection_id, bc.institution_name"
                 "  FROM bank_accounts ba"
                 "  JOIN bank_connections bc ON bc.id = ba.connection_id"
@@ -881,6 +884,7 @@ def _get_accounts_grouped(user_id: Optional[str] = None) -> dict:
                 "SELECT ba.id, ba.name, ba.mask, ba.type, ba.subtype,"
                 "       ba.balance_current, ba.balance_available, ba.description,"
                 "       COALESCE(ba.currency, 'CAD') AS currency,"
+                "       COALESCE(ba.is_duplicate, 0) AS is_duplicate,"
                 "       bc.id AS connection_id, bc.institution_name"
                 "  FROM bank_accounts ba"
                 "  JOIN bank_connections bc ON bc.id = ba.connection_id"
@@ -890,8 +894,15 @@ def _get_accounts_grouped(user_id: Optional[str] = None) -> dict:
         for r in rows:
             inst = r["institution_name"] or "Unknown Institution"
             if inst not in grouped:
-                grouped[inst] = {"connection_id": r["connection_id"], "accounts": []}
-            grouped[inst]["accounts"].append(dict(r))
+                grouped[inst] = {
+                    "connection_id": r["connection_id"],
+                    "accounts": [],
+                    "hidden_count": 0,
+                }
+            if r["is_duplicate"]:
+                grouped[inst]["hidden_count"] += 1
+            else:
+                grouped[inst]["accounts"].append(dict(r))
         return grouped
     except Exception:
         return {}

--- a/ui/templates/accounts.html
+++ b/ui/templates/accounts.html
@@ -82,6 +82,11 @@
         {% endfor %}
       </tbody>
     </table>
+    {% if data.hidden_count %}
+    <p style="color:#94a3b8;font-size:0.8rem;margin:0.35rem 0.6rem 0">
+      {{ data.hidden_count }} shared account{{ 's' if data.hidden_count != 1 else '' }} hidden (duplicate of another connected bank).
+    </p>
+    {% endif %}
   </section>
   {% endfor %}
   {% endif %}


### PR DESCRIPTION
## Problem
When the same bank account is connected via two separate Plaid items (joint account, or same bank linked twice), every sync duplicates transactions.

## Changes

### DB migration (`server/db.py`)
- `is_duplicate INTEGER NOT NULL DEFAULT 0` on `bank_accounts`
- `primary_account_id TEXT` on `bank_accounts`

### `_deduplicate_accounts(conn, user_id)` (`server/main.py`)
- **Pass 1 – mask-based:** groups by `(mask, name, type, subtype)` where mask is non-NULL. Strict, cross-connection dedup.
- **Pass 2 – cross-connection, mask-less:** groups by `(name, type, subtype)` where mask is NULL/empty, but **only** flags duplicates that span >1 connection (same-connection accounts are never collapsed).
- Lexicographically smallest `id` becomes primary; others get `is_duplicate=1` + `primary_account_id`.

### `sync()` (`server/main.py`)
- Calls `_deduplicate_accounts()` after each connection's accounts are upserted.
- Builds a user-scoped set of duplicate `plaid_account_id`s and skips their transactions in the `added_txns` loop.

### UI (`ui/server.py` + `accounts.html`)
- `_get_accounts_grouped()` filters out `is_duplicate=1` accounts from display, adds `hidden_count` per institution.
- Accounts page shows a note when accounts are hidden.

## Tests (10 new in `tests/test_dedup_accounts.py`)
- Two identical accounts → correct primary/duplicate
- Different masks → no dedup
- NULL mask same connection → no dedup (safe)
- NULL mask cross-connection → dedup (Pass 2)
- User isolation
- Idempotency
- Three-way duplicates
- Empty user_id safe no-op
- `sync()` integration: duplicate account txns not inserted
- `_get_accounts_grouped()` hides duplicates + reports `hidden_count`

## Production verification
Tested against real data at `~/.friday-bp/data.db`:
- RBC Advantage Banking × 2 → correctly deduplicated ✅
- RBC Day to Day Banking × 2 → correctly deduplicated ✅
- BMO Primary Chequing × 2 (same connection) → left alone ✅