### PR TITLE
Fix: automatic duplicate Plaid account detection and enforcement

### DIFF
--- a/FIXES.md
+++ b/FIXES.md
@@ -2,6 +2,43 @@
 
 ---
 
+### Bug: BMO e-Transfer miscategorized as Rent (+ duplicate-account transaction leakage)
+
+**Symptom:** An Interac e-Transfer sent from RBC Day to Day Banking to Ridvan's own BMO Primary Chequing Account (merchant: `e-Transfer sent Ridvan BMO 5BMPRX`, $2,000, 2026-04-23) was classified by the LLM as "Rent" (spending) instead of being skipped as an internal transfer.
+
+**Root cause (multi-part):**
+
+1. **LLM misclassification:** The "Personal — Rent (Samirah Kalali)" rule (priority 100) has a vague description — any $2,000-ish e-transfer could match. The LLM saw the $2,000 amount and guessed rent, ignoring the "BMO" substring in the merchant name that indicates the e-Transfer destination is Ridvan's own BMO account.
+
+2. **Transfer detector miss:** `detect_internal_transfers` uses a 7-day lookback by default. When the two RBC connections sync in sequence with overlap, the corresponding BMO inflow (`[CW]INTERAC ETRNSFR AD RECVD TINGYI SONG...`, -$2,000 on same date into BMO Primary Chequing) should pair with the RBC outflow — but the merchant names differ on each side, so the LLM-based matching may not have surfaced the transfer hint.
+
+3. **Duplicate account race condition:** Ridvan has two RBC connections (`002f1312` and `4113091f`) that cover the same physical accounts. The deduplication logic (`_deduplicate_accounts`) runs after each sync. When connection `002f1312` synced first, account `d7a3b56b` was not yet marked `is_duplicate=1`. The LLM classified transaction `edba5558` from that account as Rent. Later, after connection `4113091f` synced, deduplication marked `d7a3b56b` as duplicate — but the bad entry already existed and was counted in Rent totals.
+
+4. **`find_transactions` includes duplicate-account transactions:** The tool's SQL did not filter `ba.is_duplicate = 0`, causing it to return `edba5558` (from the duplicate account) alongside `0c8ab4b1` (from the primary account).
+
+5. **`get_needs_review` includes duplicate-account entries:** The needs-review query also lacked the `is_duplicate = 0` filter.
+
+**Fix:**
+
+- **Bad entry already cleaned up:** The Rent entry for `edba5558` was deleted (manually corrected). The `0c8ab4b1` (primary account) version is correctly classified as skip (manual, reviewed=1). The BMO inflow `4bfb4bde` is also correctly skip.
+
+- **New classification rule (priority 9):** Added "Internal — e-Transfer to BMO account (own account)": any Interac e-Transfer where the merchant name contains "BMO" is always an internal transfer to Ridvan's own BMO account — skip. This runs at priority 9 (before the generic "Internal transfer" at 10), preventing future misclassification even if the transfer detector misses the pairing.
+
+- **`find_transactions` fix:** Added `ba.is_duplicate = 0` to the WHERE clause so the tool only returns transactions from primary (non-duplicate) accounts.
+
+- **`get_needs_review` fix:** Added `ba.is_duplicate = 0` to the WHERE clause for the same reason.
+
+**Files changed:**
+- `server/main.py` — `find_transactions` query + `get_needs_review` query
+
+**Rule added:** `99e8410b-5f76-429c-a427-b56bb83cd339` — "Internal — e-Transfer to BMO account (own account)", priority 9, rule_type=skip
+
+---
+
+
+
+---
+
 ### Bug: Disconnect redirects to wrong page (Bug 1)
 
 **Symptom:** Clicking "Disconnect" on the `/accounts` page (which POSTs to `POST /profile` with `action=disconnect_bank`) left the user on the profile page instead of returning them to accounts.

--- a/SKILL.md
+++ b/SKILL.md
@@ -153,6 +153,8 @@ Invoke for any personal finance request:
 - `list(filters?)` — query transactions (supports date, ledger, category, account filters)
 - `get_needs_review` — transactions that need manual review: uncertain classifications (confidence < 0.7) or unrouted transactions with no line item assigned
 - `get_needs_review_summary` — **call this immediately after every `sync`**; returns a pre-formatted batch message (`count`, `summary`, `transactions`) ready to present to the user in one message. Use `summary` as-is for the user-facing message. Includes merchant, amount, date, account, and classifier reasoning for each transaction.
+- `get_suspicious_transactions(include_dismissed?)` — return transactions flagged as suspicious (duplicate charges, unusually large, new merchants, card-testing patterns). Call after `sync` when `suspicious_count > 0`. Returns list with merchant, amount, date, reason, and risk_level.
+- `dismiss_suspicious(transaction_id)` — mark a flagged suspicious transaction as dismissed after the user confirms it is a false positive.
 - `route(transaction_id, allocations)` — manually assign a transaction to a ledger/line item
 - `add_hint(text)` — add a natural-language classification hint for the LLM
 - `list_hints` — list all classification hints
@@ -201,6 +203,7 @@ Invoke for any personal finance request:
 - Always use the MCP tools — never guess from general knowledge
 - Call `sync` before answering spending questions if data may be stale
 - **After every `sync`, call `get_needs_review_summary` and, if `count > 0`, present the `summary` field to the user in a single message** — do not send one message per transaction
+- **After every `sync`, if `suspicious_count > 0` in the sync result, immediately call `get_suspicious_transactions` and present the flagged items to the user** — include merchant, amount, reason, and risk level for each; suggest `dismiss_suspicious(transaction_id)` if the user confirms a flag is a false positive
 - Use `list_rules` to show what classification rules are active before adding new ones
 - Open `start_link` when the user wants to connect or reconnect a bank
 - Use `create_property_ledger` for rental properties — it seeds the right line items automatically

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -55,7 +55,10 @@ CREATE TABLE IF NOT EXISTS bank_accounts (
   balance_current REAL,                        -- current balance from last sync
   balance_available REAL,                      -- available balance from last sync
   description TEXT,                            -- user-set context for classifier
-  default_ledger_id TEXT REFERENCES ledgers(id) -- transactions from this account route here by default
+  default_ledger_id TEXT REFERENCES ledgers(id), -- transactions from this account route here by default
+  is_duplicate INTEGER NOT NULL DEFAULT 0,     -- 1 = this account is a duplicate of primary_account_id (#269)
+  primary_account_id TEXT                      -- ID of the canonical account when is_duplicate=1
+  -- INVARIANT: transactions from is_duplicate=1 accounts are NEVER classified or shown in reports
 );
 
 -- ---------------------------------------------------------------------------

--- a/server/db.py
+++ b/server/db.py
@@ -196,6 +196,19 @@ def init_db(path: str | Path) -> None:
         _add_col_if_missing(conn, "bank_accounts", "primary_account_id", "TEXT")
         conn.commit()
 
+        # Migration: suspicious_transactions (#273 — fraud/anomaly detection).
+        conn.execute("""
+            CREATE TABLE IF NOT EXISTS suspicious_transactions (
+                id             TEXT PRIMARY KEY DEFAULT (lower(hex(randomblob(16)))),
+                transaction_id TEXT NOT NULL REFERENCES transactions(id) ON DELETE CASCADE,
+                reason         TEXT NOT NULL,
+                risk_level     TEXT NOT NULL DEFAULT 'medium',
+                flagged_at     INTEGER NOT NULL DEFAULT (unixepoch()),
+                dismissed      INTEGER NOT NULL DEFAULT 0
+            )
+        """)
+        conn.commit()
+
         # Migration: plaid_revocation_log (#265 — durable revocation audit log).
         # Mirrors every access token inserted via complete_link so that
         # wipe.py and retry_pending_revocations() can revoke tokens even

--- a/server/excel_export.py
+++ b/server/excel_export.py
@@ -89,14 +89,17 @@ def _fetch_monthly_totals(
 
     month is 1-indexed (1=Jan … 12=Dec).
     """
+    # INVARIANT: never include transactions from duplicate accounts (#269)
     rows = conn.execute(
         """
         SELECT CAST(strftime('%m', t.date) AS INTEGER) AS month,
                SUM(te.amount) AS total
         FROM transaction_entries te
         JOIN transactions t ON t.id = te.transaction_id
+        LEFT JOIN bank_accounts ba ON ba.id = t.bank_account_id
         WHERE te.line_item_id = ?
           AND strftime('%Y', t.date) = ?
+          AND COALESCE(ba.is_duplicate, 0) = 0
         GROUP BY month
         """,
         (line_item_id, str(year)),
@@ -109,6 +112,7 @@ def _fetch_raw_transactions(
     years: list[int] | None,
 ) -> list[dict]:
     """Return every classified transaction entry with full context."""
+    # INVARIANT: never include transactions from duplicate accounts (#269)
     if years:
         placeholders = ",".join("?" * len(years))
         year_strs = [str(y) for y in years]
@@ -120,7 +124,9 @@ def _fetch_raw_transactions(
             JOIN transactions t ON t.id = te.transaction_id
             JOIN line_items li ON li.id = te.line_item_id
             JOIN ledgers l ON l.id = te.ledger_id
+            LEFT JOIN bank_accounts ba ON ba.id = t.bank_account_id
             WHERE strftime('%Y', t.date) IN ({placeholders})
+              AND COALESCE(ba.is_duplicate, 0) = 0
             ORDER BY t.date, t.merchant
             """,
             year_strs,
@@ -133,6 +139,8 @@ def _fetch_raw_transactions(
             JOIN transactions t ON t.id = te.transaction_id
             JOIN line_items li ON li.id = te.line_item_id
             JOIN ledgers l ON l.id = te.ledger_id
+            LEFT JOIN bank_accounts ba ON ba.id = t.bank_account_id
+            WHERE COALESCE(ba.is_duplicate, 0) = 0
             ORDER BY t.date, t.merchant
             """).fetchall()
     return [dict(r) for r in rows]

--- a/server/main.py
+++ b/server/main.py
@@ -961,7 +961,8 @@ def _build_ledger_drilldown(
             "FROM transaction_entries te "
             "JOIN transactions t ON te.transaction_id = t.id "
             "LEFT JOIN bank_accounts b ON t.bank_account_id = b.id "
-            "WHERE te.line_item_id = ?" + date_filter_sql + " ORDER BY t.date DESC"
+            "WHERE te.line_item_id = ? AND COALESCE(b.is_duplicate, 0) = 0"
+            + date_filter_sql + " ORDER BY t.date DESC"
         )
         txn_rows = conn.execute(txn_sql, [item["id"]] + date_params).fetchall()
 
@@ -1424,6 +1425,9 @@ def classify_pending_transactions(user_id: str, limit: int | None = None) -> dic
         hints_list = _fetch_hints(conn)
 
         # Fetch all unclassified, non-pending transactions for this user.
+        # Exclude transactions from accounts marked as duplicates (is_duplicate=1)
+        # — those are joint/shared accounts that appear in multiple Plaid connections
+        # and their transactions are already covered by the primary account (issue #269).
         unclassified = conn.execute(
             """
             SELECT t.id, t.merchant, t.amount, t.date,
@@ -1433,6 +1437,7 @@ def classify_pending_transactions(user_id: str, limit: int | None = None) -> dic
             JOIN bank_connections bc ON bc.id = ba.connection_id
             WHERE bc.user_id = ?
               AND t.pending = 0
+              AND ba.is_duplicate = 0
               AND NOT EXISTS (
                 SELECT 1 FROM transaction_entries te
                 WHERE te.transaction_id = t.id
@@ -1722,6 +1727,285 @@ def _deduplicate_accounts(conn, user_id: str) -> None:  # conn: sqlite3.Connecti
                     (e["id"],),
                 )
     _apply_groups(groups2)
+
+
+# ---------------------------------------------------------------------------
+# Suspicious transaction detection (#273)
+# ---------------------------------------------------------------------------
+
+# Merchants that should never be flagged (payroll, rent, mortgage, etc.)
+_SUSPICIOUS_WHITELIST: set[str] = {
+    # Payroll processors
+    "adp", "adp totalsource", "adp payroll", "adp workforce",
+    "paychex", "gusto", "rippling", "ceridian", "workday payroll",
+    "paylocity", "bamboohr payroll",
+    # Banks / e-transfers (payroll credits)
+    "direct deposit", "payroll", "salary", "wages",
+    # Mortgage / rent
+    "mortgage", "rent", "rental payment", "property management",
+    # Utilities (large regular bills)
+    "hydro", "ontario hydro", "toronto hydro", "enbridge", "bell", "rogers",
+    "telus", "shaw",
+    # Common insurance
+    "intact", "td insurance", "sun life", "manulife",
+}
+
+
+def _is_whitelisted(merchant: str) -> bool:
+    """Return True when *merchant* matches an entry in the whitelist."""
+    m = merchant.lower().strip()
+    return any(w in m for w in _SUSPICIOUS_WHITELIST)
+
+
+# Rule types that should never trigger suspicious-transaction logic.
+_SKIP_RULE_TYPES = {"transfer", "savings", "income", "skip"}
+
+
+def _detect_suspicious_transactions(conn, user_id: str) -> list[dict]:
+    """Scan recent transactions and flag anomalies into suspicious_transactions.
+
+    Runs four detection passes:
+      1. Duplicate charge — same merchant + amount + account within 24 h.
+      2. Unusually large — amount > 3× average for that merchant.
+      3. New merchant, large amount — first-ever merchant AND amount > $200.
+      4. Card testing — 3+ micro-charges (< $5) from same merchant in 1 h.
+
+    Only positive-amount transactions (expenses) are evaluated.
+    Already-flagged, whitelisted, and transfer/savings/income/skip
+    transactions are skipped.
+
+    Returns a list of newly-inserted suspicious-transaction dicts.
+    """
+    import math as _math
+
+    new_flags: list[dict] = []
+
+    if not user_id:
+        return new_flags
+
+    # Set of transaction IDs already in suspicious_transactions (any risk level)
+    already_flagged: set[str] = {
+        r[0]
+        for r in conn.execute(
+            "SELECT transaction_id FROM suspicious_transactions"
+        ).fetchall()
+    }
+
+    # Set of transaction IDs classified as transfer/savings/income/skip
+    skip_tx_ids: set[str] = {
+        r[0]
+        for r in conn.execute(
+            """
+            SELECT DISTINCT te.transaction_id
+              FROM transaction_entries te
+              JOIN line_items li ON li.id = te.line_item_id
+              JOIN classification_rules cr ON cr.rule_type IN ('transfer','savings','income','skip')
+             WHERE li.item_type IN ('income')
+            """
+        ).fetchall()
+    }
+    # Also grab entries where source='rule' and the matched rule is a skip/transfer rule
+    skip_tx_ids |= {
+        r[0]
+        for r in conn.execute(
+            """
+            SELECT DISTINCT te.transaction_id
+              FROM transaction_entries te
+             WHERE te.source = 'rule'
+               AND EXISTS (
+                   SELECT 1 FROM classification_rules cr
+                    WHERE cr.rule_type IN ('transfer','savings','income','skip')
+               )
+            """
+        ).fetchall()
+    }
+
+    # Fetch all non-pending expense transactions for this user
+    txns = conn.execute(
+        """
+        SELECT t.id, t.merchant, t.amount, t.date, t.authorized_datetime,
+               t.bank_account_id, ba.name AS account_name
+          FROM transactions t
+          JOIN bank_accounts ba ON ba.id = t.bank_account_id
+          JOIN bank_connections bc ON bc.id = ba.connection_id
+         WHERE bc.user_id = ?
+           AND t.pending = 0
+           AND t.amount > 0
+           AND ba.is_duplicate = 0
+         ORDER BY t.date DESC, t.authorized_datetime DESC
+        """,
+        (user_id,),
+    ).fetchall()
+
+    # Build a quick tx_id -> row lookup for enrichment
+    tx_lookup: dict[str, object] = {r["id"]: r for r in txns}
+
+    def _flag(transaction_id: str, reason: str, risk_level: str) -> dict | None:
+        if transaction_id in already_flagged:
+            return None
+        row_id = __import__('uuid').uuid4().hex
+        import time as _t
+        conn.execute(
+            "INSERT INTO suspicious_transactions (id, transaction_id, reason, risk_level, flagged_at, dismissed) "
+            "VALUES (?, ?, ?, ?, ?, 0)",
+            (row_id, transaction_id, reason, risk_level, int(_t.time())),
+        )
+        already_flagged.add(transaction_id)
+        tx_row = tx_lookup.get(transaction_id)
+        return {
+            "id": row_id,
+            "transaction_id": transaction_id,
+            "merchant": tx_row["merchant"] if tx_row else None,
+            "amount": tx_row["amount"] if tx_row else None,
+            "reason": reason,
+            "risk_level": risk_level,
+        }
+
+    # Build quick lookup structures
+    # merchant -> list of (date_str, amount, tx_id, bank_account_id, authorized_datetime)
+    by_merchant: dict[str, list] = {}
+    for row in txns:
+        m = (row["merchant"] or "").strip()
+        if not m:
+            continue
+        by_merchant.setdefault(m, []).append(row)
+
+    # -----------------------------------------------------------------------
+    # Pass 1 (highest priority): Card testing — 3+ charges < $5 from same
+    # merchant in 1 h → risk: high  (run before duplicate pass so that
+    # card-test micro-charges are tagged with the more informative reason)
+    # -----------------------------------------------------------------------
+    from datetime import datetime as _dt, timezone as _tz  # shared import for all passes
+
+    def _parse_epoch(row) -> float:
+        """Return a Unix timestamp for a transaction row."""
+        try:
+            ds = row["authorized_datetime"] or row["date"]
+            if ds and "T" in str(ds):
+                return _dt.fromisoformat(str(ds).replace("Z", "+00:00")).timestamp()
+            return _dt.strptime(str(ds), "%Y-%m-%d").timestamp() if ds else 0.0
+        except Exception:
+            return 0.0
+
+    for merchant, rows in by_merchant.items():
+        if _is_whitelisted(merchant):
+            continue
+        micro = [
+            r for r in rows
+            if r["amount"] < 5 and r["id"] not in skip_tx_ids
+        ]
+        if len(micro) < 3:
+            continue
+        timed: list[tuple[float, object]] = [(ep, r) for r in micro if (ep := _parse_epoch(r)) is not None]
+        timed.sort(key=lambda x: x[0])
+        i = 0
+        while i < len(timed):
+            window = [timed[i]]
+            j = i + 1
+            while j < len(timed) and timed[j][0] - timed[i][0] <= 3600:
+                window.append(timed[j])
+                j += 1
+            if len(window) >= 3:
+                for _, r in window:
+                    if r["id"] in already_flagged or r["id"] in skip_tx_ids:
+                        continue
+                    flag = _flag(
+                        r["id"],
+                        f"Possible card-testing: {len(window)} micro-charges "
+                        f"under $5 at {merchant!r} within 1 hour",
+                        "high",
+                    )
+                    if flag:
+                        new_flags.append(flag)
+                break  # found one window, move on
+            i += 1
+
+    # -----------------------------------------------------------------------
+    # Pass 2: Duplicate charge
+    # same merchant + same amount + same account within 24 h → risk: high
+    # (after card-testing pass so micro-charges get the more specific label)
+    # -----------------------------------------------------------------------
+    for tx in txns:
+        tx_id = tx["id"]
+        if tx_id in already_flagged or tx_id in skip_tx_ids:
+            continue
+        merchant = (tx["merchant"] or "").strip()
+        if not merchant or _is_whitelisted(merchant):
+            continue
+
+        tx_epoch = _parse_epoch(tx)
+
+        for other in by_merchant.get(merchant, []):
+            if other["id"] == tx_id:
+                continue
+            if other["id"] in skip_tx_ids:
+                continue
+            if other["bank_account_id"] != tx["bank_account_id"]:
+                continue
+            if abs(other["amount"] - tx["amount"]) > 0.01:
+                continue
+            other_epoch = _parse_epoch(other)
+            if abs(tx_epoch - other_epoch) <= 86400:  # 24 h
+                flag = _flag(
+                    tx_id,
+                    f"Possible duplicate charge: ${tx['amount']:.2f} at {merchant!r} within 24 h",
+                    "high",
+                )
+                if flag:
+                    new_flags.append(flag)
+                break  # only flag once per transaction
+
+    # -----------------------------------------------------------------------
+    # Pass 3: Unusually large (> 3× merchant average, min 3 prior txns)
+    # -----------------------------------------------------------------------
+    for merchant, rows in by_merchant.items():
+        if _is_whitelisted(merchant):
+            continue
+        # Need at least 4 transactions (3 prior + 1 new)
+        valid_rows = [r for r in rows if r["id"] not in skip_tx_ids]
+        if len(valid_rows) < 4:
+            continue
+        amounts = [r["amount"] for r in valid_rows]
+        avg = sum(amounts[1:]) / len(amounts[1:])  # exclude most recent
+        if avg <= 0:
+            continue
+        newest = valid_rows[0]
+        if newest["id"] in already_flagged:
+            continue
+        if newest["amount"] > 3 * avg:
+            flag = _flag(
+                newest["id"],
+                f"Unusually large charge: ${newest['amount']:.2f} at {merchant!r} "
+                f"(avg is ${avg:.2f})",
+                "medium",
+            )
+            if flag:
+                new_flags.append(flag)
+
+    # -----------------------------------------------------------------------
+    # Pass 4: New merchant + large amount (> $200)
+    # -----------------------------------------------------------------------
+    for tx in txns:
+        tx_id = tx["id"]
+        if tx_id in already_flagged or tx_id in skip_tx_ids:
+            continue
+        merchant = (tx["merchant"] or "").strip()
+        if not merchant or _is_whitelisted(merchant):
+            continue
+        if tx["amount"] <= 200:
+            continue
+        prior_count = len([r for r in by_merchant.get(merchant, []) if r["id"] != tx_id])
+        if prior_count == 0:
+            flag = _flag(
+                tx_id,
+                f"First-ever charge from new merchant {merchant!r}: ${tx['amount']:.2f}",
+                "low",
+            )
+            if flag:
+                new_flags.append(flag)
+
+    conn.commit()
+    return new_flags
 
 
 @mcp.tool
@@ -2097,10 +2381,18 @@ def sync() -> dict:
                 # any newly inserted (unclassified) transactions.  Errors are
                 # caught so a classification failure never blocks sync.
                 auto_classify_result = {"classified": 0, "skipped": 0, "uncertain": 0}
+                suspicious_flags: list[dict] = []
                 try:
                     uid = get_active_user_id(server.paths.DB_PATH)
                     if uid:
                         auto_classify_result = classify_pending_transactions(uid)
+                        # Run suspicious transaction detection after classification
+                        try:
+                            suspicious_flags = _detect_suspicious_transactions(db_conn, uid)
+                        except Exception as _sus_exc:
+                            _logger.warning(
+                                "Suspicious transaction detection failed: %s", _sus_exc
+                            )
                 except Exception as _exc:
                     _logger.warning("Auto-classification after sync failed: %s", _exc)
 
@@ -2109,6 +2401,19 @@ def sync() -> dict:
 
     except LockBusy:
         return {"status": "already_running"}
+
+    # Top-5 suspicious for the summary (sorted high -> medium -> low)
+    _risk_order = {"high": 0, "medium": 1, "low": 2}
+    sorted_flags = sorted(suspicious_flags, key=lambda f: _risk_order.get(f.get("risk_level", "low"), 3))
+    top_suspicious = [
+        {
+            "merchant": f.get("merchant"),
+            "amount": f.get("amount"),
+            "reason": f["reason"],
+            "risk_level": f["risk_level"],
+        }
+        for f in sorted_flags[:5]
+    ]
 
     return {
         "status": "ok",
@@ -2121,7 +2426,89 @@ def sync() -> dict:
         "auto_skipped": auto_classify_result.get("skipped", 0),
         "auto_uncertain": auto_classify_result.get("uncertain", 0),
         "health_check": health_check_result,
+        "suspicious_count": len(suspicious_flags),
+        "suspicious": top_suspicious,
     }
+
+
+@mcp.tool
+def get_suspicious_transactions(include_dismissed: bool = False) -> dict:
+    """Return transactions flagged as suspicious. Call after sync to check for issues."""
+    uid = get_active_user_id(server.paths.DB_PATH)
+    if not uid:
+        return {"error": "No active user", "transactions": []}
+
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        where = "" if include_dismissed else "AND st.dismissed = 0"
+        rows = conn.execute(
+            f"""
+            SELECT st.id, st.transaction_id, st.reason, st.risk_level,
+                   st.flagged_at, st.dismissed,
+                   t.merchant, t.amount, t.date,
+                   ba.name AS account_name
+              FROM suspicious_transactions st
+              JOIN transactions t ON t.id = st.transaction_id
+              JOIN bank_accounts ba ON ba.id = t.bank_account_id
+              JOIN bank_connections bc ON bc.id = ba.connection_id
+             WHERE bc.user_id = ? AND ba.is_duplicate = 0 {where}
+             ORDER BY st.risk_level, st.flagged_at DESC
+            """,
+            (uid,),
+        ).fetchall()
+        return {
+            "transactions": [
+                {
+                    "id": r["id"],
+                    "transaction_id": r["transaction_id"],
+                    "merchant": r["merchant"],
+                    "amount": r["amount"],
+                    "date": r["date"],
+                    "account_name": r["account_name"],
+                    "reason": r["reason"],
+                    "risk_level": r["risk_level"],
+                    "flagged_at": r["flagged_at"],
+                    "dismissed": bool(r["dismissed"]),
+                }
+                for r in rows
+            ]
+        }
+    finally:
+        conn.close()
+
+
+@mcp.tool
+def dismiss_suspicious(transaction_id: str) -> dict:
+    """Mark a flagged suspicious transaction as dismissed (user confirmed it's fine)."""
+    uid = get_active_user_id(server.paths.DB_PATH)
+    if not uid:
+        return {"error": "No active user"}
+
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        # Verify the transaction belongs to this user
+        row = conn.execute(
+            """
+            SELECT st.id
+              FROM suspicious_transactions st
+              JOIN transactions t ON t.id = st.transaction_id
+              JOIN bank_accounts ba ON ba.id = t.bank_account_id
+              JOIN bank_connections bc ON bc.id = ba.connection_id
+             WHERE st.transaction_id = ? AND bc.user_id = ?
+            """,
+            (transaction_id, uid),
+        ).fetchone()
+        if not row:
+            return {"status": "error", "message": f"No suspicious flag found for transaction {transaction_id!r}"}
+
+        conn.execute(
+            "UPDATE suspicious_transactions SET dismissed = 1 WHERE transaction_id = ?",
+            (transaction_id,),
+        )
+        conn.commit()
+        return {"status": "ok", "transaction_id": transaction_id}
+    finally:
+        conn.close()
 
 
 @mcp.tool
@@ -2137,7 +2524,9 @@ def list(filters: Optional[dict] = None) -> dict:
       source       (str: "rule" | "llm" | "manual")
     """
     filters = filters or {}
-    conditions: list[str] = []
+    # INVARIANT: never include transactions from duplicate accounts (#269)
+    # Use COALESCE so transactions with NULL bank_account_id (e.g. test fixtures) still appear
+    conditions: list[str] = ["COALESCE(ba.is_duplicate, 0) = 0"]
     params: list = []
 
     if "date_from" in filters:
@@ -2177,6 +2566,7 @@ def list(filters: Optional[dict] = None) -> dict:
             t.currency
         FROM transaction_entries te
         JOIN transactions t ON t.id = te.transaction_id
+        LEFT JOIN bank_accounts ba ON ba.id = t.bank_account_id
         {where_clause}
         ORDER BY t.date DESC, te.id
     """
@@ -2222,6 +2612,7 @@ def get_needs_review() -> dict:
             JOIN bank_connections bc ON bc.id = ba.connection_id
             WHERE bc.user_id = ?
               AND te.reviewed = 0
+              AND ba.is_duplicate = 0
               AND (
                 te.uncertain = 1
                 OR te.line_item_id IS NULL
@@ -2589,10 +2980,12 @@ def analyze_recurring_merchants(min_occurrences: int = 2, lookback_days: int = 9
     conn = get_db(server.paths.DB_PATH)
     try:
         if uid:
+            # INVARIANT: never surface recurring merchants from duplicate accounts (#269)
             base_filter = (
                 "  JOIN bank_accounts ba ON ba.id = t.bank_account_id\n"
                 "  JOIN bank_connections bc ON bc.id = ba.connection_id\n"
                 " WHERE bc.user_id = ?\n"
+                "   AND ba.is_duplicate = 0\n"
                 "   AND t.merchant IS NOT NULL\n"
                 "   AND TRIM(t.merchant) != ''\n"
                 "   AND t.date >= ?\n"
@@ -2600,7 +2993,11 @@ def analyze_recurring_merchants(min_occurrences: int = 2, lookback_days: int = 9
             params = (uid, cutoff)
         else:
             base_filter = (
-                " WHERE t.merchant IS NOT NULL\n   AND TRIM(t.merchant) != ''\n   AND t.date >= ?\n"
+                "  JOIN bank_accounts ba ON ba.id = t.bank_account_id\n"
+                " WHERE ba.is_duplicate = 0\n"
+                "   AND t.merchant IS NOT NULL\n"
+                "   AND TRIM(t.merchant) != ''\n"
+                "   AND t.date >= ?\n"
             )
             params = (cutoff,)
 
@@ -2733,7 +3130,9 @@ def summary(period: str) -> dict:
         JOIN transactions   t  ON t.id  = te.transaction_id
         JOIN line_items     li ON li.id = te.line_item_id
         JOIN ledgers        l  ON l.id  = li.ledger_id
+        LEFT JOIN bank_accounts  ba ON ba.id = t.bank_account_id
         WHERE {date_filter}
+          AND COALESCE(ba.is_duplicate, 0) = 0
         GROUP BY te.line_item_id
         ORDER BY total DESC
     """
@@ -3514,6 +3913,7 @@ def find_transactions(
     conditions: list[str] = [
         "bc.user_id = ?",
         "t.pending = 0",
+        "ba.is_duplicate = 0",  # exclude duplicate-account transactions (issue #269)
     ]
     params: list = [uid]
 

--- a/tests/test_suspicious_transactions.py
+++ b/tests/test_suspicious_transactions.py
@@ -1,0 +1,234 @@
+"""Tests for suspicious transaction detection (#273)."""
+from __future__ import annotations
+
+import sqlite3
+import tempfile
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+from server.db import init_db, get_db
+from server.main import _detect_suspicious_transactions
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_db() -> tuple[Path, sqlite3.Connection]:
+    tmp = tempfile.mktemp(suffix=".db")
+    p = Path(tmp)
+    init_db(p)
+    conn = get_db(p)
+    return p, conn
+
+
+def _insert_user(conn) -> str:
+    uid = str(uuid.uuid4())
+    from argon2 import PasswordHasher
+    ph = PasswordHasher()
+    conn.execute(
+        "INSERT INTO users (id, username, password_hash, created_at) VALUES (?, ?, ?, ?)",
+        (uid, "testuser", ph.hash("password123"), int(time.time())),
+    )
+    conn.commit()
+    return uid
+
+
+def _insert_connection(conn, user_id: str) -> str:
+    cid = str(uuid.uuid4())
+    conn.execute(
+        "INSERT INTO bank_connections (id, user_id, plaid_access_token_encrypted, status, plaid_env) "
+        "VALUES (?, ?, ?, 'active', 'sandbox')",
+        (cid, user_id, "enc_token"),
+    )
+    conn.commit()
+    return cid
+
+
+def _insert_account(conn, connection_id: str, name: str = "Chequing") -> str:
+    aid = str(uuid.uuid4())
+    conn.execute(
+        "INSERT INTO bank_accounts (id, connection_id, plaid_account_id, name) VALUES (?, ?, ?, ?)",
+        (aid, connection_id, str(uuid.uuid4()), name),
+    )
+    conn.commit()
+    return aid
+
+
+def _insert_txn(
+    conn,
+    account_id: str,
+    merchant: str,
+    amount: float,
+    date: str = "2024-06-01",
+    authorized_datetime: str | None = None,
+    pending: int = 0,
+) -> str:
+    tid = str(uuid.uuid4())
+    conn.execute(
+        "INSERT INTO transactions (id, bank_account_id, plaid_transaction_id, date, "
+        "authorized_datetime, merchant, amount, currency, pending) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, 'CAD', ?)",
+        (tid, account_id, str(uuid.uuid4()), date, authorized_datetime, merchant, amount, pending),
+    )
+    conn.commit()
+    return tid
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_charge_detected():
+    """Same merchant, same amount, same account within 24h → risk: high."""
+    _db, conn = _make_db()
+    uid = _insert_user(conn)
+    cid = _insert_connection(conn, uid)
+    aid = _insert_account(conn, cid)
+
+    # Two identical charges close together (same day)
+    _insert_txn(conn, aid, "Netflix", 15.99, date="2024-06-01",
+                authorized_datetime="2024-06-01T10:00:00")
+    _insert_txn(conn, aid, "Netflix", 15.99, date="2024-06-01",
+                authorized_datetime="2024-06-01T11:00:00")
+
+    flags = _detect_suspicious_transactions(conn, uid)
+    conn.close()
+
+    merchants = [f["merchant"] for f in flags]
+    reasons = [f["reason"] for f in flags]
+    assert any("Netflix" in (m or "") for m in merchants), f"Expected Netflix in flags: {flags}"
+    assert any("duplicate" in r.lower() for r in reasons), f"Expected duplicate reason: {reasons}"
+    assert any(f["risk_level"] == "high" for f in flags), f"Expected high risk: {flags}"
+
+
+def test_unusually_large_charge_detected():
+    """Amount > 3× merchant average (with ≥3 prior txns) → risk: medium."""
+    _db, conn = _make_db()
+    uid = _insert_user(conn)
+    cid = _insert_connection(conn, uid)
+    aid = _insert_account(conn, cid)
+
+    # 3 prior ~$10 charges, then one $500 charge
+    for i in range(3):
+        _insert_txn(conn, aid, "Starbucks", 10.00, date=f"2024-05-{i+1:02d}")
+    _insert_txn(conn, aid, "Starbucks", 500.00, date="2024-06-01")
+
+    flags = _detect_suspicious_transactions(conn, uid)
+    conn.close()
+
+    merchants = [f["merchant"] for f in flags]
+    reasons = [f["reason"] for f in flags]
+    assert any("Starbucks" in (m or "") for m in merchants), f"Expected Starbucks in flags: {flags}"
+    assert any("large" in r.lower() or "unusually" in r.lower() for r in reasons), \
+        f"Expected unusually large reason: {reasons}"
+    assert any(f["risk_level"] == "medium" for f in flags), f"Expected medium risk: {flags}"
+
+
+def test_new_merchant_large_amount_detected():
+    """First-ever merchant + amount > $200 → risk: low."""
+    _db, conn = _make_db()
+    uid = _insert_user(conn)
+    cid = _insert_connection(conn, uid)
+    aid = _insert_account(conn, cid)
+
+    _insert_txn(conn, aid, "AcmeCorp Unknown Store", 350.00, date="2024-06-01")
+
+    flags = _detect_suspicious_transactions(conn, uid)
+    conn.close()
+
+    merchants = [f["merchant"] for f in flags]
+    reasons = [f["reason"] for f in flags]
+    assert any("AcmeCorp" in (m or "") for m in merchants), f"Expected AcmeCorp in flags: {flags}"
+    assert any("new merchant" in r.lower() or "first" in r.lower() for r in reasons), \
+        f"Expected new-merchant reason: {reasons}"
+    assert any(f["risk_level"] == "low" for f in flags), f"Expected low risk: {flags}"
+
+
+def test_card_testing_detected():
+    """3+ micro-charges (< $5) from same merchant within 1 h → risk: high."""
+    _db, conn = _make_db()
+    uid = _insert_user(conn)
+    cid = _insert_connection(conn, uid)
+    aid = _insert_account(conn, cid)
+
+    # Four $1.00 charges within 30 minutes
+    base = "2024-06-01T12:00:00"
+    for i in range(4):
+        ts = f"2024-06-01T12:{i * 5:02d}:00"
+        _insert_txn(conn, aid, "ShadyMerchant", 1.00, date="2024-06-01",
+                    authorized_datetime=ts)
+
+    flags = _detect_suspicious_transactions(conn, uid)
+    conn.close()
+
+    merchants = [f["merchant"] for f in flags]
+    reasons = [f["reason"] for f in flags]
+    assert any("ShadyMerchant" in (m or "") for m in merchants), \
+        f"Expected ShadyMerchant in flags: {flags}"
+    assert any("card" in r.lower() or "micro" in r.lower() for r in reasons), \
+        f"Expected card-testing reason: {reasons}"
+    assert any(f["risk_level"] == "high" for f in flags), f"Expected high risk: {flags}"
+
+
+def test_dismissed_transaction_not_reflagged():
+    """A previously dismissed transaction must not be re-flagged."""
+    _db, conn = _make_db()
+    uid = _insert_user(conn)
+    cid = _insert_connection(conn, uid)
+    aid = _insert_account(conn, cid)
+
+    tid1 = _insert_txn(conn, aid, "Netflix", 15.99, date="2024-06-01",
+                       authorized_datetime="2024-06-01T10:00:00")
+    tid2 = _insert_txn(conn, aid, "Netflix", 15.99, date="2024-06-01",
+                       authorized_datetime="2024-06-01T11:00:00")
+
+    # Pre-insert a dismissed flag for tid1
+    conn.execute(
+        "INSERT INTO suspicious_transactions (id, transaction_id, reason, risk_level, dismissed) "
+        "VALUES (?, ?, ?, ?, 1)",
+        (str(uuid.uuid4()), tid1, "Possible duplicate", "high"),
+    )
+    conn.commit()
+
+    flags = _detect_suspicious_transactions(conn, uid)
+    conn.close()
+
+    # tid1 should NOT appear again in new_flags
+    new_tx_ids = [f["transaction_id"] for f in flags]
+    assert tid1 not in new_tx_ids, f"Dismissed transaction {tid1} was re-flagged"
+
+
+def test_whitelisted_merchants_not_flagged():
+    """Payroll, rent, and mortgage merchants must not be flagged."""
+    _db, conn = _make_db()
+    uid = _insert_user(conn)
+    cid = _insert_connection(conn, uid)
+    aid = _insert_account(conn, cid)
+
+    # Payroll — two identical charges (would normally be duplicate)
+    _insert_txn(conn, aid, "ADP Payroll", 3000.00, date="2024-06-01",
+                authorized_datetime="2024-06-01T09:00:00")
+    _insert_txn(conn, aid, "ADP Payroll", 3000.00, date="2024-06-01",
+                authorized_datetime="2024-06-01T09:05:00")
+
+    # Rent — new merchant large amount
+    _insert_txn(conn, aid, "Rent Payment", 1800.00, date="2024-06-01")
+
+    # Mortgage
+    _insert_txn(conn, aid, "Mortgage Payment", 2200.00, date="2024-06-01")
+
+    flags = _detect_suspicious_transactions(conn, uid)
+    conn.close()
+
+    merchants = [f["merchant"] for f in flags]
+    assert not any("ADP" in (m or "") for m in merchants), \
+        f"ADP Payroll should not be flagged: {flags}"
+    assert not any("Rent" in (m or "") for m in merchants), \
+        f"Rent Payment should not be flagged: {flags}"
+    assert not any("Mortgage" in (m or "") for m in merchants), \
+        f"Mortgage Payment should not be flagged: {flags}"


### PR DESCRIPTION
## Problem

Users with joint bank accounts (e.g. RBC) connected via **two separate Plaid connections** end up with duplicate `bank_account` rows covering the same physical account. This caused:

- Transactions from the same account **double-counted** in summaries and ledgers
- The classify pipeline processing the same transactions twice
- `find_transactions`, `get_needs_review`, `list`, `summary`, `ledger drilldown`, `analyze_recurring_merchants`, and Excel export all returning duplicate data
- A specific misclassification: an e-Transfer to Ridvan's own BMO account was classified as *Rent* because the duplicate account's entry wasn't excluded before classification

Currently 3 duplicate RBC account pairs exist and are now correctly excluded.

## What Was Fixed

### Schema (#269)
- Added `is_duplicate` (INTEGER DEFAULT 0) and `primary_account_id` (TEXT) columns to `bank_accounts`
- DB migration seeds these columns on startup
- **Invariant:** transactions from `is_duplicate=1` accounts are **never** classified or shown in any report

### Enforcement — 10 query sites patched
| Tool / Function | Change |
|---|---|
| `classify_pending_transactions` | Skip `is_duplicate=1` accounts |
| `_build_ledger_drilldown` | Added `is_duplicate=0` to WHERE |
| `summary` | LEFT JOIN + `COALESCE(ba.is_duplicate, 0) = 0` |
| `list` | Base conditions always include guard |
| `get_needs_review` | Added `is_duplicate=0` filter |
| `find_transactions` | Added `ba.is_duplicate=0` |
| `analyze_recurring_merchants` | Both uid and no-uid paths patched |
| `excel_export.py` | All 3 queries patched (monthly totals + 2x raw transactions) |

### Suspicious Transaction Detection (#273)
New `_detect_suspicious_transactions()` runs automatically after every sync with 4 detection passes:
1. **Card testing** — 3+ micro-charges (<$5) from same merchant within 1 hour → **high**
2. **Duplicate charge** — same merchant + amount + account within 24h → **high**
3. **Unusually large** — >3× merchant average (min 3 prior transactions) → **medium**
4. **New merchant, large amount** — first-ever charge > → **low**

New MCP tools: `get_suspicious_transactions()`, `dismiss_suspicious()`  
`sync()` now returns `suspicious_count` and `suspicious[]` (top-5) in its response.

## Testing

- **757 tests pass**, 1 skipped — no regressions
- `tests/test_dedup_accounts.py` — 10 tests: detection logic, sync exclusion, user isolation, idempotency
- `tests/test_suspicious_transactions.py` — 6 tests: all 4 detection passes, dismissed flag, whitelist
- Targeted tests: `test_list_tool`, `test_summary_tool`, `test_ledger_drilldown`, `test_excel_export` all green

## Files Changed
- `server/main.py` — 406 lines: 10 query patches + suspicious detection + 2 new MCP tools
- `server/excel_export.py` — 3 query patches
- `server/db.py` — suspicious_transactions table migration
- `db/schema.sql` — `is_duplicate` + `primary_account_id` columns
- `SKILL.md` — new tool docs + post-sync suspicious check instructions
- `FIXES.md` — detailed root-cause analysis
- `tests/test_suspicious_transactions.py` — new test file (6 tests)