### PR TITLE
feat: async LLM classification after every sync with UI status

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -334,8 +334,9 @@ That's the whole API. ~15 tools.
 
 ## Sync Pipeline
 
-Every `sync()` call executes the full pipeline automatically — no separate
-trigger needed:
+The `sync()` MCP tool executes the full pipeline (including classification)
+automatically. The UI `/api/sync` route runs sync and classification as two
+chained async background threads so both phases show progress independently:
 
 ```
 Plaid fetch
@@ -443,8 +444,14 @@ After 3 successful LLM classifications of the same merchant, auto-promote
 to a legacy Tier-1 routing_rule. System gets cheaper and faster over time.
 
 ### classify_pending_transactions — key design notes (#165 + #205)
-- Called automatically at the end of `sync()`. Errors are logged but never
-  block the sync response.
+- Called automatically after every sync via the UI's async classification
+  background thread (see "Async classification" below). Errors are logged
+  but never block the sync or UI response.
+- The `sync()` MCP tool accepts a `classify=True` (default) parameter;
+  the UI route passes `classify=False` and handles classification separately
+  so progress can be tracked and surfaced independently.
+- `POST /api/classify` triggers a standalone classification job.
+- `GET /api/classify/status` returns `{running, result}` for UI polling.
 - Idempotent: already-classified transactions (any `transaction_entries` row)
   are skipped on every call.
 - Pending transactions (`pending=1`) are never classified.

--- a/server/main.py
+++ b/server/main.py
@@ -962,7 +962,8 @@ def _build_ledger_drilldown(
             "JOIN transactions t ON te.transaction_id = t.id "
             "LEFT JOIN bank_accounts b ON t.bank_account_id = b.id "
             "WHERE te.line_item_id = ? AND COALESCE(b.is_duplicate, 0) = 0"
-            + date_filter_sql + " ORDER BY t.date DESC"
+            + date_filter_sql
+            + " ORDER BY t.date DESC"
         )
         txn_rows = conn.execute(txn_sql, [item["id"]] + date_params).fetchall()
 
@@ -1736,18 +1737,41 @@ def _deduplicate_accounts(conn, user_id: str) -> None:  # conn: sqlite3.Connecti
 # Merchants that should never be flagged (payroll, rent, mortgage, etc.)
 _SUSPICIOUS_WHITELIST: set[str] = {
     # Payroll processors
-    "adp", "adp totalsource", "adp payroll", "adp workforce",
-    "paychex", "gusto", "rippling", "ceridian", "workday payroll",
-    "paylocity", "bamboohr payroll",
+    "adp",
+    "adp totalsource",
+    "adp payroll",
+    "adp workforce",
+    "paychex",
+    "gusto",
+    "rippling",
+    "ceridian",
+    "workday payroll",
+    "paylocity",
+    "bamboohr payroll",
     # Banks / e-transfers (payroll credits)
-    "direct deposit", "payroll", "salary", "wages",
+    "direct deposit",
+    "payroll",
+    "salary",
+    "wages",
     # Mortgage / rent
-    "mortgage", "rent", "rental payment", "property management",
+    "mortgage",
+    "rent",
+    "rental payment",
+    "property management",
     # Utilities (large regular bills)
-    "hydro", "ontario hydro", "toronto hydro", "enbridge", "bell", "rogers",
-    "telus", "shaw",
+    "hydro",
+    "ontario hydro",
+    "toronto hydro",
+    "enbridge",
+    "bell",
+    "rogers",
+    "telus",
+    "shaw",
     # Common insurance
-    "intact", "td insurance", "sun life", "manulife",
+    "intact",
+    "td insurance",
+    "sun life",
+    "manulife",
 }
 
 
@@ -1776,7 +1800,6 @@ def _detect_suspicious_transactions(conn, user_id: str) -> list[dict]:
 
     Returns a list of newly-inserted suspicious-transaction dicts.
     """
-    import math as _math
 
     new_flags: list[dict] = []
 
@@ -1785,30 +1808,19 @@ def _detect_suspicious_transactions(conn, user_id: str) -> list[dict]:
 
     # Set of transaction IDs already in suspicious_transactions (any risk level)
     already_flagged: set[str] = {
-        r[0]
-        for r in conn.execute(
-            "SELECT transaction_id FROM suspicious_transactions"
-        ).fetchall()
+        r[0] for r in conn.execute("SELECT transaction_id FROM suspicious_transactions").fetchall()
     }
 
     # Set of transaction IDs classified as transfer/savings/income/skip
-    skip_tx_ids: set[str] = {
-        r[0]
-        for r in conn.execute(
-            """
+    skip_tx_ids: set[str] = {r[0] for r in conn.execute("""
             SELECT DISTINCT te.transaction_id
               FROM transaction_entries te
               JOIN line_items li ON li.id = te.line_item_id
               JOIN classification_rules cr ON cr.rule_type IN ('transfer','savings','income','skip')
              WHERE li.item_type IN ('income')
-            """
-        ).fetchall()
-    }
+            """).fetchall()}
     # Also grab entries where source='rule' and the matched rule is a skip/transfer rule
-    skip_tx_ids |= {
-        r[0]
-        for r in conn.execute(
-            """
+    skip_tx_ids |= {r[0] for r in conn.execute("""
             SELECT DISTINCT te.transaction_id
               FROM transaction_entries te
              WHERE te.source = 'rule'
@@ -1816,9 +1828,7 @@ def _detect_suspicious_transactions(conn, user_id: str) -> list[dict]:
                    SELECT 1 FROM classification_rules cr
                     WHERE cr.rule_type IN ('transfer','savings','income','skip')
                )
-            """
-        ).fetchall()
-    }
+            """).fetchall()}
 
     # Fetch all non-pending expense transactions for this user
     txns = conn.execute(
@@ -1843,8 +1853,9 @@ def _detect_suspicious_transactions(conn, user_id: str) -> list[dict]:
     def _flag(transaction_id: str, reason: str, risk_level: str) -> dict | None:
         if transaction_id in already_flagged:
             return None
-        row_id = __import__('uuid').uuid4().hex
+        row_id = __import__("uuid").uuid4().hex
         import time as _t
+
         conn.execute(
             "INSERT INTO suspicious_transactions (id, transaction_id, reason, risk_level, flagged_at, dismissed) "
             "VALUES (?, ?, ?, ?, ?, 0)",
@@ -1875,7 +1886,7 @@ def _detect_suspicious_transactions(conn, user_id: str) -> list[dict]:
     # merchant in 1 h → risk: high  (run before duplicate pass so that
     # card-test micro-charges are tagged with the more informative reason)
     # -----------------------------------------------------------------------
-    from datetime import datetime as _dt, timezone as _tz  # shared import for all passes
+    from datetime import datetime as _dt  # shared import for all passes
 
     def _parse_epoch(row) -> float:
         """Return a Unix timestamp for a transaction row."""
@@ -1890,13 +1901,12 @@ def _detect_suspicious_transactions(conn, user_id: str) -> list[dict]:
     for merchant, rows in by_merchant.items():
         if _is_whitelisted(merchant):
             continue
-        micro = [
-            r for r in rows
-            if r["amount"] < 5 and r["id"] not in skip_tx_ids
-        ]
+        micro = [r for r in rows if r["amount"] < 5 and r["id"] not in skip_tx_ids]
         if len(micro) < 3:
             continue
-        timed: list[tuple[float, object]] = [(ep, r) for r in micro if (ep := _parse_epoch(r)) is not None]
+        timed: list[tuple[float, object]] = [
+            (ep, r) for r in micro if (ep := _parse_epoch(r)) is not None
+        ]
         timed.sort(key=lambda x: x[0])
         i = 0
         while i < len(timed):
@@ -2412,7 +2422,9 @@ def sync(classify: bool = True) -> dict:
 
     # Top-5 suspicious for the summary (sorted high -> medium -> low)
     _risk_order = {"high": 0, "medium": 1, "low": 2}
-    sorted_flags = sorted(suspicious_flags, key=lambda f: _risk_order.get(f.get("risk_level", "low"), 3))
+    sorted_flags = sorted(
+        suspicious_flags, key=lambda f: _risk_order.get(f.get("risk_level", "low"), 3)
+    )
     top_suspicious = [
         {
             "merchant": f.get("merchant"),
@@ -2507,7 +2519,10 @@ def dismiss_suspicious(transaction_id: str) -> dict:
             (transaction_id, uid),
         ).fetchone()
         if not row:
-            return {"status": "error", "message": f"No suspicious flag found for transaction {transaction_id!r}"}
+            return {
+                "status": "error",
+                "message": f"No suspicious flag found for transaction {transaction_id!r}",
+            }
 
         conn.execute(
             "UPDATE suspicious_transactions SET dismissed = 1 WHERE transaction_id = ?",

--- a/server/main.py
+++ b/server/main.py
@@ -2009,8 +2009,14 @@ def _detect_suspicious_transactions(conn, user_id: str) -> list[dict]:
 
 
 @mcp.tool
-def sync() -> dict:
-    """Pull new transactions from Plaid, classify them, and return a summary."""
+def sync(classify: bool = True) -> dict:
+    """Pull new transactions from Plaid and return a summary.
+
+    Args:
+        classify: If True (default), run LLM auto-classification on newly synced
+            transactions before returning.  Pass ``False`` when the caller wants
+            to run classification separately (e.g. the UI background flow).
+    """
 
     def _get(obj, key, default=None):
         """Get a field from a dict or an SDK object."""
@@ -2377,24 +2383,26 @@ def sync() -> dict:
                     total_removed += conn_removed
                     total_classified += conn_classified
 
-                # After all connections are synced, run auto-classification on
-                # any newly inserted (unclassified) transactions.  Errors are
-                # caught so a classification failure never blocks sync.
+                # After all connections are synced, optionally run
+                # auto-classification on any newly inserted (unclassified)
+                # transactions.  Errors are caught so a classification failure
+                # never blocks sync.
                 auto_classify_result = {"classified": 0, "skipped": 0, "uncertain": 0}
                 suspicious_flags: list[dict] = []
-                try:
-                    uid = get_active_user_id(server.paths.DB_PATH)
-                    if uid:
-                        auto_classify_result = classify_pending_transactions(uid)
-                        # Run suspicious transaction detection after classification
-                        try:
-                            suspicious_flags = _detect_suspicious_transactions(db_conn, uid)
-                        except Exception as _sus_exc:
-                            _logger.warning(
-                                "Suspicious transaction detection failed: %s", _sus_exc
-                            )
-                except Exception as _exc:
-                    _logger.warning("Auto-classification after sync failed: %s", _exc)
+                if classify:
+                    try:
+                        uid = get_active_user_id(server.paths.DB_PATH)
+                        if uid:
+                            auto_classify_result = classify_pending_transactions(uid)
+                            # Run suspicious transaction detection after classification
+                            try:
+                                suspicious_flags = _detect_suspicious_transactions(db_conn, uid)
+                            except Exception as _sus_exc:
+                                _logger.warning(
+                                    "Suspicious transaction detection failed: %s", _sus_exc
+                                )
+                    except Exception as _exc:
+                        _logger.warning("Auto-classification after sync failed: %s", _exc)
 
             finally:
                 db_conn.close()

--- a/tests/test_suspicious_transactions.py
+++ b/tests/test_suspicious_transactions.py
@@ -1,4 +1,5 @@
 """Tests for suspicious transaction detection (#273)."""
+
 from __future__ import annotations
 
 import sqlite3
@@ -7,15 +8,13 @@ import time
 import uuid
 from pathlib import Path
 
-import pytest
-
-from server.db import init_db, get_db
+from server.db import get_db, init_db
 from server.main import _detect_suspicious_transactions
-
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_db() -> tuple[Path, sqlite3.Connection]:
     tmp = tempfile.mktemp(suffix=".db")
@@ -28,6 +27,7 @@ def _make_db() -> tuple[Path, sqlite3.Connection]:
 def _insert_user(conn) -> str:
     uid = str(uuid.uuid4())
     from argon2 import PasswordHasher
+
     ph = PasswordHasher()
     conn.execute(
         "INSERT INTO users (id, username, password_hash, created_at) VALUES (?, ?, ?, ?)",
@@ -91,10 +91,12 @@ def test_duplicate_charge_detected():
     aid = _insert_account(conn, cid)
 
     # Two identical charges close together (same day)
-    _insert_txn(conn, aid, "Netflix", 15.99, date="2024-06-01",
-                authorized_datetime="2024-06-01T10:00:00")
-    _insert_txn(conn, aid, "Netflix", 15.99, date="2024-06-01",
-                authorized_datetime="2024-06-01T11:00:00")
+    _insert_txn(
+        conn, aid, "Netflix", 15.99, date="2024-06-01", authorized_datetime="2024-06-01T10:00:00"
+    )
+    _insert_txn(
+        conn, aid, "Netflix", 15.99, date="2024-06-01", authorized_datetime="2024-06-01T11:00:00"
+    )
 
     flags = _detect_suspicious_transactions(conn, uid)
     conn.close()
@@ -124,8 +126,9 @@ def test_unusually_large_charge_detected():
     merchants = [f["merchant"] for f in flags]
     reasons = [f["reason"] for f in flags]
     assert any("Starbucks" in (m or "") for m in merchants), f"Expected Starbucks in flags: {flags}"
-    assert any("large" in r.lower() or "unusually" in r.lower() for r in reasons), \
-        f"Expected unusually large reason: {reasons}"
+    assert any(
+        "large" in r.lower() or "unusually" in r.lower() for r in reasons
+    ), f"Expected unusually large reason: {reasons}"
     assert any(f["risk_level"] == "medium" for f in flags), f"Expected medium risk: {flags}"
 
 
@@ -144,8 +147,9 @@ def test_new_merchant_large_amount_detected():
     merchants = [f["merchant"] for f in flags]
     reasons = [f["reason"] for f in flags]
     assert any("AcmeCorp" in (m or "") for m in merchants), f"Expected AcmeCorp in flags: {flags}"
-    assert any("new merchant" in r.lower() or "first" in r.lower() for r in reasons), \
-        f"Expected new-merchant reason: {reasons}"
+    assert any(
+        "new merchant" in r.lower() or "first" in r.lower() for r in reasons
+    ), f"Expected new-merchant reason: {reasons}"
     assert any(f["risk_level"] == "low" for f in flags), f"Expected low risk: {flags}"
 
 
@@ -160,18 +164,19 @@ def test_card_testing_detected():
     base = "2024-06-01T12:00:00"
     for i in range(4):
         ts = f"2024-06-01T12:{i * 5:02d}:00"
-        _insert_txn(conn, aid, "ShadyMerchant", 1.00, date="2024-06-01",
-                    authorized_datetime=ts)
+        _insert_txn(conn, aid, "ShadyMerchant", 1.00, date="2024-06-01", authorized_datetime=ts)
 
     flags = _detect_suspicious_transactions(conn, uid)
     conn.close()
 
     merchants = [f["merchant"] for f in flags]
     reasons = [f["reason"] for f in flags]
-    assert any("ShadyMerchant" in (m or "") for m in merchants), \
-        f"Expected ShadyMerchant in flags: {flags}"
-    assert any("card" in r.lower() or "micro" in r.lower() for r in reasons), \
-        f"Expected card-testing reason: {reasons}"
+    assert any(
+        "ShadyMerchant" in (m or "") for m in merchants
+    ), f"Expected ShadyMerchant in flags: {flags}"
+    assert any(
+        "card" in r.lower() or "micro" in r.lower() for r in reasons
+    ), f"Expected card-testing reason: {reasons}"
     assert any(f["risk_level"] == "high" for f in flags), f"Expected high risk: {flags}"
 
 
@@ -182,10 +187,12 @@ def test_dismissed_transaction_not_reflagged():
     cid = _insert_connection(conn, uid)
     aid = _insert_account(conn, cid)
 
-    tid1 = _insert_txn(conn, aid, "Netflix", 15.99, date="2024-06-01",
-                       authorized_datetime="2024-06-01T10:00:00")
-    tid2 = _insert_txn(conn, aid, "Netflix", 15.99, date="2024-06-01",
-                       authorized_datetime="2024-06-01T11:00:00")
+    tid1 = _insert_txn(
+        conn, aid, "Netflix", 15.99, date="2024-06-01", authorized_datetime="2024-06-01T10:00:00"
+    )
+    tid2 = _insert_txn(
+        conn, aid, "Netflix", 15.99, date="2024-06-01", authorized_datetime="2024-06-01T11:00:00"
+    )
 
     # Pre-insert a dismissed flag for tid1
     conn.execute(
@@ -211,10 +218,22 @@ def test_whitelisted_merchants_not_flagged():
     aid = _insert_account(conn, cid)
 
     # Payroll — two identical charges (would normally be duplicate)
-    _insert_txn(conn, aid, "ADP Payroll", 3000.00, date="2024-06-01",
-                authorized_datetime="2024-06-01T09:00:00")
-    _insert_txn(conn, aid, "ADP Payroll", 3000.00, date="2024-06-01",
-                authorized_datetime="2024-06-01T09:05:00")
+    _insert_txn(
+        conn,
+        aid,
+        "ADP Payroll",
+        3000.00,
+        date="2024-06-01",
+        authorized_datetime="2024-06-01T09:00:00",
+    )
+    _insert_txn(
+        conn,
+        aid,
+        "ADP Payroll",
+        3000.00,
+        date="2024-06-01",
+        authorized_datetime="2024-06-01T09:05:00",
+    )
 
     # Rent — new merchant large amount
     _insert_txn(conn, aid, "Rent Payment", 1800.00, date="2024-06-01")
@@ -226,9 +245,12 @@ def test_whitelisted_merchants_not_flagged():
     conn.close()
 
     merchants = [f["merchant"] for f in flags]
-    assert not any("ADP" in (m or "") for m in merchants), \
-        f"ADP Payroll should not be flagged: {flags}"
-    assert not any("Rent" in (m or "") for m in merchants), \
-        f"Rent Payment should not be flagged: {flags}"
-    assert not any("Mortgage" in (m or "") for m in merchants), \
-        f"Mortgage Payment should not be flagged: {flags}"
+    assert not any(
+        "ADP" in (m or "") for m in merchants
+    ), f"ADP Payroll should not be flagged: {flags}"
+    assert not any(
+        "Rent" in (m or "") for m in merchants
+    ), f"Rent Payment should not be flagged: {flags}"
+    assert not any(
+        "Mortgage" in (m or "") for m in merchants
+    ), f"Mortgage Payment should not be flagged: {flags}"

--- a/ui/server.py
+++ b/ui/server.py
@@ -851,9 +851,7 @@ def _run_classification_background(user_id: str) -> None:
             result = _sm.classify_pending_transactions(user_id)
             _classify_state["result"] = {"status": "ok", **result}
         except Exception as exc:
-            _logging.getLogger(__name__).error(
-                "Background classification failed: %s", exc
-            )
+            _logging.getLogger(__name__).error("Background classification failed: %s", exc)
             _classify_state["result"] = {"status": "error", "error": str(exc)}
         finally:
             _classify_state["running"] = False
@@ -927,9 +925,7 @@ def api_classify(request: Request):
     if not uid:
         return JSONResponse({"error": "No active user"}, status_code=400)
 
-    _threading.Thread(
-        target=_run_classification_background, args=(uid,), daemon=True
-    ).start()
+    _threading.Thread(target=_run_classification_background, args=(uid,), daemon=True).start()
     return JSONResponse({"status": "ok", "message": "Classification started"})
 
 

--- a/ui/server.py
+++ b/ui/server.py
@@ -27,6 +27,8 @@ Route overview
   GET  /ledgers       read-only ledger tree
   GET  /link          Plaid Link JS embed
   GET  /static/<path> static file serving
+  POST /api/classify        trigger LLM classification of pending transactions
+  GET  /api/classify/status poll classification job state
 """
 
 from __future__ import annotations
@@ -84,6 +86,16 @@ from ui.auth import (
 # Run DB migrations on startup so schema is always up to date
 # (safe to call repeatedly — all operations are idempotent)
 init_db(_paths.DB_PATH)
+
+# ── Background classification state ─────────────────────────────────────────
+# Tracks whether an async LLM classification job is running and its last result.
+import threading as _threading
+
+_classify_lock = _threading.Lock()
+_classify_state: dict = {
+    "running": False,
+    "result": None,  # dict with classified/skipped/uncertain or error
+}
 
 app = FastAPI(title="Friday Budgeting Pro UI", version="0.1.0")
 
@@ -820,13 +832,44 @@ def _get_last_synced_at() -> Optional[str]:
         return str(ts)
 
 
+def _run_classification_background(user_id: str) -> None:
+    """Classify all pending transactions for *user_id* in a background thread.
+
+    Updates ``_classify_state`` so ``/api/classify/status`` can report progress.
+    Safe to call when a classification job is already running — the second call
+    will block on ``_classify_lock`` until the first finishes, then see there
+    are no remaining unclassified transactions (idempotent).
+    """
+    import logging as _logging
+
+    import server.main as _sm
+
+    with _classify_lock:
+        _classify_state["running"] = True
+        _classify_state["result"] = None
+        try:
+            result = _sm.classify_pending_transactions(user_id)
+            _classify_state["result"] = {"status": "ok", **result}
+        except Exception as exc:
+            _logging.getLogger(__name__).error(
+                "Background classification failed: %s", exc
+            )
+            _classify_state["result"] = {"status": "error", "error": str(exc)}
+        finally:
+            _classify_state["running"] = False
+
+
 @app.post("/api/sync")
 def api_sync(request: Request):
-    """AJAX sync — returns JSON immediately; sync runs in a background thread."""
+    """AJAX sync — returns JSON immediately; sync runs in a background thread.
+
+    After the sync completes, LLM classification is automatically kicked off
+    as a separate background thread so the UI can track the two phases
+    independently.  Sync runs with ``classify=False`` so classification does
+    not block the sync response.
+    """
     if not _is_authenticated(request):
         return JSONResponse({"error": "Unauthorized"}, status_code=401)
-
-    import threading
 
     from server.sync_lock import acquire_sync_lock
 
@@ -839,20 +882,67 @@ def api_sync(request: Request):
     def _run():
         try:
             import server.main as _sm
+            from ui.auth import get_active_user_id
 
-            _sm.sync()
+            # Sync without inline classification so we can run it separately.
+            _sm.sync(classify=False)
+
+            # Kick off async LLM classification immediately after sync.
+            uid = get_active_user_id(_paths.DB_PATH)
+            if uid:
+                _threading.Thread(
+                    target=_run_classification_background,
+                    args=(uid,),
+                    daemon=True,
+                ).start()
         except Exception as exc:
             import logging
 
             logging.getLogger(__name__).error("api_sync background: %s", exc)
 
-    threading.Thread(target=_run, daemon=True).start()
+    _threading.Thread(target=_run, daemon=True).start()
     return JSONResponse(
         {
             "status": "ok",
             "added": 0,
             "connections_synced": 0,
             "message": "Sync started in background",
+        }
+    )
+
+
+@app.post("/api/classify")
+def api_classify(request: Request):
+    """Manually trigger LLM classification of all pending transactions."""
+    if not _is_authenticated(request):
+        return JSONResponse({"error": "Unauthorized"}, status_code=401)
+
+    from ui.auth import get_active_user_id
+
+    with _classify_lock:
+        if _classify_state["running"]:
+            return JSONResponse({"status": "already_running"})
+
+    uid = get_active_user_id(_paths.DB_PATH)
+    if not uid:
+        return JSONResponse({"error": "No active user"}, status_code=400)
+
+    _threading.Thread(
+        target=_run_classification_background, args=(uid,), daemon=True
+    ).start()
+    return JSONResponse({"status": "ok", "message": "Classification started"})
+
+
+@app.get("/api/classify/status")
+def api_classify_status(request: Request):
+    """Return current classification job state."""
+    if not _is_authenticated(request):
+        return JSONResponse({"error": "Unauthorized"}, status_code=401)
+
+    return JSONResponse(
+        {
+            "running": _classify_state["running"],
+            "result": _classify_state["result"],
         }
     )
 

--- a/ui/templates/dashboard.html
+++ b/ui/templates/dashboard.html
@@ -25,19 +25,49 @@
     </div>
     <div id="sync-result" style="margin-top:0.75rem"></div>
     <script>
+    async function pollClassification(el) {
+      // Poll /api/classify/status until classification is done, then update el.
+      let polls = 0;
+      const poll = setInterval(async () => {
+        polls++;
+        try {
+          const r = await fetch('/api/classify/status');
+          const d = await r.json();
+          if (!d.running || polls > 40) {
+            clearInterval(poll);
+            if (d.result && d.result.status === 'ok') {
+              const n = d.result.classified || 0;
+              const u = d.result.uncertain || 0;
+              let msg = '&#x1F9E0; Classified ' + n + ' transaction' + (n !== 1 ? 's' : '');
+              if (u > 0) msg += ' (' + u + ' uncertain)';
+              el.innerHTML += '<div class="alert alert-success">' + msg + '</div>';
+            } else if (d.result && d.result.status === 'error') {
+              el.innerHTML += '<div class="alert alert-error">&#x26A0;&#xFE0F; Classification error: ' + (d.result.error || 'unknown') + '</div>';
+            } else if (polls > 40) {
+              el.innerHTML += '<div class="alert alert-info">&#x1F9E0; Classification timed out (still running in background)</div>';
+            }
+          } else {
+            // Still running — update spinner text
+            const spinner = document.getElementById('classify-spinner');
+            if (spinner) spinner.textContent = '&#x1F9E0; Classifying transactions' + '.'.repeat((polls % 3) + 1);
+          }
+        } catch(e) { clearInterval(poll); }
+      }, 2000);
+    }
+
     async function doSync(btn) {
       btn.disabled = true;
-      btn.textContent = 'Syncing…';
+      btn.textContent = 'Syncing\u2026';
       document.getElementById('sync-result').innerHTML = '';
       try {
         const r = await fetch('/api/sync', {method: 'POST'});
         const d = await r.json();
         const el = document.getElementById('sync-result');
         if (d.status === 'ok') {
-          el.innerHTML = '<div class="alert alert-info">⏳ Syncing…</div>';
+          el.innerHTML = '<div class="alert alert-info">\u29d3 Syncing\u2026</div>';
           const ts = document.getElementById('last-synced');
           if (ts) ts.textContent = 'Just now';
-          // Poll for the result every 3s
+          // Poll for sync result every 3s
           let polls = 0;
           const poll = setInterval(async () => {
             polls++;
@@ -48,20 +78,26 @@
                 clearInterval(poll);
                 const added = d2.added || 0;
                 const conns = d2.connections_synced || 0;
-                el.innerHTML = '<div class="alert alert-success">✅ Synced — ' + added + ' new transaction' + (added !== 1 ? 's' : '') + ' across ' + conns + ' connection' + (conns !== 1 ? 's' : '') + '.</div>';
+                el.innerHTML =
+                  '<div class="alert alert-success">\u2705 Synced \u2014 ' + added +
+                  ' new transaction' + (added !== 1 ? 's' : '') +
+                  ' across ' + conns + ' connection' + (conns !== 1 ? 's' : '') + '.</div>' +
+                  '<div class="alert alert-info" id="classify-spinner">\u1F9E0 Classifying transactions\u2026</div>';
                 btn.disabled = false;
                 btn.textContent = 'Sync Now';
+                // Start polling classification status
+                pollClassification(el);
               }
             } catch(e) { clearInterval(poll); }
           }, 3000);
-          return; // keep button disabled while polling
+          return; // keep button disabled while polling sync
         } else if (d.status === 'already_running') {
-          el.innerHTML = '<div class="alert alert-info">⏳ Sync already in progress…</div>';
+          el.innerHTML = '<div class="alert alert-info">\u29d3 Sync already in progress\u2026</div>';
         } else {
-          el.innerHTML = '<div class="alert alert-error">❌ ' + (d.detail || d.message || 'Sync failed') + '</div>';
+          el.innerHTML = '<div class="alert alert-error">\u274c ' + (d.detail || d.message || 'Sync failed') + '</div>';
         }
       } catch(e) {
-        document.getElementById('sync-result').innerHTML = '<div class="alert alert-error">❌ Network error</div>';
+        document.getElementById('sync-result').innerHTML = '<div class="alert alert-error">\u274c Network error</div>';
       }
       btn.disabled = false;
       btn.textContent = 'Sync Now';


### PR DESCRIPTION
## Summary

Automatically runs LLM classification as a separate async background job after every sync, with live status shown in the dashboard UI.

## Changes

### `server/main.py`
- `sync(classify=True)` gains a `classify` flag — MCP callers still get inline classification (default `True`); the UI passes `False` to decouple the two phases

### `ui/server.py`
- `_run_classification_background(user_id)` — background thread helper that runs `classify_pending_transactions` and writes result to `_classify_state`
- `POST /api/sync` — now chains a classification thread immediately after sync finishes (sync runs with `classify=False`)
- `POST /api/classify` — manually trigger classification any time
- `GET /api/classify/status` — returns `{running, result}` for UI polling

### `ui/templates/dashboard.html`
- After sync completes, shows a 🧠 Classifying phase spinner
- Polls `/api/classify/status` every 2s
- Displays final count: "Classified N transactions (K uncertain)"

### `ARCHITECTURE.md`
- Documents the two-phase async UI flow and new endpoints

## How it works

```
POST /api/sync
  → background thread: sync(classify=False)
      → on completion: background thread: classify_pending_transactions()
  → UI polls /api/sync/result  →  shows ✅ Synced
  → UI polls /api/classify/status  →  shows 🧠 Classifying... → classified count
```

Closes: auto-classify after sync (UX improvement)