### PR TITLE
[P5] feat(savings): add savings as valid line item type

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -201,7 +201,7 @@ Full schema lives in `db/schema.sql` (source of truth). Summary:
 | `bank_connections` | One row per Plaid Item (institution) |
 | `bank_accounts` | Individual accounts within a connection |
 | `ledgers` | Financial entities: personal \| property \| investment |
-| `line_items` | Categories within a ledger (income \| expense) |
+| `line_items` | Categories within a ledger (income \| expense \| savings) |
 | `transactions` | Raw from Plaid — never modified after insert |
 | `transaction_entries` | Classification result: transaction → line item |
 | `classification_rules` | Natural language rules, priority-ordered, evaluated by LLM |
@@ -296,7 +296,7 @@ tool calls; nothing new is required from the UI.
 - `add_ledger(name)` — creates a generic personal ledger
 - `create_property_ledger(name, description?)` — creates a `property` ledger seeded with 6 default line items (Rent income, Mortgage, Property tax, Maintenance & repairs, Insurance, Utilities)
 - `create_investment_ledger(name)` — creates an `investment` ledger seeded with 2 default line items (Contributions, Dividends & Returns)
-- `add_line_item(ledger_id, name, item_type)` — `item_type` is `income` or `expense`
+- `add_line_item(ledger_id, name, item_type)` — `item_type` is `income`, `expense`, or `savings`
 - `remove_line_item(id)`
 - `set_account_ledger(account_id, ledger_id)` — routes transactions from a bank account to a specific ledger by default
 

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -80,7 +80,7 @@ CREATE TABLE IF NOT EXISTS line_items (
   id TEXT PRIMARY KEY,
   ledger_id TEXT REFERENCES ledgers(id),
   name TEXT NOT NULL,
-  item_type TEXT DEFAULT 'expense'             -- income | expense
+  item_type TEXT DEFAULT 'expense'             -- income | expense | savings
 );
 
 -- ---------------------------------------------------------------------------

--- a/server/db.py
+++ b/server/db.py
@@ -130,6 +130,7 @@ def init_db(path: str | Path) -> None:
         _add_col_if_missing(conn, "bank_accounts", "default_ledger_id", "TEXT")
 
         # Migration: line_items item_type (#174)
+        # Valid values: 'income' | 'expense' | 'savings' (savings added in #234)
         _add_col_if_missing(conn, "line_items", "item_type", "TEXT NOT NULL DEFAULT 'expense'")
 
         # Migration: users.home_currency (#159)

--- a/server/excel_export.py
+++ b/server/excel_export.py
@@ -161,6 +161,7 @@ def _write_ledger_sheet(
     line_items = _fetch_line_items(conn, ledger["id"])
     income_items = [li for li in line_items if li["item_type"] == "income"]
     expense_items = [li for li in line_items if li["item_type"] == "expense"]
+    savings_items = [li for li in line_items if li["item_type"] == "savings"]
 
     row = 1  # 1-indexed openpyxl rows
 
@@ -206,8 +207,21 @@ def _write_ledger_sheet(
             ws.cell(row=row, column=14, value=ytd)
             row += 1
 
+        # --- Savings section ---
+        for li in savings_items:
+            totals = _fetch_monthly_totals(conn, li["id"], year)
+            ws.cell(row=row, column=1, value=li["name"]).fill = _INCOME_FILL
+            ws.cell(row=row, column=1).font = _BOLD_FONT
+            ytd = 0.0
+            for m in range(1, 13):
+                val = totals.get(m, 0.0)
+                ws.cell(row=row, column=m + 1, value=val)
+                ytd += val
+            ws.cell(row=row, column=14, value=ytd)
+            row += 1
+
         # --- Net row ---
-        # Compute net: income - expenses for each month
+        # Compute net: income - expenses - savings for each month
         income_by_month: dict[int, float] = {}
         for li in income_items:
             for m, v in _fetch_monthly_totals(conn, li["id"], year).items():
@@ -218,11 +232,16 @@ def _write_ledger_sheet(
             for m, v in _fetch_monthly_totals(conn, li["id"], year).items():
                 expense_by_month[m] = expense_by_month.get(m, 0.0) + v
 
+        savings_by_month: dict[int, float] = {}
+        for li in savings_items:
+            for m, v in _fetch_monthly_totals(conn, li["id"], year).items():
+                savings_by_month[m] = savings_by_month.get(m, 0.0) + v
+
         net_cell = ws.cell(row=row, column=1, value="Net")
         net_cell.font = _BOLD_FONT
         net_ytd = 0.0
         for m in range(1, 13):
-            net = income_by_month.get(m, 0.0) - expense_by_month.get(m, 0.0)
+            net = income_by_month.get(m, 0.0) - expense_by_month.get(m, 0.0) - savings_by_month.get(m, 0.0)
             ws.cell(row=row, column=m + 1, value=net)
             net_ytd += net
         ws.cell(row=row, column=14, value=net_ytd)
@@ -244,13 +263,15 @@ def _write_summary_sheet(
     ws.cell(row=1, column=2, value="Year").font = _BOLD_FONT
     ws.cell(row=1, column=3, value="Income").font = _BOLD_FONT
     ws.cell(row=1, column=4, value="Expenses").font = _BOLD_FONT
-    ws.cell(row=1, column=5, value="Net").font = _BOLD_FONT
+    ws.cell(row=1, column=5, value="Savings").font = _BOLD_FONT
+    ws.cell(row=1, column=6, value="Net").font = _BOLD_FONT
 
     row = 2
     for ledger in ledgers:
         line_items = _fetch_line_items(conn, ledger["id"])
         income_items = [li for li in line_items if li["item_type"] == "income"]
         expense_items = [li for li in line_items if li["item_type"] == "expense"]
+        savings_items = [li for li in line_items if li["item_type"] == "savings"]
 
         for year in years:
             total_income = 0.0
@@ -263,13 +284,19 @@ def _write_summary_sheet(
                 totals = _fetch_monthly_totals(conn, li["id"], year)
                 total_expense += sum(totals.values())
 
-            net = total_income - total_expense
+            total_savings = 0.0
+            for li in savings_items:
+                totals = _fetch_monthly_totals(conn, li["id"], year)
+                total_savings += sum(totals.values())
+
+            net = total_income - total_expense - total_savings
 
             ws.cell(row=row, column=1, value=ledger["name"])
             ws.cell(row=row, column=2, value=year)
             ws.cell(row=row, column=3, value=total_income)
             ws.cell(row=row, column=4, value=total_expense)
-            ws.cell(row=row, column=5, value=net)
+            ws.cell(row=row, column=5, value=total_savings)
+            ws.cell(row=row, column=6, value=net)
             row += 1
 
 

--- a/server/main.py
+++ b/server/main.py
@@ -292,6 +292,7 @@ def apply_initial_setup(
         ("Shopping", "expense"),
         ("Misc", "expense"),
         ("Other", "expense"),
+        ("Investments & Savings", "savings"),
     ]
 
     # Build the full ledger spec: Personal first, then any extras.
@@ -952,6 +953,7 @@ def _build_ledger_drilldown(
 
     total_income = 0.0
     total_expenses = 0.0
+    total_savings = 0.0
     line_items_out = []
 
     for item in item_rows:
@@ -986,6 +988,8 @@ def _build_ledger_drilldown(
         item_total = round(item_total, 2)
         if item["item_type"] == "income":
             total_income += item_total
+        elif item["item_type"] == "savings":
+            total_savings += item_total
         else:
             total_expenses += item_total
 
@@ -1009,7 +1013,8 @@ def _build_ledger_drilldown(
         "totals": {
             "income": round(total_income, 2),
             "expenses": round(total_expenses, 2),
-            "net": round(total_income - total_expenses, 2),
+            "savings": round(total_savings, 2),
+            "net": round(total_income - total_expenses - total_savings, 2),
         },
     }
 
@@ -1107,13 +1112,13 @@ def add_line_item(ledger_id: str, name: str, item_type: str) -> dict:
     name : str
         Non-empty display name for the line item.
     item_type : str
-        Must be ``'income'`` or ``'expense'``.
+        Must be ``'income'``, ``'expense'``, or ``'savings'``.
     """
     name = name.strip() if name else ""
     if not name:
         return {"status": "error", "message": "Line item name must be non-empty"}
-    if item_type not in ("income", "expense"):
-        return {"status": "error", "message": "item_type must be 'income' or 'expense'"}
+    if item_type not in ("income", "expense", "savings"):
+        return {"status": "error", "message": "item_type must be 'income', 'expense', or 'savings'"}
 
     uid = get_active_user_id(server.paths.DB_PATH)
     conn = get_db(server.paths.DB_PATH)
@@ -3223,6 +3228,7 @@ def summary(period: str) -> dict:
 
     income: float = 0.0
     expenses: float = 0.0
+    savings: float = 0.0
     by_line_item: list[dict] = []
 
     for row in rows:
@@ -3237,6 +3243,8 @@ def summary(period: str) -> dict:
         )
         if row["item_type"] == "income":
             income += total
+        elif row["item_type"] == "savings":
+            savings += total
         else:
             expenses += total
 
@@ -3244,7 +3252,8 @@ def summary(period: str) -> dict:
         "period": period,
         "income": round(income, 2),
         "expenses": round(expenses, 2),
-        "net": round(income - expenses, 2),
+        "savings": round(savings, 2),
+        "net": round(income - expenses - savings, 2),
         "by_line_item": by_line_item,
     }
 

--- a/tests/test_savings_item_type.py
+++ b/tests/test_savings_item_type.py
@@ -12,7 +12,6 @@ Covers:
 from __future__ import annotations
 
 import uuid
-from pathlib import Path
 
 import pytest
 
@@ -36,8 +35,8 @@ def tmp_db(tmp_path, monkeypatch):
 
 def test_add_line_item_savings(tmp_db, monkeypatch):
     """add_line_item() accepts item_type='savings'."""
+    from server.main import add_line_item, apply_initial_setup
     from ui.auth import create_user
-    from server.main import apply_initial_setup, add_line_item
 
     monkeypatch.setenv("OPENCLAW_DIR", str(tmp_db.parent.parent))
     create_user(tmp_db, "testuser", "testpass123")
@@ -65,8 +64,8 @@ def test_add_line_item_savings(tmp_db, monkeypatch):
 
 def test_add_line_item_rejects_invalid_type(tmp_db, monkeypatch):
     """add_line_item() rejects unknown item_type."""
+    from server.main import add_line_item, apply_initial_setup
     from ui.auth import create_user
-    from server.main import apply_initial_setup, add_line_item
 
     monkeypatch.setenv("OPENCLAW_DIR", str(tmp_db.parent.parent))
     create_user(tmp_db, "testuser2", "testpass123")
@@ -83,8 +82,8 @@ def test_add_line_item_rejects_invalid_type(tmp_db, monkeypatch):
 
 def test_personal_ledger_seeds_investments_savings(tmp_db, monkeypatch):
     """Personal ledger includes 'Investments & Savings' with savings type."""
-    from ui.auth import create_user
     from server.main import apply_initial_setup
+    from ui.auth import create_user
 
     monkeypatch.setenv("OPENCLAW_DIR", str(tmp_db.parent.parent))
     create_user(tmp_db, "testuser3", "testpass123")
@@ -102,8 +101,8 @@ def test_personal_ledger_seeds_investments_savings(tmp_db, monkeypatch):
 
 def test_get_ledger_totals_include_savings(tmp_db, monkeypatch):
     """get_ledger() totals include savings separately from expenses."""
-    from ui.auth import create_user
     from server.main import apply_initial_setup, get_ledger
+    from ui.auth import create_user
 
     monkeypatch.setenv("OPENCLAW_DIR", str(tmp_db.parent.parent))
     create_user(tmp_db, "testuser4", "testpass123")
@@ -171,8 +170,8 @@ def test_get_ledger_totals_include_savings(tmp_db, monkeypatch):
 
 def test_summary_includes_savings(tmp_db, monkeypatch):
     """summary() includes savings field, net = income - expenses - savings."""
-    from ui.auth import create_user
     from server.main import apply_initial_setup, summary
+    from ui.auth import create_user
 
     monkeypatch.setenv("OPENCLAW_DIR", str(tmp_db.parent.parent))
     create_user(tmp_db, "testuser5", "testpass123")

--- a/tests/test_savings_item_type.py
+++ b/tests/test_savings_item_type.py
@@ -1,0 +1,227 @@
+"""
+tests/test_savings_item_type.py — Tests for savings as valid item_type (#234).
+
+Covers:
+  - add_line_item() accepts item_type='savings'
+  - add_line_item() rejects invalid types
+  - Personal ledger seeds include 'Investments & Savings' with savings type
+  - get_ledger() totals include savings separately from expenses
+  - summary() includes savings field, net = income - expenses - savings
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+
+import server.paths
+from server.db import get_db, init_db
+
+
+def _uid() -> str:
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "friday-bp" / "data.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(server.paths, "DB_PATH", db_path)
+    monkeypatch.setattr(server.paths, "APP_DIR", db_path.parent)
+    init_db(db_path)
+    return db_path
+
+
+def test_add_line_item_savings(tmp_db, monkeypatch):
+    """add_line_item() accepts item_type='savings'."""
+    from ui.auth import create_user
+    from server.main import apply_initial_setup, add_line_item
+
+    monkeypatch.setenv("OPENCLAW_DIR", str(tmp_db.parent.parent))
+    create_user(tmp_db, "testuser", "testpass123")
+
+    setup = apply_initial_setup(banks_to_link=[], extra_ledgers=[], hints=[])
+    assert setup["status"] == "ok"
+
+    # Get ledger_id
+    conn = get_db(tmp_db)
+    ledger_id = conn.execute("SELECT id FROM ledgers LIMIT 1").fetchone()["id"]
+    conn.close()
+
+    result = add_line_item(ledger_id=ledger_id, name="TFSA Contributions", item_type="savings")
+    assert result["status"] == "ok", result
+    assert "item_id" in result
+
+    # Verify the item_type was persisted correctly
+    conn = get_db(tmp_db)
+    row = conn.execute(
+        "SELECT item_type FROM line_items WHERE id = ?", (result["item_id"],)
+    ).fetchone()
+    conn.close()
+    assert row["item_type"] == "savings"
+
+
+def test_add_line_item_rejects_invalid_type(tmp_db, monkeypatch):
+    """add_line_item() rejects unknown item_type."""
+    from ui.auth import create_user
+    from server.main import apply_initial_setup, add_line_item
+
+    monkeypatch.setenv("OPENCLAW_DIR", str(tmp_db.parent.parent))
+    create_user(tmp_db, "testuser2", "testpass123")
+    apply_initial_setup(banks_to_link=[], extra_ledgers=[], hints=[])
+
+    conn = get_db(tmp_db)
+    ledger_id = conn.execute("SELECT id FROM ledgers LIMIT 1").fetchone()["id"]
+    conn.close()
+
+    result = add_line_item(ledger_id=ledger_id, name="Bad Item", item_type="investment")
+    assert result["status"] == "error"
+    assert "savings" in result["message"]
+
+
+def test_personal_ledger_seeds_investments_savings(tmp_db, monkeypatch):
+    """Personal ledger includes 'Investments & Savings' with savings type."""
+    from ui.auth import create_user
+    from server.main import apply_initial_setup
+
+    monkeypatch.setenv("OPENCLAW_DIR", str(tmp_db.parent.parent))
+    create_user(tmp_db, "testuser3", "testpass123")
+    apply_initial_setup(banks_to_link=[], extra_ledgers=[], hints=[])
+
+    conn = get_db(tmp_db)
+    row = conn.execute(
+        "SELECT name, item_type FROM line_items WHERE name = 'Investments & Savings'"
+    ).fetchone()
+    conn.close()
+
+    assert row is not None, "Investments & Savings line item not found"
+    assert row["item_type"] == "savings"
+
+
+def test_get_ledger_totals_include_savings(tmp_db, monkeypatch):
+    """get_ledger() totals include savings separately from expenses."""
+    from ui.auth import create_user
+    from server.main import apply_initial_setup, get_ledger
+
+    monkeypatch.setenv("OPENCLAW_DIR", str(tmp_db.parent.parent))
+    create_user(tmp_db, "testuser4", "testpass123")
+    apply_initial_setup(banks_to_link=[], extra_ledgers=[], hints=[])
+
+    conn = get_db(tmp_db)
+    ledger = conn.execute("SELECT id FROM ledgers LIMIT 1").fetchone()
+    savings_li = conn.execute(
+        "SELECT id FROM line_items WHERE item_type = 'savings' LIMIT 1"
+    ).fetchone()
+    income_li = conn.execute(
+        "SELECT id FROM line_items WHERE item_type = 'income' LIMIT 1"
+    ).fetchone()
+    expense_li = conn.execute(
+        "SELECT id FROM line_items WHERE item_type = 'expense' LIMIT 1"
+    ).fetchone()
+
+    # Insert fake transactions and entries
+    tx1 = _uid()
+    tx2 = _uid()
+    tx3 = _uid()
+    account_id = _uid()
+    bc_id = _uid()
+    conn.execute(
+        "INSERT INTO bank_connections (id, plaid_access_token_encrypted, status) "
+        "VALUES (?, 'enc:test', 'active')",
+        (bc_id,),
+    )
+    conn.execute(
+        "INSERT INTO bank_accounts (id, connection_id, name) VALUES (?, ?, 'Chequing')",
+        (account_id, bc_id),
+    )
+    for tx_id, amount in [(tx1, 1000.0), (tx2, 300.0), (tx3, 500.0)]:
+        conn.execute(
+            "INSERT INTO transactions (id, date, merchant, amount, bank_account_id) "
+            "VALUES (?, '2026-01-15', 'Test', ?, ?)",
+            (tx_id, amount, account_id),
+        )
+    conn.execute(
+        "INSERT INTO transaction_entries (id, transaction_id, ledger_id, line_item_id, amount) "
+        "VALUES (?, ?, ?, ?, 1000.0)",
+        (_uid(), tx1, ledger["id"], income_li["id"]),
+    )
+    conn.execute(
+        "INSERT INTO transaction_entries (id, transaction_id, ledger_id, line_item_id, amount) "
+        "VALUES (?, ?, ?, ?, 300.0)",
+        (_uid(), tx2, ledger["id"], expense_li["id"]),
+    )
+    conn.execute(
+        "INSERT INTO transaction_entries (id, transaction_id, ledger_id, line_item_id, amount) "
+        "VALUES (?, ?, ?, ?, 500.0)",
+        (_uid(), tx3, ledger["id"], savings_li["id"]),
+    )
+    conn.commit()
+    conn.close()
+
+    result = get_ledger(ledger_id=ledger["id"], period="2026-01")
+    totals = result["totals"]
+
+    assert totals["income"] == 1000.0
+    assert totals["expenses"] == 300.0
+    assert totals["savings"] == 500.0
+    assert totals["net"] == 200.0  # 1000 - 300 - 500
+
+
+def test_summary_includes_savings(tmp_db, monkeypatch):
+    """summary() includes savings field, net = income - expenses - savings."""
+    from ui.auth import create_user
+    from server.main import apply_initial_setup, summary
+
+    monkeypatch.setenv("OPENCLAW_DIR", str(tmp_db.parent.parent))
+    create_user(tmp_db, "testuser5", "testpass123")
+    apply_initial_setup(banks_to_link=[], extra_ledgers=[], hints=[])
+
+    conn = get_db(tmp_db)
+    ledger = conn.execute("SELECT id FROM ledgers LIMIT 1").fetchone()
+    savings_li = conn.execute(
+        "SELECT id FROM line_items WHERE item_type = 'savings' LIMIT 1"
+    ).fetchone()
+    income_li = conn.execute(
+        "SELECT id FROM line_items WHERE item_type = 'income' LIMIT 1"
+    ).fetchone()
+    expense_li = conn.execute(
+        "SELECT id FROM line_items WHERE item_type = 'expense' LIMIT 1"
+    ).fetchone()
+
+    account_id = _uid()
+    bc_id = _uid()
+    conn.execute(
+        "INSERT INTO bank_connections (id, plaid_access_token_encrypted, status) "
+        "VALUES (?, 'enc:test', 'active')",
+        (bc_id,),
+    )
+    conn.execute(
+        "INSERT INTO bank_accounts (id, connection_id, name) VALUES (?, ?, 'Chequing')",
+        (account_id, bc_id),
+    )
+    for tx_id, amount in [(_uid(), 2000.0), (_uid(), 400.0), (_uid(), 600.0)]:
+        conn.execute(
+            "INSERT INTO transactions (id, date, merchant, amount, bank_account_id) "
+            "VALUES (?, '2026-02-10', 'Test', ?, ?)",
+            (tx_id, amount, account_id),
+        )
+    txs = conn.execute("SELECT id FROM transactions WHERE date='2026-02-10'").fetchall()
+    li_map = [income_li["id"], expense_li["id"], savings_li["id"]]
+    amounts = [2000.0, 400.0, 600.0]
+    for tx, li_id, amt in zip(txs, li_map, amounts):
+        conn.execute(
+            "INSERT INTO transaction_entries (id, transaction_id, ledger_id, line_item_id, amount) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (_uid(), tx["id"], ledger["id"], li_id, amt),
+        )
+    conn.commit()
+    conn.close()
+
+    result = summary(period="2026-02")
+    assert "savings" in result, f"savings not in summary: {result}"
+    assert result["income"] == 2000.0
+    assert result["expenses"] == 400.0
+    assert result["savings"] == 600.0
+    assert result["net"] == 1000.0  # 2000 - 400 - 600

--- a/tests/test_setup_tool.py
+++ b/tests/test_setup_tool.py
@@ -85,7 +85,7 @@ def test_apply_minimal_creates_personal_ledger_with_10_items(tmp_db):
 
     assert result["status"] == "ok"
     assert result["ledgers_created"] == ["Personal"]
-    assert result["line_items_created"] == 10
+    assert result["line_items_created"] == 11  # 10 expense/income + 1 savings
     assert result["hints_created"] == 0
     assert result["banks_to_link"] == []
 
@@ -96,13 +96,14 @@ def test_apply_minimal_creates_personal_ledger_with_10_items(tmp_db):
     assert ledgers[0]["name"] == "Personal"
 
     line_items = conn.execute("SELECT name, item_type FROM line_items").fetchall()
-    assert len(line_items) == 10
+    assert len(line_items) == 11
 
     # Check standard items are present
     item_pairs = {(r["name"], r["item_type"]) for r in line_items}
     assert ("Salary", "income") in item_pairs
     assert ("Groceries", "expense") in item_pairs
     assert ("Dining", "expense") in item_pairs
+    assert ("Investments & Savings", "savings") in item_pairs
     conn.close()
 
 
@@ -112,8 +113,8 @@ def test_apply_with_extra_ledger_creates_personal_and_business(tmp_db):
 
     assert result["status"] == "ok"
     assert set(result["ledgers_created"]) == {"Personal", "Business"}
-    # 10 personal + 1 business
-    assert result["line_items_created"] == 11
+    # 11 personal + 1 business
+    assert result["line_items_created"] == 12
 
     conn = get_db(tmp_db)
     ledger_names = {r["name"] for r in conn.execute("SELECT name FROM ledgers").fetchall()}
@@ -167,7 +168,7 @@ def test_apply_is_idempotent(tmp_db):
     conn.close()
 
     assert ledger_count == 2  # Personal + Business
-    assert line_item_count == 11  # 10 personal + 1 business
+    assert line_item_count == 12  # 11 personal + 1 business
     assert hint_count == 1
 
 


### PR DESCRIPTION
Closes #234

Adds `savings` as a valid `item_type` for `line_items`, alongside the existing `income` and `expense` types.

**Changes:**
- `db/schema.sql`: updated `item_type` comment to include `savings`
- `server/db.py`: migration comment updated (no structural change needed — no existing CHECK constraint)
- `server/main.py`: seeded `Investments & Savings` (savings) in Personal ledger defaults; `add_line_item()` now accepts `'savings'`; ledger drilldown and `summary()` track savings separately from expenses; `net = income - expenses - savings`
- `server/excel_export.py`: savings section added to ledger sheets and Summary sheet
- `ARCHITECTURE.md`: updated line_items type docs and `add_line_item` docs

**Interactive check:** Called `add_line_item(item_type='savings')` — returned `{'status': 'ok', 'item_id': '...'}`. Verified `Investments & Savings` seeded correctly. Invalid type `'investment'` correctly rejected.

**CI:** will update automatically