### PR TITLE
[P5] feat(savings): seed default savings classifier rule

### DIFF
--- a/server/db.py
+++ b/server/db.py
@@ -70,8 +70,8 @@ def init_db(path: str | Path) -> None:
                 (
                     20,
                     "Investment contribution",
-                    "Outflows to Wealthsimple, Questrade, or any investment platform are Transfer/Savings, not spending",
-                    "transfer",
+                    "Outflows to Wealthsimple, Questrade, RBC Direct Investing, RRSP, TFSA, or any investment platform are Savings, not spending or transfers",
+                    "savings",
                 ),
                 (
                     30,
@@ -226,6 +226,21 @@ def init_db(path: str | Path) -> None:
                 revoked                INTEGER NOT NULL DEFAULT 0
             )
         """)
+        conn.commit()
+
+        # Migration: Investment contribution rule → savings type (#235)
+        # The default rule at priority 20 was previously typed 'transfer'.
+        # Update it to 'savings' so investment outflows are classified correctly.
+        conn.execute(
+            """
+            UPDATE classification_rules
+            SET rule_type = 'savings',
+                description = 'Outflows to Wealthsimple, Questrade, RBC Direct Investing, RRSP, TFSA, or any investment platform are Savings, not spending or transfers'
+            WHERE name = 'Investment contribution'
+              AND is_default = 1
+              AND rule_type = 'transfer'
+            """
+        )
         conn.commit()
 
         # Migration: create default user only when there is existing data to migrate

--- a/server/main.py
+++ b/server/main.py
@@ -295,6 +295,11 @@ def apply_initial_setup(
         ("Investments & Savings", "savings"),
     ]
 
+    # Default classification hints always seeded on setup (#235)
+    DEFAULT_HINTS = [
+        "Transfers to investment accounts (TFSA, RRSP, Wealthsimple, Questrade, brokerage) should be classified as savings, not expenses or transfers",
+    ]
+
     # Build the full ledger spec: Personal first, then any extras.
     ledger_specs = [{"name": "Personal", "line_items": PERSONAL_LINE_ITEMS}]
     for el in extra_ledgers or []:
@@ -350,7 +355,10 @@ def apply_initial_setup(
                     line_items_created += 1
 
             # Upsert hints — de-dupe on exact text.
-            for hint_text in hints or []:
+            # Always include DEFAULT_HINTS; user-supplied hints are additive.
+            # NOTE: use [*iterable] not list() — 'list' is shadowed by the list() MCP tool.
+            all_hints = [*DEFAULT_HINTS, *(hints or [])]
+            for hint_text in all_hints:
                 if uid:
                     existing_hint = conn.execute(
                         "SELECT id FROM classification_hints WHERE text = ? AND user_id = ?",

--- a/tests/test_savings_classifier_rule.py
+++ b/tests/test_savings_classifier_rule.py
@@ -1,0 +1,122 @@
+"""
+tests/test_savings_classifier_rule.py — Tests for savings classifier rule (#235).
+
+Covers:
+  - Default 'Investment contribution' rule has rule_type='savings' (not 'transfer')
+  - Default investment savings hint is always seeded on apply_initial_setup
+  - Migration updates existing 'transfer' Investment contribution rule to 'savings'
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+import server.paths
+from server.db import get_db, init_db
+
+
+def _uid() -> str:
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def tmp_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "friday-bp" / "data.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(server.paths, "DB_PATH", db_path)
+    monkeypatch.setattr(server.paths, "APP_DIR", db_path.parent)
+    init_db(db_path)
+    return db_path
+
+
+def test_investment_contribution_rule_is_savings_type(tmp_db, monkeypatch):
+    """The default 'Investment contribution' rule is seeded with rule_type='savings'."""
+    from server.main import apply_initial_setup
+    from ui.auth import create_user
+
+    monkeypatch.setenv("OPENCLAW_DIR", str(tmp_db.parent.parent))
+    create_user(tmp_db, "testuser", "testpass123")
+    apply_initial_setup(banks_to_link=[], extra_ledgers=[], hints=[])
+
+    conn = get_db(tmp_db)
+    rule = conn.execute(
+        "SELECT name, rule_type, is_default FROM classification_rules WHERE name = 'Investment contribution'"
+    ).fetchone()
+    conn.close()
+
+    assert rule is not None, "Investment contribution rule not found"
+    assert rule["rule_type"] == "savings", f"Expected savings, got {rule['rule_type']}"
+    assert rule["is_default"] == 1, "Investment contribution rule should be is_default=1"
+
+
+def test_investment_contribution_rule_description_mentions_rrsp_tfsa(tmp_db, monkeypatch):
+    """The investment rule description mentions RRSP, TFSA, Wealthsimple, Questrade."""
+    from server.main import apply_initial_setup
+    from ui.auth import create_user
+
+    monkeypatch.setenv("OPENCLAW_DIR", str(tmp_db.parent.parent))
+    create_user(tmp_db, "testuser2", "testpass123")
+    apply_initial_setup(banks_to_link=[], extra_ledgers=[], hints=[])
+
+    conn = get_db(tmp_db)
+    rule = conn.execute(
+        "SELECT description FROM classification_rules WHERE name = 'Investment contribution'"
+    ).fetchone()
+    conn.close()
+
+    desc = rule["description"].lower()
+    assert "wealthsimple" in desc, "Rule description should mention Wealthsimple"
+    assert "questrade" in desc, "Rule description should mention Questrade"
+    assert "rrsp" in desc, "Rule description should mention RRSP"
+    assert "tfsa" in desc, "Rule description should mention TFSA"
+
+
+def test_default_savings_hint_seeded_on_setup(tmp_db, monkeypatch):
+    """apply_initial_setup always seeds the investment savings classification hint."""
+    from server.main import apply_initial_setup
+    from ui.auth import create_user
+
+    monkeypatch.setenv("OPENCLAW_DIR", str(tmp_db.parent.parent))
+    create_user(tmp_db, "testuser3", "testpass123")
+    result = apply_initial_setup(banks_to_link=[], extra_ledgers=[], hints=[])
+
+    # The default hint should always be seeded
+    assert result["hints_created"] >= 1, "Expected at least 1 hint created"
+
+    conn = get_db(tmp_db)
+    hints = conn.execute("SELECT text FROM classification_hints").fetchall()
+    conn.close()
+
+    hint_texts = [h["text"].lower() for h in hints]
+    assert any(
+        "tfsa" in t or "rrsp" in t or "investment" in t for t in hint_texts
+    ), f"Expected investment savings hint, got: {hint_texts}"
+
+
+def test_migration_updates_transfer_rule_to_savings(tmp_db, monkeypatch):
+    """migrate_db() updates existing 'transfer' Investment contribution rule to 'savings'."""
+    # Manually insert the old-style rule (transfer type)
+    conn = get_db(tmp_db)
+    conn.execute(
+        "INSERT INTO classification_rules (id, name, description, rule_type, priority, is_default, enabled, created_at) "
+        "VALUES (?, 'Investment contribution', 'Old transfer rule', 'transfer', 20, 1, 1, unixepoch())",
+        (_uid(),),
+    )
+    conn.commit()
+    conn.close()
+
+    # Re-run init_db (which includes migrations) — should update the rule_type
+    from server.db import init_db
+
+    init_db(tmp_db)
+
+    conn = get_db(tmp_db)
+    rule = conn.execute(
+        "SELECT rule_type FROM classification_rules WHERE name = 'Investment contribution' AND is_default = 1"
+    ).fetchone()
+    conn.close()
+
+    assert rule is not None
+    assert rule["rule_type"] == "savings", f"Expected savings after migration, got {rule['rule_type']}"

--- a/tests/test_setup_tool.py
+++ b/tests/test_setup_tool.py
@@ -86,7 +86,7 @@ def test_apply_minimal_creates_personal_ledger_with_10_items(tmp_db):
     assert result["status"] == "ok"
     assert result["ledgers_created"] == ["Personal"]
     assert result["line_items_created"] == 11  # 10 expense/income + 1 savings
-    assert result["hints_created"] == 0
+    assert result["hints_created"] == 1  # 1 default investment savings hint always seeded
     assert result["banks_to_link"] == []
 
     # Verify in DB
@@ -126,13 +126,14 @@ def test_apply_with_hints_creates_classification_hints(tmp_db):
     hints = ["Amazon is usually Shopping", "Starbucks is Dining"]
     result = apply_initial_setup(banks_to_link=[], extra_ledgers=[], hints=hints)
 
-    assert result["hints_created"] == 2
+    assert result["hints_created"] == 3  # 1 default + 2 user-supplied
 
     conn = get_db(tmp_db)
     rows = conn.execute("SELECT text FROM classification_hints ORDER BY text").fetchall()
     texts = [r["text"] for r in rows]
     assert "Amazon is usually Shopping" in texts
     assert "Starbucks is Dining" in texts
+    assert any("TFSA" in t or "investment" in t.lower() for t in texts), "Default savings hint missing"
     conn.close()
 
 
@@ -169,7 +170,7 @@ def test_apply_is_idempotent(tmp_db):
 
     assert ledger_count == 2  # Personal + Business
     assert line_item_count == 12  # 11 personal + 1 business
-    assert hint_count == 1
+    assert hint_count == 2  # 1 default savings hint + 1 user hint
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #235

Seeds a default `savings` classification rule for investment account transfers.

**Changes:**
- `server/db.py`: Updated 'Investment contribution' default rule from `rule_type='transfer'` to `rule_type='savings'`; expanded description to include RRSP, TFSA, RBC Direct Investing; added migration to update existing DBs
- `server/main.py`: Added `DEFAULT_HINTS` with investment savings hint always seeded on `apply_initial_setup`; fixed list() shadowing bug (uses `[*iter]` instead)
- `tests/test_savings_classifier_rule.py`: 4 new tests covering rule type, description, hint seeding, migration
- `tests/test_setup_tool.py`: Updated hint count expectations for new default hint

**Interactive check:** Called `list_rules()` — Investment contribution rule has `rule_type='savings'`, `is_default=True`. Called `list_hints()` — default savings hint present after `apply_initial_setup`.

**CI:** will update automatically