### PR TITLE
[P5] feat(savings): savings rate tracking in summary() + savings_trend() tool

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -325,7 +325,8 @@ tool calls; nothing new is required from the UI.
 are tracked as a follow-up (deferred from #173 to keep scope manageable).
 
 ### Reports
-- `summary(period)` → spending totals
+- `summary(period)` → spending totals; includes `savings_rate`, `savings_rate_ytd`, `savings_contributions`, `unspent_balance`, `total_saved`
+- `savings_trend(months?)` → month-by-month savings breakdown with cumulative total (default 12 months)
 - `export_excel(years?)` → generate Excel file(s)
 
 That's the whole API. ~15 tools.

--- a/SKILL.md
+++ b/SKILL.md
@@ -182,7 +182,8 @@ Invoke for any personal finance request:
 - `undo_auto_promoted_rule(rule_id)` — revert an auto-promoted rule and its affected entries
 
 ### Reports
-- `summary(period)` — spending totals by category for a period (e.g. `this_month`, `last_month`)
+- `summary(period)` — spending totals by category for a period; includes `savings_rate`, `savings_rate_ytd`, `savings_contributions`, `unspent_balance`, `total_saved` fields
+- `savings_trend(months?)` — month-by-month savings breakdown for the last N months (default 12); includes `savings_contributions`, `unspent_balance`, `total_saved`, `savings_rate`, `cumulative_saved` per month
 - `export_excel(years?)` — generate Excel workbook and return download URL
 
 ### Settings

--- a/server/main.py
+++ b/server/main.py
@@ -3165,7 +3165,13 @@ def summary(period: str) -> dict:
               "period": str,
               "income": float,
               "expenses": float,
-              "net": float,      # income - expenses
+              "savings": float,           # sum of savings-type line items
+              "net": float,               # income - expenses - savings
+              "savings_contributions": float,  # same as savings
+              "unspent_balance": float,    # income - expenses (may be negative)
+              "total_saved": float,        # savings_contributions + unspent_balance
+              "savings_rate": str,         # e.g. "16.8%"
+              "savings_rate_ytd": str,     # year-to-date savings rate
               "by_line_item": [
                 {"line_item": str, "ledger": str, "type": str, "total": float},
                 ...
@@ -3231,6 +3237,20 @@ def summary(period: str) -> dict:
     conn = get_db(server.paths.DB_PATH)
     try:
         rows = conn.execute(sql, date_params).fetchall()
+
+        # Compute YTD savings rate (separate query, only needed when period != ytd/year)
+        ytd_start = f"{year_str}-01-01"
+        ytd_sql = """
+            SELECT li.item_type, SUM(te.amount) AS total
+            FROM transaction_entries te
+            JOIN transactions   t  ON t.id  = te.transaction_id
+            JOIN line_items     li ON li.id = te.line_item_id
+            LEFT JOIN bank_accounts ba ON ba.id = t.bank_account_id
+            WHERE t.date >= ? AND t.date <= ?
+              AND COALESCE(ba.is_duplicate, 0) = 0
+            GROUP BY li.item_type
+        """
+        ytd_rows = conn.execute(ytd_sql, [ytd_start, today_str]).fetchall()
     finally:
         conn.close()
 
@@ -3256,14 +3276,160 @@ def summary(period: str) -> dict:
         else:
             expenses += total
 
+    # Compute savings metrics
+    savings_contributions = round(savings, 2)
+    unspent_balance = round(income - expenses, 2)  # may be negative if overspent
+    total_saved = round(savings_contributions + unspent_balance, 2)
+    savings_rate_pct = round(savings / income * 100, 1) if income > 0 else 0.0
+    savings_rate = f"{savings_rate_pct}%"
+
+    # YTD savings rate from separate query
+    ytd_income: float = 0.0
+    ytd_savings: float = 0.0
+    for row in ytd_rows:
+        v = float(row["total"] or 0.0)
+        if row["item_type"] == "income":
+            ytd_income += v
+        elif row["item_type"] == "savings":
+            ytd_savings += v
+    ytd_rate_pct = round(ytd_savings / ytd_income * 100, 1) if ytd_income > 0 else 0.0
+    savings_rate_ytd = f"{ytd_rate_pct}%"
+
     return {
         "period": period,
         "income": round(income, 2),
         "expenses": round(expenses, 2),
-        "savings": round(savings, 2),
+        "savings": savings_contributions,
         "net": round(income - expenses - savings, 2),
+        "savings_contributions": savings_contributions,
+        "unspent_balance": unspent_balance,
+        "total_saved": total_saved,
+        "savings_rate": savings_rate,
+        "savings_rate_ytd": savings_rate_ytd,
         "by_line_item": by_line_item,
     }
+
+
+@mcp.tool
+def savings_trend(months: int = 12) -> dict:
+    """Return month-by-month savings breakdown for the last N months.
+
+    Each entry includes savings contributions (savings-type line items),
+    unspent balance (income − expenses), total saved, savings rate, and
+    a running cumulative total.
+
+    Parameters
+    ----------
+    months : int
+        Number of months to include, counting back from the current month.
+        Defaults to 12.
+
+    Returns
+    -------
+    dict
+        ::
+
+            {
+              "months": [
+                {
+                  "month": "YYYY-MM",
+                  "income": float,
+                  "expenses": float,
+                  "savings_contributions": float,
+                  "unspent_balance": float,
+                  "total_saved": float,
+                  "savings_rate": str,       # e.g. "16.8%"
+                  "cumulative_saved": float, # running total from oldest month
+                },
+                ...
+              ]
+            }
+
+        Months are ordered oldest-first.  Months with no transactions are
+        included with zero values so charts have continuous x-axis data.
+    """
+    import calendar
+
+    today = _datetime.now().date()
+
+    # Build the list of YYYY-MM strings for the last N months
+    month_list: list[str] = []
+    y, m = today.year, today.month
+    for _ in range(months):
+        month_list.append(f"{y:04d}-{m:02d}")
+        m -= 1
+        if m == 0:
+            m = 12
+            y -= 1
+    month_list.reverse()  # oldest first
+
+    # Single query: fetch income, expenses, savings per month
+    sql = """
+        SELECT
+            substr(t.date, 1, 7)   AS month,
+            li.item_type            AS item_type,
+            SUM(te.amount)          AS total
+        FROM transaction_entries te
+        JOIN transactions   t  ON t.id  = te.transaction_id
+        JOIN line_items     li ON li.id = te.line_item_id
+        LEFT JOIN bank_accounts ba ON ba.id = t.bank_account_id
+        WHERE t.date >= ? AND t.date <= ?
+          AND COALESCE(ba.is_duplicate, 0) = 0
+        GROUP BY month, li.item_type
+        ORDER BY month
+    """
+
+    oldest_month = month_list[0]
+    date_from = f"{oldest_month}-01"
+    last_day = calendar.monthrange(today.year, today.month)[1]
+    date_to = f"{today.year:04d}-{today.month:02d}-{last_day:02d}"
+
+    conn = get_db(server.paths.DB_PATH)
+    try:
+        rows = conn.execute(sql, [date_from, date_to]).fetchall()
+    finally:
+        conn.close()
+
+    # Aggregate by month
+    by_month: dict[str, dict[str, float]] = {}
+    for row in rows:
+        mo = row["month"]
+        if mo not in by_month:
+            by_month[mo] = {"income": 0.0, "expenses": 0.0, "savings": 0.0}
+        total = float(row["total"] or 0.0)
+        if row["item_type"] == "income":
+            by_month[mo]["income"] += total
+        elif row["item_type"] == "savings":
+            by_month[mo]["savings"] += total
+        else:
+            by_month[mo]["expenses"] += total
+
+    # Build output, filling zeros for months with no data
+    cumulative: float = 0.0
+    result_months = []
+    for mo in month_list:
+        data = by_month.get(mo, {"income": 0.0, "expenses": 0.0, "savings": 0.0})
+        inc = data["income"]
+        exp = data["expenses"]
+        sav = data["savings"]
+        unspent = round(inc - exp, 2)
+        total_saved = round(sav + unspent, 2)
+        cumulative = round(cumulative + total_saved, 2)
+        savings_rate_pct = round(sav / inc * 100, 1) if inc > 0 else 0.0
+        result_months.append(
+            {
+                "month": mo,
+                "income": round(inc, 2),
+                "expenses": round(exp, 2),
+                "savings_contributions": round(sav, 2),
+                "unspent_balance": unspent,
+                "total_saved": total_saved,
+                "savings_rate": f"{savings_rate_pct}%",
+                "cumulative_saved": cumulative,
+            }
+        )
+
+    return {"months": result_months}
 
 
 @mcp.tool

--- a/tests/test_savings_rate.py
+++ b/tests/test_savings_rate.py
@@ -1,0 +1,214 @@
+"""
+tests/test_savings_rate.py — Tests for savings rate tracking (#248).
+
+Covers:
+  - summary() returns savings_rate, savings_rate_ytd, savings_contributions,
+    unspent_balance, total_saved
+  - savings_rate = savings / income × 100
+  - unspent_balance = income - expenses (can be negative)
+  - total_saved = savings_contributions + unspent_balance
+  - savings_trend(months) returns month-by-month breakdown with cumulative
+  - Gracefully returns 0% when no income
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+import server.paths
+from server.db import get_db, init_db
+
+
+def _uid() -> str:
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def seeded_db(tmp_path, monkeypatch):
+    """DB with a user, ledger, and some savings/income/expense transactions."""
+    db_path = tmp_path / "friday-bp" / "data.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(server.paths, "DB_PATH", db_path)
+    monkeypatch.setattr(server.paths, "APP_DIR", db_path.parent)
+    init_db(db_path)
+
+    from server.main import apply_initial_setup
+    from ui.auth import create_user
+
+    monkeypatch.setenv("OPENCLAW_DIR", str(db_path.parent.parent))
+    create_user(db_path, "testuser", "testpass123")
+    apply_initial_setup(banks_to_link=[], extra_ledgers=[], hints=[])
+
+    conn = get_db(db_path)
+    ledger = conn.execute("SELECT id FROM ledgers LIMIT 1").fetchone()
+    income_li = conn.execute(
+        "SELECT id FROM line_items WHERE item_type = 'income' LIMIT 1"
+    ).fetchone()
+    expense_li = conn.execute(
+        "SELECT id FROM line_items WHERE item_type = 'expense' LIMIT 1"
+    ).fetchone()
+    savings_li = conn.execute(
+        "SELECT id FROM line_items WHERE item_type = 'savings' LIMIT 1"
+    ).fetchone()
+
+    # Create bank account
+    bc_id = _uid()
+    account_id = _uid()
+    conn.execute(
+        "INSERT INTO bank_connections (id, plaid_access_token_encrypted, status) VALUES (?, 'enc:test', 'active')",
+        (bc_id,),
+    )
+    conn.execute(
+        "INSERT INTO bank_accounts (id, connection_id, name) VALUES (?, ?, 'Chequing')",
+        (account_id, bc_id),
+    )
+
+    # Insert transactions for 2026-05 (fixed month for deterministic tests)
+    def add_tx(amount, li_id, tx_date="2026-05-15"):
+        tx_id = _uid()
+        conn.execute(
+            "INSERT INTO transactions (id, date, merchant, amount, bank_account_id) "
+            "VALUES (?, ?, 'Test', ?, ?)",
+            (tx_id, tx_date, amount, account_id),
+        )
+        conn.execute(
+            "INSERT INTO transaction_entries (id, transaction_id, ledger_id, line_item_id, amount) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (_uid(), tx_id, ledger["id"], li_id, amount),
+        )
+
+    # income: 4000, expenses: 2500, savings: 500
+    add_tx(4000.0, income_li["id"])
+    add_tx(2500.0, expense_li["id"])
+    add_tx(500.0, savings_li["id"])
+
+    conn.commit()
+    conn.close()
+
+    return {
+        "db_path": db_path,
+        "ledger_id": ledger["id"],
+        "income_li": income_li["id"],
+        "expense_li": expense_li["id"],
+        "savings_li": savings_li["id"],
+        "account_id": account_id,
+        "bc_id": bc_id,
+    }
+
+
+def test_summary_includes_savings_rate(seeded_db):
+    """summary() returns savings_rate as a percentage string."""
+    from server.main import summary
+
+    result = summary("2026-05")
+    assert "savings_rate" in result, f"savings_rate missing from summary: {result.keys()}"
+    assert result["savings_rate"] == "12.5%"  # 500/4000 = 12.5%
+
+
+def test_summary_includes_savings_rate_ytd(seeded_db):
+    """summary() returns savings_rate_ytd."""
+    from server.main import summary
+
+    result = summary("2026-05")
+    assert "savings_rate_ytd" in result
+    # YTD should be a percentage string
+    assert result["savings_rate_ytd"].endswith("%")
+
+
+def test_summary_includes_savings_contributions(seeded_db):
+    """summary() returns savings_contributions field."""
+    from server.main import summary
+
+    result = summary("2026-05")
+    assert "savings_contributions" in result
+    assert result["savings_contributions"] == 500.0
+
+
+def test_summary_unspent_balance(seeded_db):
+    """unspent_balance = income - expenses (not including savings)."""
+    from server.main import summary
+
+    result = summary("2026-05")
+    assert "unspent_balance" in result
+    assert result["unspent_balance"] == 1500.0  # 4000 - 2500
+
+
+def test_summary_total_saved(seeded_db):
+    """total_saved = savings_contributions + unspent_balance."""
+    from server.main import summary
+
+    result = summary("2026-05")
+    assert "total_saved" in result
+    assert result["total_saved"] == 2000.0  # 500 + 1500
+
+
+def test_summary_zero_savings_rate_with_no_income(tmp_path, monkeypatch):
+    """summary() returns 0% savings_rate gracefully when no income."""
+    db_path = tmp_path / "friday-bp" / "data.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(server.paths, "DB_PATH", db_path)
+    monkeypatch.setattr(server.paths, "APP_DIR", db_path.parent)
+    init_db(db_path)
+
+    from server.main import apply_initial_setup, summary
+    from ui.auth import create_user
+
+    monkeypatch.setenv("OPENCLAW_DIR", str(db_path.parent.parent))
+    create_user(db_path, "testuser2", "testpass123")
+    apply_initial_setup(banks_to_link=[], extra_ledgers=[], hints=[])
+
+    result = summary("2026-01")
+    assert result["savings_rate"] == "0.0%"
+    assert result["savings_rate_ytd"] == "0.0%"
+
+
+def test_savings_trend_returns_months(seeded_db):
+    """savings_trend(12) returns a list of 12 month entries."""
+    from server.main import savings_trend
+
+    result = savings_trend(months=12)
+    assert "months" in result
+    assert len(result["months"]) == 12, f"Expected 12 months, got {len(result['months'])}"
+
+
+def test_savings_trend_entry_structure(seeded_db):
+    """Each savings_trend entry has the required fields."""
+    from server.main import savings_trend
+
+    result = savings_trend(months=1)
+    entry = result["months"][0]
+    required_fields = [
+        "month", "income", "expenses", "savings_contributions",
+        "unspent_balance", "total_saved", "savings_rate", "cumulative_saved",
+    ]
+    for field in required_fields:
+        assert field in entry, f"Field '{field}' missing from trend entry: {entry.keys()}"
+
+
+def test_savings_trend_cumulative(seeded_db):
+    """savings_trend cumulative_saved accumulates across months."""
+    from server.main import savings_trend
+
+    result = savings_trend(months=3)
+    months = result["months"]
+
+    # Cumulative should be monotonically increasing (or at least >= previous)
+    cumulative_values = [m["cumulative_saved"] for m in months]
+    # Each entry's cumulative = prev cumulative + total_saved
+    running = 0.0
+    for entry in months:
+        running = round(running + entry["total_saved"], 2)
+        assert abs(entry["cumulative_saved"] - running) < 0.01, (
+            f"Cumulative mismatch: {entry['cumulative_saved']} != {running}"
+        )
+
+
+def test_savings_trend_oldest_first(seeded_db):
+    """savings_trend returns months in oldest-first order."""
+    from server.main import savings_trend
+
+    result = savings_trend(months=6)
+    months_out = [m["month"] for m in result["months"]]
+    assert months_out == sorted(months_out), "Expected oldest-first ordering"


### PR DESCRIPTION
Closes #248

Adds savings rate metrics to `summary()` and a new `savings_trend()` MCP tool.

**Changes to `summary()`:**
Added fields: `savings_contributions`, `unspent_balance`, `total_saved`, `savings_rate`, `savings_rate_ytd`. All new fields are additive — existing callers unaffected.

**New `savings_trend(months=12)` tool:**
Returns month-by-month array (oldest-first) with: `income`, `expenses`, `savings_contributions`, `unspent_balance`, `total_saved`, `savings_rate`, `cumulative_saved`. Empty months filled with zeros for continuous charting.

**SKILL.md + ARCHITECTURE.md:** Updated Reports section with new tool and enhanced summary() description.

**Interactive check:** Called `summary('2026-05')` — returned `savings_rate='10.0%'`, `savings_rate_ytd='10.0%'`, `savings_contributions=300.0`, `unspent_balance=1500.0`, `total_saved=1800.0`. Called `savings_trend(3)` — returned 3-month array with all required fields, correct cumulative totals.

**CI:** will update automatically