### PR TITLE
[P5] feat(savings): budget_summary() with savings section and status

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -326,6 +326,7 @@ are tracked as a follow-up (deferred from #173 to keep scope manageable).
 
 ### Reports
 - `summary(period)` → spending totals; includes `savings_rate`, `savings_rate_ytd`, `savings_contributions`, `unspent_balance`, `total_saved`
+- `budget_summary(period?)` → all `summary()` fields plus `savings_section` with status (`on_track`/`under_saving`/`over_saving`) vs 20% benchmark
 - `savings_trend(months?)` → month-by-month savings breakdown with cumulative total (default 12 months)
 - `export_excel(years?)` → generate Excel file(s)
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -183,6 +183,7 @@ Invoke for any personal finance request:
 
 ### Reports
 - `summary(period)` — spending totals by category for a period; includes `savings_rate`, `savings_rate_ytd`, `savings_contributions`, `unspent_balance`, `total_saved` fields
+- `budget_summary(period?)` — all `summary()` fields plus `savings_section` with `status` (`on_track`/`under_saving`/`over_saving`), benchmark (20%), and narrative note
 - `savings_trend(months?)` — month-by-month savings breakdown for the last N months (default 12); includes `savings_contributions`, `unspent_balance`, `total_saved`, `savings_rate`, `cumulative_saved` per month
 - `export_excel(years?)` — generate Excel workbook and return download URL
 

--- a/server/main.py
+++ b/server/main.py
@@ -3433,6 +3433,83 @@ def savings_trend(months: int = 12) -> dict:
 
 
 @mcp.tool
+def budget_summary(period: str = "month") -> dict:
+    """Return a budget breakdown with a dedicated savings section.
+
+    Wraps ``summary()`` and adds a ``savings_section`` with a status field
+    indicating whether the user is on track with savings goals.  All existing
+    summary fields are preserved — this is purely additive.
+
+    The status benchmarks against the common 20% savings-rate target:
+    - ``on_track``      → savings_rate >= 20%
+    - ``under_saving``  → 0 < savings_rate < 20%
+    - ``over_saving``   → savings_contributions > income (edge-case: large lump-sum)
+
+    Parameters
+    ----------
+    period : str
+        Same values as ``summary()`` — e.g. ``"month"``, ``"year"``, ``"ytd"``,
+        or a specific ``"YYYY-MM"`` / ``"YYYY"``.
+
+    Returns
+    -------
+    dict
+        All fields from ``summary()`` plus::
+
+            {
+              ...,  # all summary() fields
+              "savings_section": {
+                "savings_contributions": float,
+                "unspent_balance": float,
+                "total_saved": float,
+                "savings_rate": str,
+                "status": str,   # "on_track" | "under_saving" | "over_saving"
+                "benchmark": "20%",
+                "benchmark_note": str,
+              }
+            }
+    """
+    # Build the full summary result — all fields already present after #248.
+    result = summary(period)
+
+    # Extract the savings values already computed by summary().
+    savings_contributions = result.get("savings_contributions", result.get("savings", 0.0))
+    unspent_balance = result.get("unspent_balance", 0.0)
+    total_saved = result.get("total_saved", 0.0)
+    savings_rate_str = result.get("savings_rate", "0.0%")
+
+    # Parse savings_rate percentage for status determination.
+    try:
+        savings_rate_pct = float(savings_rate_str.rstrip("%"))
+    except (ValueError, AttributeError):
+        savings_rate_pct = 0.0
+
+    income = result.get("income", 0.0)
+
+    if income > 0 and savings_contributions > income:
+        status = "over_saving"
+        benchmark_note = "Your savings contributions exceed your income this period — likely a large lump-sum deposit."
+    elif savings_rate_pct >= 20.0:
+        status = "on_track"
+        benchmark_note = f"Your savings rate of {savings_rate_str} meets the 20% benchmark."
+    else:
+        status = "under_saving"
+        benchmark_note = f"Your savings rate of {savings_rate_str} is below the 20% benchmark. Consider automating a fixed monthly transfer."
+
+    savings_section = {
+        "savings_contributions": savings_contributions,
+        "unspent_balance": unspent_balance,
+        "total_saved": total_saved,
+        "savings_rate": savings_rate_str,
+        "status": status,
+        "benchmark": "20%",
+        "benchmark_note": benchmark_note,
+    }
+
+    return {**result, "savings_section": savings_section}
+
+
+@mcp.tool
 def export_excel(years: Optional[List] = None) -> dict:
     """Generate and return an Excel export of transactions."""
     server.paths.ensure_app_dir()

--- a/tests/test_budget_summary.py
+++ b/tests/test_budget_summary.py
@@ -1,0 +1,186 @@
+"""
+tests/test_budget_summary.py — Tests for budget_summary() savings section (#237).
+
+Covers:
+  - budget_summary() returns all summary() fields (additive, no breakage)
+  - budget_summary() returns savings_section with required fields
+  - status field: on_track (>= 20%), under_saving (< 20%), over_saving (> income)
+  - Existing summary() callers not affected
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+import server.paths
+from server.db import get_db, init_db
+
+
+def _uid() -> str:
+    return str(uuid.uuid4())
+
+
+@pytest.fixture
+def seeded_db(tmp_path, monkeypatch):
+    """DB with a user, ledger, and controllable income/expense/savings entries."""
+    db_path = tmp_path / "friday-bp" / "data.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr(server.paths, "DB_PATH", db_path)
+    monkeypatch.setattr(server.paths, "APP_DIR", db_path.parent)
+    init_db(db_path)
+
+    from server.main import apply_initial_setup
+    from ui.auth import create_user
+
+    monkeypatch.setenv("OPENCLAW_DIR", str(db_path.parent.parent))
+    create_user(db_path, "testuser", "testpass123")
+    apply_initial_setup(banks_to_link=[], extra_ledgers=[], hints=[])
+
+    conn = get_db(db_path)
+    ledger = conn.execute("SELECT id FROM ledgers LIMIT 1").fetchone()
+    income_li = conn.execute(
+        "SELECT id FROM line_items WHERE item_type = 'income' LIMIT 1"
+    ).fetchone()
+    expense_li = conn.execute(
+        "SELECT id FROM line_items WHERE item_type = 'expense' LIMIT 1"
+    ).fetchone()
+    savings_li = conn.execute(
+        "SELECT id FROM line_items WHERE item_type = 'savings' LIMIT 1"
+    ).fetchone()
+
+    bc_id = _uid()
+    account_id = _uid()
+    conn.execute(
+        "INSERT INTO bank_connections (id, plaid_access_token_encrypted, status) VALUES (?, 'enc:test', 'active')",
+        (bc_id,),
+    )
+    conn.execute(
+        "INSERT INTO bank_accounts (id, connection_id, name) VALUES (?, ?, 'Chequing')",
+        (account_id, bc_id),
+    )
+    conn.commit()
+    conn.close()
+
+    return {
+        "db_path": db_path,
+        "ledger_id": ledger["id"],
+        "income_li": income_li["id"],
+        "expense_li": expense_li["id"],
+        "savings_li": savings_li["id"],
+        "account_id": account_id,
+        "bc_id": bc_id,
+    }
+
+
+def _add_entries(db_path, seeded, entries):
+    """Add (amount, line_item_id, date) entries to the DB."""
+    conn = get_db(db_path)
+    for amount, li_id, dt in entries:
+        tx_id = _uid()
+        conn.execute(
+            "INSERT INTO transactions (id, date, merchant, amount, bank_account_id) "
+            "VALUES (?, ?, 'Test', ?, ?)",
+            (tx_id, dt, amount, seeded["account_id"]),
+        )
+        conn.execute(
+            "INSERT INTO transaction_entries (id, transaction_id, ledger_id, line_item_id, amount) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (_uid(), tx_id, seeded["ledger_id"], li_id, amount),
+        )
+    conn.commit()
+    conn.close()
+
+
+def test_budget_summary_includes_all_summary_fields(seeded_db):
+    """budget_summary() returns all the same fields as summary()."""
+    from server.main import budget_summary, summary
+
+    s = summary("2026-01")
+    bs = budget_summary("2026-01")
+
+    # All keys from summary must be in budget_summary
+    for key in s:
+        assert key in bs, f"Key '{key}' from summary() missing in budget_summary()"
+
+
+def test_budget_summary_has_savings_section(seeded_db):
+    """budget_summary() returns savings_section with required fields."""
+    from server.main import budget_summary
+
+    result = budget_summary("2026-01")
+    assert "savings_section" in result, "savings_section missing from budget_summary"
+
+    section = result["savings_section"]
+    required = [
+        "savings_contributions", "unspent_balance", "total_saved",
+        "savings_rate", "status", "benchmark", "benchmark_note",
+    ]
+    for field in required:
+        assert field in section, f"Field '{field}' missing from savings_section"
+
+    assert section["benchmark"] == "20%"
+
+
+def test_budget_summary_status_on_track(seeded_db):
+    """status is 'on_track' when savings_rate >= 20%."""
+    from server.main import budget_summary
+
+    # income=1000, savings=250 → 25% rate → on_track
+    _add_entries(
+        seeded_db["db_path"],
+        seeded_db,
+        [
+            (1000.0, seeded_db["income_li"], "2026-06-10"),
+            (250.0, seeded_db["savings_li"], "2026-06-11"),
+        ],
+    )
+    result = budget_summary("2026-06")
+    assert result["savings_section"]["status"] == "on_track", (
+        f"Expected on_track but got: {result['savings_section']}"
+    )
+
+
+def test_budget_summary_status_under_saving(seeded_db):
+    """status is 'under_saving' when savings_rate < 20%."""
+    from server.main import budget_summary
+
+    # income=1000, savings=100 → 10% → under_saving
+    _add_entries(
+        seeded_db["db_path"],
+        seeded_db,
+        [
+            (1000.0, seeded_db["income_li"], "2026-07-10"),
+            (100.0, seeded_db["savings_li"], "2026-07-11"),
+        ],
+    )
+    result = budget_summary("2026-07")
+    assert result["savings_section"]["status"] == "under_saving", (
+        f"Expected under_saving but got: {result['savings_section']}"
+    )
+
+
+def test_budget_summary_status_no_income(seeded_db):
+    """status is 'under_saving' when there's no income (0% rate)."""
+    from server.main import budget_summary
+
+    result = budget_summary("2026-03")
+    section = result["savings_section"]
+    assert section["status"] in ("under_saving", "on_track"), (
+        f"Unexpected status with no data: {section['status']}"
+    )
+
+
+def test_summary_not_broken_by_budget_summary(seeded_db):
+    """summary() still works correctly after budget_summary() addition."""
+    from server.main import summary
+
+    result = summary("2026-01")
+    # Must still have the core fields
+    for field in ["period", "income", "expenses", "savings", "net",
+                  "savings_rate", "savings_rate_ytd", "by_line_item"]:
+        assert field in result, f"summary() missing '{field}' after #237"
+
+    # Must NOT have savings_section (that's budget_summary only)
+    assert "savings_section" not in result, "summary() should not have savings_section"


### PR DESCRIPTION
Closes #237

Adds `budget_summary()` MCP tool with a dedicated savings section.

**Changes:**
- New `budget_summary(period='month')` MCP tool that wraps `summary()` and adds a `savings_section` dict:
  - `savings_contributions`, `unspent_balance`, `total_saved`, `savings_rate`
  - `status`: `on_track` (≥ 20%), `under_saving` (< 20%), `over_saving` (savings > income)
  - `benchmark`: '20%'
  - `benchmark_note`: human-readable explanation
- `summary()` is completely unchanged — `savings_section` only in `budget_summary()`
- SKILL.md + ARCHITECTURE.md: updated Reports section

**Interactive check:** Called `budget_summary('2026-05')` with 24% savings rate — returned `status='on_track'`, correct savings_contributions, unspent_balance, total_saved. Called `summary('2026-05')` — unchanged, no savings_section.

**CI:** will update automatically