### PR TITLE
feat(ui): display savings section on dashboard and ledgers

### DIFF
--- a/ui/server.py
+++ b/ui/server.py
@@ -969,6 +969,24 @@ def api_sync_result(request: Request):
         conn.close()
 
 
+@app.get("/api/summary")
+def api_summary(request: Request, period: str = "this_month"):
+    """Return spending/savings summary for the given period.
+
+    Valid period values: ``this_month``, ``last_month``, ``this_year``,
+    ``ytd``, or a specific ``YYYY-MM`` / ``YYYY`` string.
+    """
+    if not _is_authenticated(request):
+        return JSONResponse({"error": "Unauthorized"}, status_code=401)
+    from server.main import summary as _summary
+
+    try:
+        result = _summary(period)
+        return JSONResponse(result)
+    except Exception as exc:  # pragma: no cover
+        return JSONResponse({"error": str(exc)}, status_code=500)
+
+
 @app.get("/dashboard", response_class=HTMLResponse)
 def dashboard_get(request: Request):
     """Main dashboard page.  Requires authentication."""

--- a/ui/templates/dashboard.html
+++ b/ui/templates/dashboard.html
@@ -105,9 +105,107 @@
     </script>
   </section>
 
-  <section>
-    <h2>Coming soon</h2>
-    <p class="hint">Charts and spending summaries will appear here in a future update.</p>
+  <section id="savings-summary-section">
+    <h2>Savings Summary</h2>
+    <div id="savings-cards" style="display:flex;gap:1em;flex-wrap:wrap;margin-top:0.75em;">
+      <div class="alert alert-info" id="savings-loading">Loading savings data&#x2026;</div>
+    </div>
   </section>
+
+  <style>
+    .savings-card {
+      background: #fffbeb;
+      border: 1px solid #fcd34d;
+      border-radius: 8px;
+      padding: 1em 1.25em;
+      min-width: 180px;
+      flex: 1;
+    }
+    .savings-card-title {
+      font-size: 0.8em;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #92400e;
+      margin-bottom: 0.25em;
+    }
+    .savings-card-value {
+      font-size: 1.6em;
+      font-weight: 700;
+      color: #d97706;
+    }
+    .savings-card-sub {
+      font-size: 0.85em;
+      color: #78350f;
+      margin-top: 0.25em;
+    }
+    .savings-badge {
+      display: inline-block;
+      padding: 0.2em 0.6em;
+      border-radius: 4px;
+      font-size: 0.8em;
+      font-weight: 600;
+      margin-top: 0.5em;
+    }
+    .savings-badge-green  { background: #d1fae5; color: #065f46; }
+    .savings-badge-amber  { background: #fef3c7; color: #92400e; }
+    .savings-badge-red    { background: #fee2e2; color: #991b1b; }
+  </style>
+
+  <script>
+  (function() {
+    async function loadSavings() {
+      var container = document.getElementById('savings-cards');
+      try {
+        var r = await fetch('/api/summary?period=this_month');
+        var d = await r.json();
+        if (d.error) {
+          container.innerHTML = '<div class="alert alert-error">&#x26A0;&#xFE0F; ' + d.error + '</div>';
+          return;
+        }
+
+        var totalSaved = d.total_saved || 0;
+        var contributions = d.savings_contributions || 0;
+        var unspent = d.unspent_balance || 0;
+        var savingsRate = d.savings_rate || '0%';
+        var savingsRateYtd = d.savings_rate_ytd || '0%';
+        var savingsRatePct = parseFloat(savingsRate);
+
+        // Determine badge
+        var badgeClass, badgeText;
+        if (totalSaved < 0) {
+          badgeClass = 'savings-badge-red';
+          badgeText = '&#x26A0;&#xFE0F; Overspent';
+        } else if (savingsRatePct >= 20) {
+          badgeClass = 'savings-badge-green';
+          badgeText = '&#x2705; On Track';
+        } else {
+          badgeClass = 'savings-badge-amber';
+          badgeText = '&#x26A0;&#xFE0F; Under Saving';
+        }
+
+        var fmt = function(n) {
+          return 'C$' + Math.abs(n).toFixed(2) + (n < 0 ? ' (deficit)' : '');
+        };
+
+        container.innerHTML =
+          '<div class="savings-card">' +
+            '<div class="savings-card-title">Total Saved</div>' +
+            '<div class="savings-card-value">' + fmt(totalSaved) + '</div>' +
+            '<div class="savings-card-sub">Contributions: ' + fmt(contributions) + '</div>' +
+            '<div class="savings-card-sub">Unspent: ' + fmt(unspent) + '</div>' +
+            '<span class="savings-badge ' + badgeClass + '">' + badgeText + '</span>' +
+          '</div>' +
+          '<div class="savings-card">' +
+            '<div class="savings-card-title">Savings Rate</div>' +
+            '<div class="savings-card-value">' + savingsRate + '</div>' +
+            '<div class="savings-card-sub">YTD rate: ' + savingsRateYtd + '</div>' +
+          '</div>';
+      } catch(e) {
+        document.getElementById('savings-loading').textContent = 'Could not load savings data.';
+      }
+    }
+    loadSavings();
+  })();
+  </script>
 </div>
 {% endblock %}

--- a/ui/templates/ledgers.html
+++ b/ui/templates/ledgers.html
@@ -179,7 +179,63 @@
           </div>
         </div>
 
-        {# ── Income/Expenses/Net totals footer (#166) ── #}
+        {% set ns_savings = namespace(has_savings=false) %}
+        {% for item in ledger.line_items %}{% if item.item_type == "savings" %}{% set ns_savings.has_savings = true %}{% endif %}{% endfor %}
+        {% if ns_savings.has_savings %}
+        <div class="item-section" data-section="savings" style="border-top:1px solid #fcd34d;margin-top:0.5em;padding-top:0.5em;">
+          <h3 style="color:#d97706;">&#x1F4B0; Savings &amp; Investments</h3>
+          <table>
+            <tbody class="items-tbody" data-section="savings">
+              {% for item in ledger.line_items %}
+              {% if item.item_type == "savings" %}
+              <tr class="line-item-row" data-item-id="{{ item.id }}" data-line-item-id="{{ item.id }}">
+                <td class="item-name-cell">
+                  <span class="item-name-display">{{ item.name }}</span>
+                  <input class="item-name-input" type="text" value="{{ item.name }}"
+                    style="display:none;" data-item-id="{{ item.id }}"
+                    data-ledger-id="{{ ledger.id }}">
+                </td>
+                <td class="item-total-cell" style="color:#d97706;">C${{ "%.2f"|format(item.total) }}</td>
+                <td class="item-count-cell">{{ item.transactions|length }} transaction{% if item.transactions|length != 1 %}s{% endif %}</td>
+                <td class="item-expand-cell">
+                  {% if item.transactions %}
+                  <button class="btn-expand-item" data-item-id="{{ item.id }}" aria-label="Toggle transactions">&#8964;</button>
+                  {% endif %}
+                </td>
+                <td>
+                  <button class="btn-danger btn-delete-item" data-item-id="{{ item.id }}"
+                    data-ledger-id="{{ ledger.id }}">x</button>
+                </td>
+              </tr>
+              {% if item.transactions %}
+              <tr class="txn-detail-row" data-parent-item-id="{{ item.id }}" style="display:none;">
+                <td colspan="5" class="txn-detail-cell">
+                  <table class="txn-table">
+                    {% for tx in item.transactions %}
+                    <tr class="{% if tx.pending %}txn-pending{% endif %}">
+                      <td class="txn-tree">{% if loop.last %}&#9492;&#9472;&#9472;{% else %}&#9500;&#9472;&#9472;{% endif %}</td>
+                      <td class="txn-date">{{ tx.date }}</td>
+                      <td class="txn-merchant">{{ tx.merchant or '(unknown)' }}</td>
+                      <td class="txn-account">{{ tx.account_name or '' }}</td>
+                      <td class="txn-amount" style="color:#d97706;">C${{ "%.2f"|format(tx.amount) }}</td>
+                    </tr>
+                    {% endfor %}
+                  </table>
+                </td>
+              </tr>
+              {% endif %}
+              {% endif %}
+              {% endfor %}
+            </tbody>
+          </table>
+          <div class="add-item-row">
+            <input type="text" class="add-item-input" placeholder="Add savings item&#x2026;"
+              data-ledger-id="{{ ledger.id }}" data-section="savings">
+          </div>
+        </div>
+        {% endif %}
+
+        {# ── Income/Expenses/Savings/Net totals footer (#166, #237) ── #}
         <div class="ledger-totals-row" data-ledger-totals="{{ ledger.id }}">
           <span>
             <span class="total-label">Total income:</span>
@@ -189,6 +245,12 @@
             <span class="total-label">Total expenses:</span>
             <span class="total-value" data-total="expenses">C${{ "%.2f"|format(ledger.totals.expenses) }}</span>
           </span>
+          {% if ledger.totals.savings > 0 %}
+          <span>
+            <span class="total-label" style="color:#d97706;">Savings:</span>
+            <span class="total-value" data-total="savings" style="color:#d97706;font-weight:600;">C${{ "%.2f"|format(ledger.totals.savings) }}</span>
+          </span>
+          {% endif %}
           <span>
             <span class="total-label">Net:</span>
             <span class="total-value {% if ledger.totals.net > 0 %}net-positive{% elif ledger.totals.net < 0 %}net-negative{% else %}net-zero{% endif %}"


### PR DESCRIPTION
## Summary

Wires the new savings data from `summary()` into the frontend. Closes #237 (UI portion).

## Changes

### `ui/server.py`
- Added `GET /api/summary` endpoint — auth-gated, delegates to `server.main.summary()`, returns JSON with all savings fields (`savings_contributions`, `unspent_balance`, `total_saved`, `savings_rate`, `savings_rate_ytd`, etc.)

### `ui/templates/dashboard.html`
- Replaced the *Coming soon* placeholder with a live **Savings Summary** section
- Two amber-coloured cards rendered client-side via `/api/summary?period=this_month`:
  - **Total Saved** — shows Contributions + Unspent breakdown and a status badge
    - 🟢 *On Track* when savings rate ≥ 20%
    - 🟡 *Under Saving* when rate < 20%
    - 🔴 *Overspent* when total_saved < 0
  - **Savings Rate** — current-period rate and YTD rate
- Styling uses the established amber palette (`bg #fffbeb`, `fg #d97706`, `border #fcd34d`) matching `accounts.html`

### `ui/templates/ledgers.html`
- Added a **Savings & Investments** section per ledger (amber-themed), rendered only when the ledger contains `item_type = 'savings'` line items
- Full expandable transaction drilldown (same UX as income/expense sections)
- Added a *Savings* row to the per-ledger totals footer (visible only when `totals.savings > 0`)
