### PR TITLE
fix(ui): fix ledgers savings section error

### DIFF
--- a/ui/templates/ledgers.html
+++ b/ui/templates/ledgers.html
@@ -245,10 +245,10 @@
             <span class="total-label">Total expenses:</span>
             <span class="total-value" data-total="expenses">C${{ "%.2f"|format(ledger.totals.expenses) }}</span>
           </span>
-          {% if ledger.totals.savings > 0 %}
+          {% if (ledger.totals.savings | default(0)) > 0 %}
           <span>
             <span class="total-label" style="color:#d97706;">Savings:</span>
-            <span class="total-value" data-total="savings" style="color:#d97706;font-weight:600;">C${{ "%.2f"|format(ledger.totals.savings) }}</span>
+            <span class="total-value" data-total="savings" style="color:#d97706;font-weight:600;">C${{ "%.2f"|format(ledger.totals.savings | default(0)) }}</span>
           </span>
           {% endif %}
           <span>


### PR DESCRIPTION
## Problem

The ledgers page was crashing with:
```
jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'savings'
```

**Root cause:** PR #313 added `{% if ledger.totals.savings > 0 %}` to `ledgers.html`. However, the live server process had been started *before* commit `3dd2f4f` added the `savings` key to the `_build_ledger_drilldown` totals dict. Python holds the old module code in memory until restart — so the server was returning `totals` dicts **without** a `savings` key, while the template on disk expected it. Jinja2 raised `UndefinedError` on every ledgers page load.

**Why `income`/`expenses`/`net` didn't break:** Those keys have always been in the totals dict; `savings` was the newly added one.

## Fix

Added Jinja2 `| default(0)` to `ledger.totals.savings` accesses in the totals footer of `ledgers.html`:

```jinja
{% if (ledger.totals.savings | default(0)) > 0 %}
```

This is a defensive template guard — if the key is absent for any reason (old in-memory code, future refactor), the row simply stays hidden rather than crashing the page. The underlying Python fix (always return `savings` in the totals dict) is already in `_build_ledger_drilldown` via commit `3dd2f4f`.

## Testing

- Reproduced the error from `~/.friday-bp/daemon.log` (multiple UndefinedError tracebacks from line 248 of ledgers.html)
- Verified fix on test instance (port 7892) with Playwright — no console errors, page loads correctly
- All 69 Playwright functional tests pass (`tests/ui_functional/test_ui_functional.py`)