### PR TITLE
fix(savings): fix savings UI showing $0 and add per-ledger savings section

### DIFF
--- a/server/db.py
+++ b/server/db.py
@@ -243,6 +243,26 @@ def init_db(path: str | Path) -> None:
         )
         conn.commit()
 
+        # Migration: fix savings line items that were seeded as expense type (#284)
+        # Line items whose names indicate savings/investments were historically
+        # seeded as item_type='expense' before the 'savings' type was added (#234).
+        # Correct them so totals and the savings UI work properly.
+        conn.execute(
+            """
+            UPDATE line_items
+            SET item_type = 'savings'
+            WHERE item_type = 'expense'
+              AND name IN (
+                'Investments & Savings',
+                'Savings & Investments',
+                'Investment & Savings',
+                'Savings and Investments',
+                'Investments and Savings'
+              )
+            """
+        )
+        conn.commit()
+
         # Migration: create default user only when there is existing data to migrate
         # (i.e. rows exist that need a user_id) but no users have been created yet.
         # On truly fresh DBs, we leave users empty so the setup wizard can create

--- a/tests/ui/_server_runner.py
+++ b/tests/ui/_server_runner.py
@@ -98,6 +98,10 @@ def _seed():
             "Healthcare",
         ]
 
+        savings_items = [
+            "Investments & Savings",
+        ]
+
         for name in income_items:
             conn.execute(
                 "INSERT INTO line_items (id, ledger_id, name, item_type) VALUES (?, ?, ?, ?)",
@@ -107,6 +111,11 @@ def _seed():
             conn.execute(
                 "INSERT INTO line_items (id, ledger_id, name, item_type) VALUES (?, ?, ?, ?)",
                 (str(uuid.uuid4()), ledger_id, name, "expense"),
+            )
+        for name in savings_items:
+            conn.execute(
+                "INSERT INTO line_items (id, ledger_id, name, item_type) VALUES (?, ?, ?, ?)",
+                (str(uuid.uuid4()), ledger_id, name, "savings"),
             )
 
         conn.commit()

--- a/tests/ui/test_dashboard.py
+++ b/tests/ui/test_dashboard.py
@@ -66,3 +66,18 @@ def test_dashboard_shows_sync_section(page, server_url):
     # There should be an h2 with "Sync" text
     sync_heading = page.locator("h2", has_text="Sync")
     assert sync_heading.count() > 0, "Expected a 'Sync' section heading on dashboard"
+
+
+def test_dashboard_has_overall_savings_section(page, server_url):
+    """Dashboard has an 'Overall Savings' section heading."""
+    _login(page, server_url)
+    savings_heading = page.locator("h2", has_text="Overall Savings")
+    assert savings_heading.count() > 0, "Expected 'Overall Savings' section heading on dashboard"
+
+
+def test_dashboard_savings_section_id_present(page, server_url):
+    """Dashboard savings section has the expected #savings-summary-section id."""
+    _login(page, server_url)
+    section = page.locator("#savings-summary-section")
+    assert section.count() > 0, "Expected #savings-summary-section on dashboard"
+    assert section.first.is_visible()

--- a/tests/ui/test_ledgers.py
+++ b/tests/ui/test_ledgers.py
@@ -81,3 +81,67 @@ def test_ledgers_shows_seeded_line_items(page, server_url):
     groceries = page.locator(".item-name-display", has_text="Groceries")
     assert salary.count() > 0, "Expected 'Salary' line item in ledger"
     assert groceries.count() > 0, "Expected 'Groceries' line item in ledger"
+
+
+def test_ledgers_shows_savings_section(page, server_url):
+    """Ledgers page shows a Savings & Investments section for each ledger."""
+    _login(page, server_url)
+    page.goto(server_url + "/ledgers")
+    savings_heading = page.locator("h3", has_text="Savings")
+    assert savings_heading.count() > 0, "Expected a Savings section in the ledger"
+    # Verify it has the correct amber/gold styling
+    section = page.locator(".item-section[data-section='savings']")
+    assert section.count() > 0, "Expected .item-section[data-section='savings'] element"
+
+
+def test_ledgers_savings_section_always_visible(page, server_url):
+    """Savings section is always shown even when no savings transactions exist."""
+    _login(page, server_url)
+    page.goto(server_url + "/ledgers")
+    # The savings section should be present regardless of whether savings data exists
+    section = page.locator(".item-section[data-section='savings']")
+    assert section.count() > 0, "Savings section should always be visible"
+    assert section.first.is_visible(), "Savings section should be visible"
+
+
+def test_ledgers_savings_section_has_add_input(page, server_url):
+    """Savings section has an 'Add savings item' input."""
+    _login(page, server_url)
+    page.goto(server_url + "/ledgers")
+    add_input = page.locator(".add-item-input[data-section='savings']")
+    assert add_input.count() > 0, "Expected 'Add savings item' input in savings section"
+
+
+def test_ledgers_savings_shows_seeded_item(page, server_url):
+    """Seeded 'Investments & Savings' line item appears in the savings section."""
+    _login(page, server_url)
+    page.goto(server_url + "/ledgers")
+    savings_item = page.locator(".item-name-display", has_text="Investments & Savings")
+    assert savings_item.count() > 0, "Expected 'Investments & Savings' in savings section"
+
+
+def test_ledgers_savings_totals_in_footer(page, server_url):
+    """Ledger totals footer shows a Savings row."""
+    _login(page, server_url)
+    page.goto(server_url + "/ledgers")
+    totals_row = page.locator(".ledger-totals-row")
+    assert totals_row.count() > 0, "Expected .ledger-totals-row footer"
+    savings_total = page.locator("[data-total='savings']")
+    assert savings_total.count() > 0, "Expected savings total value in footer"
+
+
+def test_ledgers_can_add_savings_item_via_api(page, server_url):
+    """Adding a savings item via the 'Add savings item' input creates a savings line item."""
+    _login(page, server_url)
+    page.goto(server_url + "/ledgers")
+
+    # Find the savings add-input and add an item
+    add_input = page.locator(".add-item-input[data-section='savings']").first
+    add_input.fill("TFSA Contributions")
+    add_input.press("Enter")
+
+    # Wait for the new item to appear in the savings tbody
+    savings_tbody = page.locator("tbody.items-tbody[data-section='savings']").first
+    new_item = savings_tbody.locator(".item-name-display", has_text="TFSA Contributions")
+    new_item.wait_for(timeout=5000)
+    assert new_item.count() > 0, "Expected 'TFSA Contributions' to appear in savings section"

--- a/ui/server.py
+++ b/ui/server.py
@@ -1715,7 +1715,7 @@ async def ledgers_rename(request: Request, ledger_id: str):
 
 @app.post("/ledgers/{ledger_id}/items")
 async def ledger_items_create(request: Request, ledger_id: str):
-    """Add a line item. JSON body: {name: str, section: 'income'|'expenses'}."""
+    """Add a line item. JSON body: {name: str, section: 'income'|'expenses'|'savings'}."""
     if not _is_authenticated(request):
         return JSONResponse({"error": "Unauthorized"}, status_code=401)
     body = await request.json()
@@ -1723,8 +1723,13 @@ async def ledger_items_create(request: Request, ledger_id: str):
     section = (body.get("section") or "expenses").strip().lower()
     if not name:
         return JSONResponse({"error": "name is required"}, status_code=400)
-    # Map 'expenses' -> 'expense', 'income' -> 'income'
-    item_type = "income" if section == "income" else "expense"
+    # Map section name to item_type
+    if section == "income":
+        item_type = "income"
+    elif section == "savings":
+        item_type = "savings"
+    else:
+        item_type = "expense"
     conn = get_db(_db_path())
     try:
         row = conn.execute("SELECT id FROM ledgers WHERE id = ?", (ledger_id,)).fetchone()

--- a/ui/templates/dashboard.html
+++ b/ui/templates/dashboard.html
@@ -106,7 +106,7 @@
   </section>
 
   <section id="savings-summary-section">
-    <h2>Savings Summary</h2>
+    <h2>Overall Savings</h2>
     <div id="savings-cards" style="display:flex;gap:1em;flex-wrap:wrap;margin-top:0.75em;">
       <div class="alert alert-info" id="savings-loading">Loading savings data&#x2026;</div>
     </div>

--- a/ui/templates/ledgers.html
+++ b/ui/templates/ledgers.html
@@ -179,9 +179,6 @@
           </div>
         </div>
 
-        {% set ns_savings = namespace(has_savings=false) %}
-        {% for item in ledger.line_items %}{% if item.item_type == "savings" %}{% set ns_savings.has_savings = true %}{% endif %}{% endfor %}
-        {% if ns_savings.has_savings %}
         <div class="item-section" data-section="savings" style="border-top:1px solid #fcd34d;margin-top:0.5em;padding-top:0.5em;">
           <h3 style="color:#d97706;">&#x1F4B0; Savings &amp; Investments</h3>
           <table>
@@ -233,7 +230,6 @@
               data-ledger-id="{{ ledger.id }}" data-section="savings">
           </div>
         </div>
-        {% endif %}
 
         {# ── Income/Expenses/Savings/Net totals footer (#166, #237) ── #}
         <div class="ledger-totals-row" data-ledger-totals="{{ ledger.id }}">
@@ -245,12 +241,10 @@
             <span class="total-label">Total expenses:</span>
             <span class="total-value" data-total="expenses">C${{ "%.2f"|format(ledger.totals.expenses) }}</span>
           </span>
-          {% if (ledger.totals.savings | default(0)) > 0 %}
           <span>
             <span class="total-label" style="color:#d97706;">Savings:</span>
             <span class="total-value" data-total="savings" style="color:#d97706;font-weight:600;">C${{ "%.2f"|format(ledger.totals.savings | default(0)) }}</span>
           </span>
-          {% endif %}
           <span>
             <span class="total-label">Net:</span>
             <span class="total-value {% if ledger.totals.net > 0 %}net-positive{% elif ledger.totals.net < 0 %}net-negative{% else %}net-zero{% endif %}"


### PR DESCRIPTION
## Summary

Fixes the savings UI showing $0 and enhances the savings display across the app.

## Root Cause of $0 (Problem 1)

The 'Savings & Investments' line item in the Personal ledger had `item_type='expense'` instead of `'savings'`. This was created before the savings type was added in #234, so all $36,000 in savings transactions were being counted as expenses, not savings. The UI correctly checks for savings-type items, but found none.

**Diagnosis: Case (a)** — the savings data IS in the DB with $36,000 in transactions, but the line item had the wrong type so the API was treating it as expenses.

## Changes

### Backend (`server/db.py`)
- Add DB migration to fix savings-named line items that were historically seeded as `expense` type (handles: 'Savings & Investments', 'Investments & Savings', and common variants)
- Migration runs automatically on server startup (idempotent)

### Backend (`ui/server.py`)
- Fix `POST /ledgers/{id}/items` to accept `section='savings'` and correctly set `item_type='savings'` (previously defaulted everything non-income to expense)

### UI (`ui/templates/ledgers.html`)
- **Always show** the Savings & Investments section per ledger (removed `{% if ns_savings.has_savings %}` conditional) — consistent with how Income and Expenses sections are always visible
- Always show savings total in the ledger footer (not only when > 0)

### UI (`ui/templates/dashboard.html`)
- Rename 'Savings Summary' heading to **'Overall Savings'** for clarity

### Tests (`tests/ui/`)
- Seed 'Investments & Savings' savings item in test DB runner
- **6 new Playwright tests** for per-ledger savings section: always visible, add input present, seeded item shown, totals footer, can add savings item via API
- **2 new Playwright tests** for dashboard 'Overall Savings' section

## Test Results

```
1049 passed, 2 skipped, 2 pre-existing failures in test_transfer_detection.py
```

The 2 failures are pre-existing (`test_get_transfer_hint_match`, `test_get_transfer_hint_inflow_match`) and unrelated to this change (confirmed by reproducing on `main` before any changes).