### PR TITLE
fix(ui): show last month when no current month data; fix ledgers savings footer

### DIFF
--- a/ui/server.py
+++ b/ui/server.py
@@ -975,6 +975,12 @@ def api_summary(request: Request, period: str = "this_month"):
 
     Valid period values: ``this_month``, ``last_month``, ``this_year``,
     ``ytd``, or a specific ``YYYY-MM`` / ``YYYY`` string.
+
+    Auto-fallback: when ``period=this_month`` and the result has no data
+    (income, expenses, and savings_contributions all zero), the endpoint
+    automatically returns last month's data instead and includes a
+    ``period_label`` field (e.g. ``"Last Month"``) so the caller knows
+    which period was actually used.
     """
     if not _is_authenticated(request):
         return JSONResponse({"error": "Unauthorized"}, status_code=401)
@@ -986,6 +992,7 @@ def api_summary(request: Request, period: str = "this_month"):
     # The UI (and this endpoint's query param) uses: "this_month", "last_month",
     # "this_year", "ytd", "YYYY-MM", "YYYY".
     _today = _date.today()
+    original_period = period
     if period == "this_month":
         period = "month"
     elif period == "this_year":
@@ -998,6 +1005,26 @@ def api_summary(request: Request, period: str = "this_month"):
 
     try:
         result = _summary(period)
+        # Auto-fallback: if this_month has no data, try last_month instead.
+        if (
+            original_period == "this_month"
+            and result.get("income", 0) == 0
+            and result.get("expenses", 0) == 0
+            and result.get("savings_contributions", 0) == 0
+        ):
+            if _today.month == 1:
+                last_month_period = f"{_today.year - 1}-12"
+            else:
+                last_month_period = f"{_today.year}-{_today.month - 1:02d}"
+            last_result = _summary(last_month_period)
+            if (
+                last_result.get("income", 0) != 0
+                or last_result.get("expenses", 0) != 0
+                or last_result.get("savings_contributions", 0) != 0
+            ):
+                last_result["period_label"] = "Last Month"
+                return JSONResponse(last_result)
+        result["period_label"] = "This Month"
         return JSONResponse(result)
     except Exception as exc:  # pragma: no cover
         return JSONResponse({"error": str(exc)}, status_code=500)
@@ -1639,6 +1666,19 @@ def ledgers_get(request: Request, period: str = "this_month"):
         period = "this_month"
     uid = _current_user_id(request)
     ledgers = _get_ledgers(uid, with_drilldown=True, period=period)
+    # Auto-fallback: if this_month has no data, silently show last_month instead.
+    if period == "this_month" and all(
+        sum(li["total"] for li in ldr["line_items"]) == 0 for ldr in ledgers
+    ):
+        from datetime import date as _lm_date
+        _lm_today = _lm_date.today()
+        fallback_ledgers = _get_ledgers(uid, with_drilldown=True, period="last_month")
+        if any(
+            sum(li["total"] for li in ldr["line_items"]) != 0
+            for ldr in fallback_ledgers
+        ):
+            ledgers = fallback_ledgers
+            period = "last_month"
     return templates.TemplateResponse(
         request,
         "ledgers.html",

--- a/ui/templates/dashboard.html
+++ b/ui/templates/dashboard.html
@@ -106,7 +106,7 @@
   </section>
 
   <section id="savings-summary-section">
-    <h2>Overall Savings</h2>
+    <h2>Overall Savings <span id="savings-period-label" style="font-size:0.6em;font-weight:400;color:#92400e;vertical-align:middle;"></span></h2>
     <div id="savings-cards" style="display:flex;gap:1em;flex-wrap:wrap;margin-top:0.75em;">
       <div class="alert alert-info" id="savings-loading">Loading savings data&#x2026;</div>
     </div>
@@ -162,6 +162,10 @@
           container.innerHTML = '<div class="alert alert-error">&#x26A0;&#xFE0F; ' + d.error + '</div>';
           return;
         }
+        // Show period label (server returns 'Last Month' when falling back)
+        var periodLabel = d.period_label || 'This Month';
+        var labelEl = document.getElementById('savings-period-label');
+        if (labelEl) labelEl.textContent = '(' + periodLabel + ')';
 
         var totalSaved = d.total_saved || 0;
         var contributions = d.savings_contributions || 0;

--- a/ui/templates/ledgers.html
+++ b/ui/templates/ledgers.html
@@ -241,12 +241,10 @@
             <span class="total-label">Expenses (excl. savings):</span>
             <span class="total-value" data-total="expenses">C${{ "%.2f"|format(ledger.totals.expenses) }}</span>
           </span>
-          {% if ledger.totals.savings > 0 %}
           <span>
             <span class="total-label">Savings &amp; investments:</span>
-            <span class="total-value" data-total="savings" style="color:#d97706">C${{ "%.2f"|format(ledger.totals.savings) }}</span>
+            <span class="total-value" data-total="savings" style="color:#d97706">C${{ "%.2f"|format(ledger.totals.savings | default(0)) }}</span>
           </span>
-          {% endif %}
           <span>
             <span class="total-label">Net (income − expenses):</span>
             <span class="total-value {% if ledger.totals.net > 0 %}net-positive{% elif ledger.totals.net < 0 %}net-negative{% else %}net-zero{% endif %}"


### PR DESCRIPTION
## Summary

Fixes two bugs affecting users on month boundaries (e.g. June 1st when all transactions are in May).

---

## Bug 1 — Dashboard shows $0 savings on month boundary

**Root cause:** `/api/summary?period=this_month` returned all zeros because it's June 1st with no June transactions yet. The dashboard JS blindly rendered those zeros.

**Fix:**
- **`ui/server.py` `api_summary()`**: When `period=this_month` and all values (income, expenses, savings_contributions) are zero, automatically fetch `last_month` data. If last month has data, return it with a `period_label: "Last Month"` field in the JSON.
- **`ui/server.py` `ledgers_get()`**: Same fallback — if `this_month` ledger totals are all zero, silently switch to `last_month` so the ledger page shows real data.
- **`ui/templates/dashboard.html`**: Read `data.period_label` from the API response and show a `(Last Month)` badge next to the savings heading so users know which period they're seeing.

---

## Bug 2 — Ledgers savings footer row conditionally hidden / test failure

**Root cause:** The ledgers template used `{% if ledger.totals.savings > 0 %}` to conditionally render the savings row in the totals footer. When there are no savings transactions (e.g. fresh DB), the element `[data-total="savings"]` didn't exist in the DOM — breaking JS selectors and causing `test_ledgers_savings_totals_in_footer` to fail.

(Historical note: this conditional was added as part of the savings feature. The original 500 error from `UndefinedError: 'dict object' has no attribute 'savings'` was fixed in #315, but the conditional guard was left too aggressive.)

**Fix:** Remove the conditional. Always render the savings footer row, using `| default(0)` on the value so it gracefully shows C$0.00 when there are no savings transactions.

---

## Test results

- ✅ All 39 UI Playwright tests pass (previously 1 failing: `test_ledgers_savings_totals_in_footer`)
- ✅ 944 non-UI unit tests pass (5 pre-existing failures in `test_savings_rate` and `test_transfer_detection` — unrelated to this PR)
- ✅ End-to-end verified with production DB copy:
  - Dashboard shows May 2026 data (C$16,688.78 net, 47.8% rate) with `(Last Month)` label
  - Ledgers page auto-selects `last_month` period and shows real transaction totals
  - Savings footer row always visible in ledger totals