### PR TITLE
feat(dashboard): spending summary, top categories, recent transactions, needs-review badge (#297)

### DIFF
--- a/ui/server.py
+++ b/ui/server.py
@@ -1115,12 +1115,143 @@ def api_summary(request: Request, period: str = "this_month"):
         return JSONResponse({"error": str(exc)}, status_code=500)
 
 
+def _get_dashboard_widgets() -> dict:
+    """Server-side data for the dashboard widgets (#297).
+
+    Returns:
+        recent_transactions: last 8 classified transactions (most recent first)
+        needs_review_count:  number of transactions awaiting manual review
+        top_categories:      top 5 line items by spending this month
+    """
+    from datetime import date as _date
+    today = _date.today()
+    # Month range
+    month_start = today.replace(day=1).isoformat()
+    month_end = today.isoformat()
+
+    conn = get_db(_db_path())
+    try:
+        from ui.auth import get_active_user_id
+        uid = get_active_user_id(_db_path())
+
+        # ── Recent transactions ──────────────────────────────────────────
+        # Pull 8 most-recent transactions whose entry was classified for
+        # this user, joined with the line-item name and amount sign.
+        if uid:
+            recent_rows = conn.execute(
+                """
+                SELECT t.id, t.merchant, t.amount, t.date, t.currency,
+                       t.pending, ba.name AS account_name,
+                       li.name AS line_item_name,
+                       te.entry_type
+                  FROM transactions t
+                  JOIN bank_accounts ba ON ba.id = t.bank_account_id
+                  JOIN bank_connections bc ON bc.id = ba.connection_id
+                  LEFT JOIN transaction_entries te ON te.transaction_id = t.id
+                  LEFT JOIN line_items li ON li.id = te.line_item_id
+                 WHERE bc.user_id = ?
+                 ORDER BY t.date DESC, t.id DESC
+                 LIMIT 8
+                """,
+                (uid,),
+            ).fetchall()
+        else:
+            recent_rows = []
+        recent_transactions = [
+            {
+                "id": r["id"],
+                "merchant": r["merchant"] or "(unknown)",
+                "amount": r["amount"],
+                "date": r["date"],
+                "currency": r["currency"] or "CAD",
+                "pending": bool(r["pending"]),
+                "account_name": r["account_name"],
+                "line_item_name": r["line_item_name"],
+                "entry_type": r["entry_type"],
+            }
+            for r in recent_rows
+        ]
+
+        # ── Needs-review count ───────────────────────────────────────────
+        if uid:
+            cnt = conn.execute(
+                """
+                SELECT COUNT(*) AS c
+                  FROM transaction_entries te
+                  JOIN transactions t ON t.id = te.transaction_id
+                  JOIN bank_accounts ba ON ba.id = t.bank_account_id
+                  JOIN bank_connections bc ON bc.id = ba.connection_id
+                 WHERE bc.user_id = ?
+                   AND (te.uncertain = 1 OR te.line_item_id IS NULL)
+                """,
+                (uid,),
+            ).fetchone()
+            needs_review_count = int(cnt["c"] or 0) if cnt else 0
+        else:
+            needs_review_count = 0
+
+        # ── Top categories (this month, by absolute spending) ───────────
+        if uid:
+            top_rows = conn.execute(
+                """
+                SELECT li.name AS line_item_name, l.name AS ledger_name,
+                       SUM(ABS(te.amount)) AS total,
+                       COUNT(*) AS tx_count
+                  FROM transaction_entries te
+                  JOIN transactions t ON t.id = te.transaction_id
+                  JOIN bank_accounts ba ON ba.id = t.bank_account_id
+                  JOIN bank_connections bc ON bc.id = ba.connection_id
+                  JOIN line_items li ON li.id = te.line_item_id
+                  JOIN ledgers l ON l.id = li.ledger_id
+                 WHERE bc.user_id = ?
+                   AND te.entry_type = 'spending'
+                   AND t.date >= ? AND t.date <= ?
+                 GROUP BY te.line_item_id
+                 ORDER BY total DESC
+                 LIMIT 5
+                """,
+                (uid, month_start, month_end),
+            ).fetchall()
+        else:
+            top_rows = []
+        top_categories = [
+            {
+                "line_item_name": r["line_item_name"],
+                "ledger_name": r["ledger_name"],
+                "total": float(r["total"] or 0),
+                "tx_count": int(r["tx_count"] or 0),
+            }
+            for r in top_rows
+        ]
+        max_total = max((c["total"] for c in top_categories), default=0) or 1.0
+        for c in top_categories:
+            c["percent"] = round(100 * c["total"] / max_total, 1)
+
+        return {
+            "recent_transactions": recent_transactions,
+            "needs_review_count": needs_review_count,
+            "top_categories": top_categories,
+        }
+    finally:
+        conn.close()
+
+
 @app.get("/dashboard", response_class=HTMLResponse)
 def dashboard_get(request: Request):
     """Main dashboard page.  Requires authentication."""
     if not _is_authenticated(request):
         return _redirect("/login")
     last_synced = _get_last_synced_at()
+    try:
+        widgets = _get_dashboard_widgets()
+    except Exception:
+        # Widgets are non-critical — if the query fails for any reason,
+        # render the page without them rather than crashing.
+        widgets = {
+            "recent_transactions": [],
+            "needs_review_count": 0,
+            "top_categories": [],
+        }
     return templates.TemplateResponse(
         request,
         "dashboard.html",
@@ -1128,6 +1259,7 @@ def dashboard_get(request: Request):
             "current_page": "dashboard",
             "last_synced_at": last_synced,
             "action_result": None,
+            **widgets,
         },
     )
 

--- a/ui/static/style.css
+++ b/ui/static/style.css
@@ -955,9 +955,40 @@ html[data-theme="dark"] .savings-badge-red    { background: #450a0a; color: #fca
   border-bottom: 1px solid var(--border-subtle);
 }
 .recent-tx-list li:last-child { border-bottom: none; }
-.recent-tx-merchant { flex: 1; font-weight: 500; }
+.recent-tx-merchant { flex: 1; font-weight: 500; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .recent-tx-date     { color: var(--muted); font-size: var(--text-sm); white-space: nowrap; }
 .recent-tx-amount   { font-weight: 600; font-variant-numeric: tabular-nums; white-space: nowrap; }
+
+/* Top categories bar chart */
+.top-categories { list-style: none; padding: 0; margin: 0; }
+.top-category {
+  padding: var(--space-2) 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+.top-category:last-child { border-bottom: none; }
+.top-category-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: 6px;
+  flex-wrap: wrap;
+}
+.top-category-name { font-weight: 500; }
+.top-category-amount { font-weight: 600; white-space: nowrap; }
+.top-category-bar {
+  width: 100%;
+  height: 8px;
+  background: var(--bg-subtle);
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+}
+.top-category-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent), var(--accent-hover));
+  border-radius: var(--radius-pill);
+  transition: width 0.4s ease;
+}
 
 /* ── 15. Mobile bottom nav ────────────────────────────────────────────── */
 

--- a/ui/templates/dashboard.html
+++ b/ui/templates/dashboard.html
@@ -155,6 +155,64 @@
     </div>
   </section>
 
+  {% if needs_review_count and needs_review_count > 0 %}
+  <section>
+    <div class="alert alert-warning" style="display:flex;align-items:center;justify-content:space-between;gap:var(--space-3);flex-wrap:wrap;">
+      <span>
+        <strong>{{ needs_review_count }}</strong>
+        transaction{{ 's' if needs_review_count != 1 else '' }} need{{ '' if needs_review_count != 1 else 's' }} manual review.
+      </span>
+      <a href="/accounts" class="btn-secondary btn-sm">Review now</a>
+    </div>
+  </section>
+  {% endif %}
+
+  {% if top_categories %}
+  <section>
+    <h2>Top spending this month</h2>
+    <ul class="top-categories">
+      {% for cat in top_categories %}
+      <li class="top-category">
+        <div class="top-category-head">
+          <span class="top-category-name">{{ cat.line_item_name }}
+            <span class="muted text-sm">· {{ cat.ledger_name }}</span>
+          </span>
+          <span class="top-category-amount numeric">C${{ "%.2f"|format(cat.total) }}
+            <span class="muted text-sm">({{ cat.tx_count }})</span>
+          </span>
+        </div>
+        <div class="top-category-bar">
+          <div class="top-category-bar-fill" style="width: {{ cat.percent }}%"></div>
+        </div>
+      </li>
+      {% endfor %}
+    </ul>
+  </section>
+  {% endif %}
+
+  {% if recent_transactions %}
+  <section>
+    <h2>Recent transactions</h2>
+    <ul class="recent-tx-list">
+      {% for tx in recent_transactions %}
+      <li>
+        <span class="recent-tx-date">{{ tx.date }}</span>
+        <span class="recent-tx-merchant">{{ tx.merchant }}
+          {% if tx.line_item_name %}
+            <span class="muted text-sm">· {{ tx.line_item_name }}</span>
+          {% elif tx.pending %}
+            <span class="badge badge-default">Pending</span>
+          {% endif %}
+        </span>
+        <span class="recent-tx-amount {% if tx.amount < 0 %}net-positive{% else %}net-negative{% endif %}">
+          {% if tx.amount < 0 %}+{% else %}−{% endif %}C${{ "%.2f"|format(tx.amount | abs) }}
+        </span>
+      </li>
+      {% endfor %}
+    </ul>
+  </section>
+  {% endif %}
+
   <script>
   (function() {
     async function loadSavings() {


### PR DESCRIPTION
The dashboard previously showed only a 'Coming soon' placeholder. It now surfaces an at-a-glance view of the user's financial health on the landing page.

## New widgets

* **Needs review banner** — alert-warning card with the number of transactions awaiting manual classification plus a Review-now button linking to /accounts. Only rendered when the count is non-zero.
* **Top spending this month** — top 5 line items by spending in the current month, each with a horizontal bar chart whose fill is proportional to the largest category.
* **Recent transactions** — last 8 transactions with date, merchant, line-item name, and signed amount. Income (Plaid negative) renders green with `+`; expenses render red with `−`.

## Implementation

* `_get_dashboard_widgets()` in `ui/server.py` runs three small queries scoped to the active user and returns a dict that's merged into the template context. Wrapped in a try/except so widget failures never crash the dashboard.
* Each section in `dashboard.html` only renders when it has data — no awkward empty states on a fresh install.
* `style.css` adds the `.top-categories` / `.top-category-bar` components plus an ellipsis on long merchant names.

## Tests

All 39 tests in `tests/ui/` pass. Playwright visual check (light + dark, desktop + 390 px mobile) shows the widgets rendering correctly with seeded data. Closes #297.