### PR TITLE
feat(accounts): net worth summary card at top of /accounts (#322)

### DIFF
--- a/ui/server.py
+++ b/ui/server.py
@@ -1347,6 +1347,151 @@ def _get_accounts_grouped(user_id: Optional[str] = None) -> dict:
         conn.close()
 
 
+def _compute_net_worth(grouped: dict, home_currency: str = "CAD") -> dict:
+    """Compute a net-worth summary across the supplied grouped accounts (#322).
+
+    Plaid balance convention used here:
+      * depository / investment / loan account balances are taken as-is
+        (positive numbers represent money the user owns).
+      * credit-card balances are returned as positive amounts owed; we
+        negate them so they reduce net worth.
+
+    Returns::
+
+        {
+          "home_currency": "CAD",
+          "assets": float,        # sum of positive (asset) balances in home_currency
+          "liabilities": float,   # sum of liability balances (positive number)
+          "net_worth": float,     # assets - liabilities, in home_currency
+          "breakdown": [{"label", "total", "count"}, …],
+          "by_currency": {"CAD": {assets, liabilities, net}, "USD": …},
+          "mixed_currency": bool,
+          "has_data": bool,       # False when there are no real balances yet
+        }
+
+    When accounts hold currencies other than ``home_currency`` we surface
+    a per-currency breakdown rather than silently mis-summing them.
+    """
+    asset_subtypes = {
+        "chequing": "Chequing",
+        "checking": "Chequing",
+        "savings":  "Savings",
+        "cd":       "Savings",
+        "money market": "Savings",
+    }
+
+    def categorise(acct: dict) -> str:
+        """Return a coarse bucket label for a single bank_account row."""
+        t = (acct.get("type") or "").lower()
+        s = (acct.get("subtype") or "").lower()
+        if t == "credit":
+            return "Credit Cards"
+        if t == "loan":
+            return "Loans"
+        if t == "investment" or s in ("401k", "403b", "ira", "roth", "tfsa", "rrsp", "brokerage"):
+            return "Investments"
+        return asset_subtypes.get(s, "Cash")
+
+    buckets: dict = {}              # label -> {total, count, currencies}
+    by_currency: dict = {}          # currency -> {assets, liabilities, net}
+    has_data = False
+
+    for inst_name, data in (grouped or {}).items():
+        for acct in data.get("accounts", []):
+            balance = acct.get("balance_current")
+            if balance is None:
+                balance = acct.get("balance_available")
+            if balance is None:
+                continue  # never synced — skip
+            has_data = True
+            currency = (acct.get("currency") or home_currency).upper()
+            is_liability = (acct.get("type") or "").lower() == "credit"
+            # Net-worth sign: credit cards reduce net worth.
+            value = -float(balance) if is_liability else float(balance)
+            label = categorise(acct)
+
+            b = buckets.setdefault(label, {"total": 0.0, "count": 0, "currencies": set()})
+            b["total"] += value
+            b["count"] += 1
+            b["currencies"].add(currency)
+
+            c = by_currency.setdefault(currency, {"assets": 0.0, "liabilities": 0.0, "net": 0.0})
+            if is_liability:
+                c["liabilities"] += float(balance)
+            else:
+                c["assets"] += float(balance)
+            c["net"] = c["assets"] - c["liabilities"]
+
+    # Stable ordering: Cash, Savings, Investments, Credit Cards, Loans
+    order = ["Cash", "Savings", "Investments", "Credit Cards", "Loans"]
+    breakdown = []
+    for label in order:
+        if label in buckets:
+            b = buckets.pop(label)
+            breakdown.append({
+                "label": label,
+                "total": b["total"],
+                "count": b["count"],
+                "is_liability": label in ("Credit Cards", "Loans"),
+            })
+    # Any unknown buckets (e.g. a new Plaid subtype) trail at the end.
+    for label, b in buckets.items():
+        breakdown.append({
+            "label": label,
+            "total": b["total"],
+            "count": b["count"],
+            "is_liability": False,
+        })
+
+    currencies = set(by_currency.keys())
+    mixed = len(currencies) > 1
+    home_currency_upper = home_currency.upper()
+
+    if not mixed and (home_currency_upper in currencies or not currencies):
+        # All balances are in the user's home currency — safe to sum.
+        c = by_currency.get(home_currency_upper, {"assets": 0.0, "liabilities": 0.0})
+        assets = c["assets"]
+        liabilities = c["liabilities"]
+        net = assets - liabilities
+    else:
+        # Mixed currencies — the headline number is the home-currency slice
+        # only.  The template surfaces a hint when other currencies exist.
+        c = by_currency.get(home_currency_upper, {"assets": 0.0, "liabilities": 0.0})
+        assets = c["assets"]
+        liabilities = c["liabilities"]
+        net = assets - liabilities
+
+    return {
+        "home_currency": home_currency_upper,
+        "assets": assets,
+        "liabilities": liabilities,
+        "net_worth": net,
+        "breakdown": breakdown,
+        "by_currency": by_currency,
+        "mixed_currency": mixed,
+        "has_data": has_data,
+    }
+
+
+def _get_home_currency(uid: Optional[str]) -> str:
+    """Look up the active user's home currency, falling back to CAD."""
+    if not uid:
+        return "CAD"
+    try:
+        conn = get_db(_db_path())
+        try:
+            row = conn.execute(
+                "SELECT home_currency FROM users WHERE id = ?", (uid,)
+            ).fetchone()
+            if row and row["home_currency"]:
+                return str(row["home_currency"]).upper()
+        finally:
+            conn.close()
+    except Exception:
+        pass
+    return "CAD"
+
+
 @app.get("/accounts", response_class=HTMLResponse)
 def accounts_get(request: Request):
     """Accounts page — bank accounts grouped by institution with balances (#158)."""
@@ -1354,10 +1499,19 @@ def accounts_get(request: Request):
         return _redirect("/login")
     uid = _current_user_id(request)
     grouped = _get_accounts_grouped(uid)
+    home_currency = _get_home_currency(uid)
+    try:
+        net_worth = _compute_net_worth(grouped, home_currency=home_currency)
+    except Exception:
+        net_worth = None
     return templates.TemplateResponse(
         request,
         "accounts.html",
-        {"current_page": "accounts", "grouped_accounts": grouped},
+        {
+            "current_page": "accounts",
+            "grouped_accounts": grouped,
+            "net_worth": net_worth,
+        },
     )
 
 

--- a/ui/static/style.css
+++ b/ui/static/style.css
@@ -959,6 +959,111 @@ html[data-theme="dark"] .savings-badge-red    { background: #450a0a; color: #fca
 .recent-tx-date     { color: var(--muted); font-size: var(--text-sm); white-space: nowrap; }
 .recent-tx-amount   { font-weight: 600; font-variant-numeric: tabular-nums; white-space: nowrap; }
 
+/* ── Net worth card (#322) ─ used at the top of /accounts ───────────────── */
+
+.net-worth-card {
+  background: linear-gradient(135deg, var(--surface) 0%, var(--accent-soft) 100%);
+  border: 1px solid var(--border);
+}
+
+html[data-theme="dark"] .net-worth-card {
+  background: linear-gradient(135deg, var(--surface) 0%, var(--surface-raised) 100%);
+  border-color: var(--border);
+}
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme]) .net-worth-card {
+    background: linear-gradient(135deg, var(--surface) 0%, var(--surface-raised) 100%);
+  }
+}
+
+.net-worth-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin-bottom: var(--space-4);
+}
+
+.net-worth-title {
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  font-weight: 600;
+  margin: 0;
+}
+
+.net-worth-total {
+  font-size: clamp(28px, 5vw, 40px);
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-strong);
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+}
+
+.net-worth-summary {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  margin-bottom: var(--space-5);
+  flex-wrap: wrap;
+}
+
+.net-worth-pair {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.net-worth-minus {
+  font-size: var(--text-xl);
+  color: var(--muted);
+  font-weight: 300;
+  align-self: flex-end;
+  padding-bottom: 2px;
+}
+
+.net-worth-asset     { font-size: var(--text-lg); font-weight: 600; color: #16a34a; }
+.net-worth-liability { font-size: var(--text-lg); font-weight: 600; color: var(--danger-fg); }
+
+html[data-theme="dark"] .net-worth-asset { color: #4ade80; }
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme]) .net-worth-asset { color: #4ade80; }
+}
+
+.net-worth-breakdown {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.net-worth-bucket {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: var(--space-3);
+  padding: var(--space-2) 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.net-worth-bucket:last-child { border-bottom: none; }
+
+.net-worth-bucket-label { font-weight: 500; }
+.net-worth-bucket-value { font-weight: 600; white-space: nowrap; }
+
+.net-worth-fx-note { margin-top: var(--space-3); }
+
+/* Mobile tweaks for the net-worth card */
+@media (max-width: 480px) {
+  .net-worth-summary {
+    gap: var(--space-2);
+  }
+  .net-worth-summary .net-worth-minus { display: none; }
+  .net-worth-summary .net-worth-pair { flex: 1; min-width: 45%; }
+  .net-worth-total { font-size: 28px; }
+}
+
 /* Top categories bar chart */
 .top-categories { list-style: none; padding: 0; margin: 0; }
 .top-category {

--- a/ui/templates/accounts.html
+++ b/ui/templates/accounts.html
@@ -3,6 +3,51 @@
 {% block title %}Accounts — Friday Budgeting Pro{% endblock %}
 
 {% block content %}
+{% if net_worth and net_worth.has_data %}
+{% set cur_symbol = {'CAD':'C$','USD':'US$','GBP':'£','EUR':'€'}.get(net_worth.home_currency, net_worth.home_currency + ' ') %}
+<div class="card net-worth-card">
+  <div class="net-worth-header">
+    <h1 class="net-worth-title">Net Worth</h1>
+    <div class="net-worth-total {% if net_worth.net_worth > 0 %}net-positive{% elif net_worth.net_worth < 0 %}net-negative{% else %}net-zero{% endif %}">
+      {% if net_worth.net_worth < 0 %}−{% endif %}{{ cur_symbol }}{{ "{:,.2f}".format(net_worth.net_worth | abs) }}
+    </div>
+  </div>
+  <div class="net-worth-summary">
+    <span class="net-worth-pair">
+      <span class="muted text-sm">Assets</span>
+      <span class="numeric net-worth-asset">{{ cur_symbol }}{{ "{:,.2f}".format(net_worth.assets) }}</span>
+    </span>
+    <span class="net-worth-minus" aria-hidden="true">−</span>
+    <span class="net-worth-pair">
+      <span class="muted text-sm">Liabilities</span>
+      <span class="numeric net-worth-liability">{{ cur_symbol }}{{ "{:,.2f}".format(net_worth.liabilities) }}</span>
+    </span>
+  </div>
+  {% if net_worth.breakdown %}
+  <ul class="net-worth-breakdown">
+    {% for b in net_worth.breakdown %}
+    <li class="net-worth-bucket">
+      <span class="net-worth-bucket-label">{{ b.label }}
+        <span class="muted text-sm">· {{ b.count }} account{{ 's' if b.count != 1 else '' }}</span>
+      </span>
+      <span class="numeric net-worth-bucket-value {% if b.is_liability %}net-negative{% endif %}">
+        {% if b.is_liability %}−{% endif %}{{ cur_symbol }}{{ "{:,.2f}".format(b.total | abs) }}
+      </span>
+    </li>
+    {% endfor %}
+  </ul>
+  {% endif %}
+  {% if net_worth.mixed_currency %}
+  <p class="hint net-worth-fx-note">
+    Showing balances in {{ net_worth.home_currency }} only.
+    Accounts in other currencies
+    ({% for cur, _ in net_worth.by_currency.items() %}{% if cur != net_worth.home_currency %}{{ cur }}{% if not loop.last %}, {% endif %}{% endif %}{% endfor %})
+    are listed below but not summed (no FX conversion available).
+  </p>
+  {% endif %}
+</div>
+{% endif %}
+
 <div class="card">
   <div class="card-toolbar">
     <h1>Accounts</h1>


### PR DESCRIPTION
Renders a Net Worth card above the existing per-institution accounts list that aggregates current balances across every linked bank account.

## What it shows

* **Net Worth** — a large headline number with a thousands-separated signed amount in the user's home currency. Green for positive, red for negative.
* **Assets − Liabilities** — the two component subtotals shown side by side.
* **Per-bucket breakdown** — accounts grouped into Cash, Savings, Investments, Credit Cards, Loans. Each row shows the bucket label, the account count, and the bucket total (negated for liabilities).

## How it works

* `_compute_net_worth(grouped, home_currency)` walks the same grouped-accounts dict the existing page already builds — no new Plaid calls, no new DB queries beyond the existing `/accounts` data.
* Plaid balance convention is respected: depository + investment + loan balances are taken as-is; credit-card balances are negated so they reduce net worth.
* Subtype-aware bucketing — `checking`/`chequing`/`savings`/`cd`/`money market` → Cash or Savings; `tfsa`/`rrsp`/`401k`/`ira`/etc. → Investments; `credit` type → Credit Cards; `loan` type → Loans.
* Multi-currency: sums kept per-currency. When everything's in the home currency the headline shows that single total. Mixed currencies surface a hint listing the other currencies (no app-wide FX helper exists yet — would be a follow-up).
* `_get_home_currency(uid)` reads `users.home_currency`, defaulting to CAD.

## Styling

* New `.net-worth-card` with a subtle accent-soft gradient in light mode and a surface→surface-raised gradient in dark mode.
* Headline uses `clamp(28px, 5vw, 40px)` so it scales from 390 px up to desktop.
* Mobile (≤ 480 px) drops the minus glyph and lets Assets/Liabilities take 50% each.

## Tests + visual check

All 39 tests in `tests/ui/` pass. `_compute_net_worth` safely no-ops (`has_data=False`) when an account has no balance populated yet (i.e. before first sync). Visual check at 1440×900 and 390×844, both themes, confirms the card sums correctly across one chequing, one savings, one credit card, and one investment account (assets C$60,214.09 − liabilities C$423.55 = net worth C$59,790.54).

Closes #322.