### PR TITLE
fix: delete transaction_entries before removing transactions on sync

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -2490,6 +2490,17 @@ def sync(classify: bool = True, progress_callback=None) -> dict:
                         # --- Removed transactions ---
                         for txn in removed_txns:
                             plaid_txn_id = _get(txn, "transaction_id")
+                            # Delete child rows first to satisfy FK constraints.
+                            # transaction_entries.transaction_id has no ON DELETE CASCADE,
+                            # so we must remove entries before deleting the parent row.
+                            # suspicious_transactions has ON DELETE CASCADE and will be
+                            # cleaned up automatically.
+                            db_conn.execute(
+                                "DELETE FROM transaction_entries WHERE transaction_id = ("
+                                "  SELECT id FROM transactions WHERE plaid_transaction_id = ?"
+                                ")",
+                                (plaid_txn_id,),
+                            )
                             db_conn.execute(
                                 "DELETE FROM transactions WHERE plaid_transaction_id = ?",
                                 (plaid_txn_id,),


### PR DESCRIPTION
## Problem

When Plaid marks a transaction as removed (e.g. a pending transaction that settled or was reversed), the sync loop attempted to `DELETE` directly from the `transactions` table.

This violated the foreign key constraint on `transaction_entries.transaction_id`, which has **no `ON DELETE CASCADE`**, causing:

```
sqlite3.IntegrityError: FOREIGN KEY constraint failed
  File "server/main.py", line 2494, in <module>
    DELETE FROM transactions WHERE plaid_transaction_id = ?
```

## Root Cause

The `transactions` table has child rows in `transaction_entries` referencing it via FK. SQLite enforces FK constraints (when enabled), so deleting a parent row without first removing its children raises an integrity error. The `suspicious_transactions` table already has `ON DELETE CASCADE`, so only `transaction_entries` needed explicit handling.

## Fix

Before deleting from `transactions`, explicitly delete matching rows from `transaction_entries` using a subquery on `plaid_transaction_id`:

```sql
DELETE FROM transaction_entries
WHERE transaction_id IN (
    SELECT id FROM transactions WHERE plaid_transaction_id = ?
);
DELETE FROM transactions WHERE plaid_transaction_id = ?;
```

This ensures the FK constraint is satisfied and the sync loop can cleanly remove Plaid-removed transactions without crashing.