### PR TITLE
feat(accounts): replace large account buttons with compact clickable-row list

### DIFF
--- a/ui/static/style.css
+++ b/ui/static/style.css
@@ -718,12 +718,120 @@ html[data-theme="dark"] .net-negative { color: #f87171; }
   margin-left: var(--space-2);
 }
 
-/* Account-table specifics */
+/* Account-table specifics (legacy, kept for compat) */
 .account-table .acct-mask    { color: var(--muted); font-size: var(--text-sm); margin-left: 4px; }
 .account-table .acct-type    { color: var(--muted); font-size: var(--text-sm); }
 .account-table .acct-balance { text-align: right; font-weight: 600; font-variant-numeric: tabular-nums; white-space: nowrap; }
 .account-table .acct-actions { text-align: right; white-space: nowrap; }
 .account-table .acct-actions .btn-sm { margin-left: 4px; }
+
+/* Compact account list (#329) */
+.acct-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+.acct-list-item {
+  border-bottom: 1px solid var(--border-subtle);
+}
+.acct-list-item:last-child { border-bottom: none; }
+
+/* The clickable account row (button) */
+.acct-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  background: var(--surface);
+  border: none;
+  border-radius: 0;
+  cursor: pointer;
+  text-align: left;
+  font-family: var(--font);
+  font-size: var(--text-md);
+  color: var(--text);
+  transition: background 0.12s;
+  min-height: var(--tap);
+}
+.acct-row:hover { background: var(--bg-subtle); }
+.acct-row[aria-expanded="true"] { background: var(--accent-soft); }
+
+.acct-row-main {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex: 1;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+.acct-row-right {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-shrink: 0;
+}
+
+.acct-row .acct-name {
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.acct-row .acct-mask {
+  color: var(--muted);
+  font-size: var(--text-sm);
+}
+.acct-type-pill {
+  display: inline-block;
+  padding: 1px 7px;
+  border-radius: var(--radius-pill);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  background: var(--bg-subtle);
+  border: 1px solid var(--border-subtle);
+  color: var(--muted);
+  text-transform: capitalize;
+  white-space: nowrap;
+}
+.acct-row .acct-balance {
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  color: var(--muted-strong);
+}
+.acct-chevron {
+  color: var(--muted);
+  font-size: var(--text-lg);
+  line-height: 1;
+  transition: transform 0.2s;
+}
+.acct-row[aria-expanded="true"] .acct-chevron { transform: rotate(90deg); }
+
+/* Expand panel */
+.acct-expand-panel {
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-subtle);
+}
+.acct-expand-panel[hidden] { display: none; }
+.acct-expand-inner {
+  padding: var(--space-3) var(--space-4);
+}
+.acct-expand-actions {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  margin-bottom: var(--space-2);
+}
+.acct-expand-inner .txn-expand-inner {
+  margin-top: var(--space-2);
+  border-top: 1px solid var(--border-subtle);
+  padding-top: var(--space-2);
+}
 
 /* On phones: convert the accounts table to a stacked card layout so the
    action buttons aren't clipped. */

--- a/ui/templates/accounts.html
+++ b/ui/templates/accounts.html
@@ -79,59 +79,43 @@
     {% if data.syncing and not data.accounts %}
     <p class="hint">⏳ Accounts will appear here once the initial sync completes…</p>
     {% else %}
-    <div class="table-scroll">
-      <table class="account-table">
-        <thead>
-          <tr>
-            <th>Account</th>
-            <th class="responsive-hide-sm">Type</th>
-            <th style="text-align:right">Balance</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for acct in data.accounts %}
-          <tr data-account-id="{{ acct.id }}">
-            <td>
-              <span class="acct-name" data-original="{{ acct.name or '' }}">{{ acct.name or '(unnamed)' }}</span>
-              {% if acct.mask %}
-              <span class="acct-mask">···{{ acct.mask }}</span>
-              {% endif %}
-            </td>
-            <td class="acct-type responsive-hide-sm">
-              {{ acct.subtype or acct.type or '—' }}
-            </td>
-            <td class="acct-balance">
+    {# Compact account list — each row clicks to reveal actions (#329) #}
+    <ul class="acct-list" role="list">
+      {% for acct in data.accounts %}
+      <li class="acct-list-item" data-account-id="{{ acct.id }}">
+        <button class="acct-row" aria-expanded="false" data-id="{{ acct.id }}" type="button">
+          <span class="acct-row-main">
+            <span class="acct-name" data-original="{{ acct.name or '' }}">{{ acct.name or '(unnamed)' }}</span>
+            {% if acct.mask %}<span class="acct-mask">···{{ acct.mask }}</span>{% endif %}
+            <span class="acct-type-pill">{{ acct.subtype or acct.type or '—' }}</span>
+          </span>
+          <span class="acct-row-right">
+            <span class="acct-balance">
               {% set balance = acct.balance_current if acct.balance_current is not none else acct.balance_available %}
               {% if balance is not none %}
                 {% set currency = acct.currency or 'CAD' %}
                 {# Credit cards: Plaid returns amount owed as positive — negate for display #}
                 {% set display_balance = -balance if acct.type == 'credit' else balance %}
-                {% if currency == 'CAD' %}C$
-                {% elif currency == 'USD' %}US$
-                {% elif currency == 'GBP' %}£
-                {% elif currency == 'EUR' %}€
-                {% else %}{{ currency }} {% endif %}{{ "%.2f"|format(display_balance) }}
+                {% if currency == 'CAD' %}C${% elif currency == 'USD' %}US${% elif currency == 'GBP' %}£{% elif currency == 'EUR' %}€{% else %}{{ currency }} {% endif %}{{ "%.2f"|format(display_balance) }}
               {% else %}
                 <span class="muted">—</span>
               {% endif %}
-            </td>
-            <td class="acct-actions">
-              <button class="btn-secondary btn-sm rename-btn" data-id="{{ acct.id }}">rename</button>
-              <button class="btn-secondary btn-sm txn-toggle-btn" data-id="{{ acct.id }}">transactions</button>
-            </td>
-          </tr>
-          <tr class="txn-expand-row" id="txn-expand-{{ acct.id }}" style="display:none">
-            <td colspan="4">
-              <div class="txn-expand-inner" id="txn-content-{{ acct.id }}">
-                <span class="muted text-sm">Loading…</span>
-              </div>
-            </td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
+            </span>
+            <span class="acct-chevron" aria-hidden="true">›</span>
+          </span>
+        </button>
+        <div class="acct-expand-panel" id="acct-expand-{{ acct.id }}" hidden>
+          <div class="acct-expand-inner">
+            <div class="acct-expand-actions">
+              <button class="btn-secondary btn-sm rename-btn" data-id="{{ acct.id }}" type="button">✎ Rename</button>
+              <button class="btn-secondary btn-sm txn-toggle-btn" data-id="{{ acct.id }}" type="button">↓ Transactions</button>
+            </div>
+            <div class="txn-expand-inner" id="txn-content-{{ acct.id }}" style="display:none"></div>
+          </div>
+        </div>
+      </li>
+      {% endfor %}
+    </ul>
     {% endif %}
     {% if data.hidden_count %}
     <p class="hint">
@@ -199,20 +183,43 @@ function buildTxnTable(txns) {
   </table></div>`;
 }
 
+// ── Account row expand/collapse (#329) ────────────────────────────────────
+document.querySelectorAll('.acct-row').forEach(rowBtn => {
+  rowBtn.addEventListener('click', function() {
+    const id      = rowBtn.dataset.id;
+    const panel   = document.getElementById('acct-expand-' + id);
+    const isOpen  = rowBtn.getAttribute('aria-expanded') === 'true';
+    // Close all other panels first
+    document.querySelectorAll('.acct-row[aria-expanded="true"]').forEach(other => {
+      if (other !== rowBtn) {
+        other.setAttribute('aria-expanded', 'false');
+        const otherId = other.dataset.id;
+        const otherPanel = document.getElementById('acct-expand-' + otherId);
+        if (otherPanel) otherPanel.hidden = true;
+      }
+    });
+    rowBtn.setAttribute('aria-expanded', !isOpen);
+    panel.hidden = isOpen;
+  });
+});
+
+// ── Transaction list toggle ───────────────────────────────────────────────
 document.querySelectorAll('.txn-toggle-btn').forEach(btn => {
   let loaded = false;
-  btn.addEventListener('click', async function() {
+  btn.addEventListener('click', async function(e) {
+    e.stopPropagation();
     const id      = btn.dataset.id;
-    const expRow  = document.getElementById('txn-expand-' + id);
     const content = document.getElementById('txn-content-' + id);
-    if (expRow.style.display !== 'none') {
-      expRow.style.display = 'none';
-      btn.textContent = 'transactions';
+    const isVisible = content.style.display !== 'none';
+    if (isVisible) {
+      content.style.display = 'none';
+      btn.textContent = '↓ Transactions';
       return;
     }
-    expRow.style.display = '';
-    btn.textContent = 'hide';
+    content.style.display = '';
+    btn.textContent = '↑ Hide';
     if (loaded) return;
+    content.innerHTML = '<span class="muted text-sm">Loading…</span>';
     try {
       const resp = await fetch('/accounts/' + id + '/transactions');
       const data = await resp.json();
@@ -226,10 +233,12 @@ document.querySelectorAll('.txn-toggle-btn').forEach(btn => {
 
 // ── Rename ───────────────────────────────────────────────────────────────
 document.querySelectorAll('.rename-btn').forEach(btn => {
-  btn.addEventListener('click', function handleRename() {
+  btn.addEventListener('click', function(e) {
+    e.stopPropagation();
     const id = btn.dataset.id;
-    const row = btn.closest('tr');
-    const nameSpan = row.querySelector('.acct-name');
+    const listItem = btn.closest('.acct-list-item');
+    const rowBtn   = listItem.querySelector('.acct-row');
+    const nameSpan = rowBtn.querySelector('.acct-name');
     const currentName = nameSpan.dataset.original || nameSpan.textContent.trim();
 
     if (btn.dataset.editing === '1') return;
@@ -241,7 +250,7 @@ document.querySelectorAll('.rename-btn').forEach(btn => {
     input.setAttribute('aria-label', 'Account name');
 
     nameSpan.replaceWith(input);
-    btn.textContent = 'cancel';
+    btn.textContent = '✕ Cancel';
     btn.dataset.editing = '1';
     input.focus();
     input.select();
@@ -254,7 +263,7 @@ document.querySelectorAll('.rename-btn').forEach(btn => {
       nameSpan.textContent = newName || currentName;
       nameSpan.dataset.original = newName || currentName;
       input.replaceWith(nameSpan);
-      btn.textContent = 'rename';
+      btn.textContent = '✎ Rename';
       delete btn.dataset.editing;
     };
 
@@ -268,22 +277,23 @@ document.querySelectorAll('.rename-btn').forEach(btn => {
           body: JSON.stringify({ name: newName })
         });
         if (resp.ok) restore(newName); else restore(currentName);
-      } catch (e) {
+      } catch (err) {
         restore(currentName);
       }
     };
 
-    input.addEventListener('keydown', e => {
-      if (e.key === 'Enter') { e.preventDefault(); save(); }
-      if (e.key === 'Escape') { restore(currentName); }
+    input.addEventListener('keydown', ev => {
+      if (ev.key === 'Enter') { ev.preventDefault(); save(); }
+      if (ev.key === 'Escape') { restore(currentName); }
     });
     input.addEventListener('blur', () => { if (!saved) save(); });
 
-    btn.addEventListener('click', () => {
+    btn.addEventListener('click', (ev) => {
+      ev.stopPropagation();
       if (btn.dataset.editing === '1') {
         saved = true;
         input.replaceWith(nameSpan);
-        btn.textContent = 'rename';
+        btn.textContent = '✎ Rename';
         delete btn.dataset.editing;
       }
     }, { once: true });


### PR DESCRIPTION
## Summary

Closes #329

Replaces the always-visible `rename` / `transactions` button columns in the accounts table with a compact, clickable-row list design. Each account is a button row that reveals an inline action panel on click — keeping the list clean at a glance while actions remain one tap away.

## Changes

**`ui/templates/accounts.html`**
- Replace `<div class="table-scroll"><table class="account-table">` per institution with `<ul class="acct-list"><li class="acct-list-item">`.
- Each `<li>` contains a full-width `<button class="acct-row">` showing: account name, mask, type pill, balance, and a `›` chevron that rotates 90° when expanded.
- Clicking a row toggles `aria-expanded` and shows `.acct-expand-panel` with **✎ Rename** and **↓ Transactions** buttons. Only one panel is open at a time (others auto-close).
- JS updated: row-expand handler, `txn-toggle-btn` and `rename-btn` use `stopPropagation` to avoid interfering with row-click.

**`ui/static/style.css`**
- Add `.acct-list`, `.acct-list-item`, `.acct-row`, `.acct-row-main`, `.acct-row-right`, `.acct-type-pill`, `.acct-chevron`, `.acct-expand-panel`, `.acct-expand-inner`, `.acct-expand-actions`.
- `.acct-row[aria-expanded="true"]` shows `var(--accent-soft)` background and rotates the chevron.
- Legacy `.account-table` styles kept for reference.