### PR TITLE
fix: reauth banner direct reconnect + Tailscale IP binding

### DIFF
--- a/server/daemon.py
+++ b/server/daemon.py
@@ -65,8 +65,8 @@ logging.basicConfig(
 log = logging.getLogger(__name__)
 
 _DEFAULT_HOST = os.environ.get(
-    "FRIDAY_BP_UI_HOST", "127.0.0.1"
-)  # localhost-only by default; override via FRIDAY_BP_UI_HOST
+    "FRIDAY_BP_UI_HOST", "0.0.0.0"
+)  # bind all interfaces by default so remote access (e.g. Tailscale) works; override via FRIDAY_BP_UI_HOST
 _DEFAULT_PORT = 6789
 
 

--- a/server/main.py
+++ b/server/main.py
@@ -453,7 +453,7 @@ def start_link(plaid_env: str | None = None) -> dict:
     resolved_env = plaid_env or db_env
     provider = PlaidProvider(env=resolved_env, client_id=db_client_id, secret=db_secret)
     link_token = provider.create_link_token()
-    return {"url": f"http://127.0.0.1:6789/link?token={link_token}", "plaid_env": provider.env}
+    return {"url": f"{_get_ui_base_url()}/link?token={link_token}", "plaid_env": provider.env}
 
 
 @mcp.tool
@@ -673,7 +673,7 @@ def refresh_connection(id: str) -> dict:
     """
     # For now, generate a fresh link token (same as start_link)
     link_token = _plaid.create_link_token()
-    return {"url": f"http://127.0.0.1:6789/link?token={link_token}"}
+    return {"url": f"{_get_ui_base_url()}/link?token={link_token}"}
 
 
 @mcp.tool
@@ -3893,13 +3893,7 @@ def reset_ui_password() -> dict:
     except Exception:
         pass
 
-    raw = os.environ.get("FRIDAY_BP_UI_PORT")
-    try:
-        port = int(raw) if raw is not None else 6789
-    except ValueError:
-        port = 6789
-
-    recovery_url = f"http://127.0.0.1:{port}/reset?t={token}"
+    recovery_url = f"{_get_ui_base_url()}/reset?t={token}"
     return {"status": "ok", "recovery_url": recovery_url}
 
 
@@ -4249,6 +4243,23 @@ def set_setting(key: str, value: str) -> dict:
 _VALID_PAGES = {"accounts", "ledgers", "profile", "dashboard"}
 
 
+def _get_ui_base_url() -> str:
+    """Return the public base URL for the UI (no trailing slash).
+
+    Prefers ``FRIDAY_BP_PUBLIC_URL`` from the environment (e.g. Tailscale IP)
+    over the localhost fallback so links work when accessed remotely.
+    """
+    public_url = os.environ.get("FRIDAY_BP_PUBLIC_URL", "").rstrip("/")
+    if public_url:
+        return public_url
+    raw = os.environ.get("FRIDAY_BP_UI_PORT")
+    try:
+        port = int(raw) if raw is not None else 6789
+    except ValueError:
+        port = 6789
+    return f"http://127.0.0.1:{port}"
+
+
 @mcp.tool
 def get_ui_url(page: str = None) -> dict:
     """Return the local UI URL, optionally deep-linked to a specific page.
@@ -4266,13 +4277,7 @@ def get_ui_url(page: str = None) -> dict:
     dict
         ``{"url": "http://127.0.0.1:<port>[/<page>]"}``
     """
-    raw = os.environ.get("FRIDAY_BP_UI_PORT")
-    try:
-        port = int(raw) if raw is not None else 6789
-    except ValueError:
-        port = 6789
-
-    base = f"http://127.0.0.1:{port}"
+    base = _get_ui_base_url()
 
     if page is None:
         return {"url": base}

--- a/ui/server.py
+++ b/ui/server.py
@@ -1260,7 +1260,7 @@ def dashboard_get(request: Request):
             "current_page": "dashboard",
             "last_synced_at": last_synced,
             "action_result": None,
-            "reauth_needed": _has_reauth_needed(uid),
+            "reauth_connections": _get_reauth_connections(uid),
             **widgets,
         },
     )
@@ -1513,7 +1513,7 @@ def accounts_get(request: Request):
             "current_page": "accounts",
             "grouped_accounts": grouped,
             "net_worth": net_worth,
-            "reauth_needed": _has_reauth_needed(uid),
+            "reauth_connections": _get_reauth_connections(uid),
         },
     )
 
@@ -1661,7 +1661,7 @@ def settings_get(request: Request):
             "timezones": _VALID_TIMEZONES,
             "saved": saved,
             "rules": rules,
-            "reauth_needed": _has_reauth_needed(uid),
+            "reauth_connections": _get_reauth_connections(uid),
         },
     )
 
@@ -1710,7 +1710,7 @@ async def settings_post(request: Request):
                 "timezones": _VALID_TIMEZONES,
                 "saved": False,
                 "error": " ".join(errors),
-                "reauth_needed": _has_reauth_needed(uid),
+                "reauth_connections": _get_reauth_connections(uid),
             },
         )
     conn = get_db(_db_path())
@@ -1774,18 +1774,25 @@ def _get_connections(user_id: Optional[str] = None) -> list[dict]:
 
 def _has_reauth_needed(user_id: Optional[str] = None) -> bool:
     """Return True if any bank connection for user_id has needs_reauth status."""
+    return bool(_get_reauth_connections(user_id))
+
+
+def _get_reauth_connections(user_id: Optional[str] = None) -> list[dict]:
+    """Return list of bank connections with needs_reauth status for the user."""
     db = get_db(_db_path())
     try:
         if user_id:
-            row = db.execute(
-                "SELECT 1 FROM bank_connections WHERE user_id = ? AND status = 'needs_reauth' LIMIT 1",
+            rows = db.execute(
+                "SELECT id, institution_name FROM bank_connections"
+                " WHERE user_id = ? AND status = 'needs_reauth'",
                 (user_id,),
-            ).fetchone()
+            ).fetchall()
         else:
-            row = db.execute(
-                "SELECT 1 FROM bank_connections WHERE status = 'needs_reauth' LIMIT 1",
-            ).fetchone()
-        return row is not None
+            rows = db.execute(
+                "SELECT id, institution_name FROM bank_connections"
+                " WHERE status = 'needs_reauth'"
+            ).fetchall()
+        return [dict(r) for r in rows]
     finally:
         db.close()
 
@@ -1837,7 +1844,7 @@ def profile_get(request: Request):
                 "connections": connections,
                 "accounts": accounts,
                 "action_result": None,
-                "reauth_needed": any(c.get("status") == "needs_reauth" for c in connections),
+                "reauth_connections": [c for c in connections if c.get("status") == "needs_reauth"],
             },
         )
     st = request.cookies.get(_SETUP_COMPLETE_COOKIE)
@@ -1865,7 +1872,7 @@ def profile_get(request: Request):
                 "connections": connections,
                 "accounts": accounts,
                 "action_result": None,
-                "reauth_needed": any(c.get("status") == "needs_reauth" for c in connections),
+                "reauth_connections": [c for c in connections if c.get("status") == "needs_reauth"],
             },
         )
         resp.set_cookie(SESSION_COOKIE, st, httponly=True, samesite="lax")
@@ -1963,7 +1970,7 @@ async def profile_post(request: Request):
                 "connections": connections,
                 "accounts": accounts,
                 "action_result": None,
-                "reauth_needed": any(c.get("status") == "needs_reauth" for c in connections),
+                "reauth_connections": [c for c in connections if c.get("status") == "needs_reauth"],
             },
         )
 
@@ -1977,7 +1984,7 @@ async def profile_post(request: Request):
             "connections": connections,
             "accounts": accounts,
             "action_result": action_result,
-            "reauth_needed": any(c.get("status") == "needs_reauth" for c in connections),
+            "reauth_connections": [c for c in connections if c.get("status") == "needs_reauth"],
         },
     )
 
@@ -2080,7 +2087,7 @@ def ledgers_get(request: Request, period: str = "this_month"):
     return templates.TemplateResponse(
         request,
         "ledgers.html",
-        {"current_page": "ledgers", "ledgers": ledgers, "period": period, "reauth_needed": _has_reauth_needed(uid)},
+        {"current_page": "ledgers", "ledgers": ledgers, "period": period, "reauth_connections": _get_reauth_connections(uid)},
     )
 
 

--- a/ui/templates/base.html
+++ b/ui/templates/base.html
@@ -82,10 +82,18 @@
     </div>
   </header>
 
-  {% if current_page and reauth_needed %}
+  {% if current_page and reauth_connections %}
   <div class="alert alert-warning reauth-banner" id="reauth-banner" role="alert">
-    ⚠️ One or more bank connections need to be re-authenticated.
-    <a href="/profile#linked-accounts">Fix on Profile →</a>
+    <span>⚠️ One or more bank connections need to be re-authenticated.</span>
+    <span class="reauth-banner-actions">
+      {% for conn in reauth_connections %}
+      <form method="post" action="/profile" style="display:inline">
+        <input type="hidden" name="action" value="reconnect_bank">
+        <input type="hidden" name="bank_id" value="{{ conn.id }}">
+        <button type="submit" class="btn-warning btn-sm">Reconnect {{ conn.institution_name or 'Bank' }} →</button>
+      </form>
+      {% endfor %}
+    </span>
     <button type="button" class="reauth-banner-dismiss" onclick="document.getElementById('reauth-banner').remove()" aria-label="Dismiss">✕</button>
   </div>
   {% endif %}


### PR DESCRIPTION
## Summary

Two UX/access fixes:

### Fix 1: Reauth Banner — One-Button Direct Plaid Flow

Previously the reauth banner just linked to `/profile#linked-accounts`, requiring extra navigation. Now:

- Added `_get_reauth_connections()` helper that returns a list of connections with `needs_reauth` status (id + institution_name)
- Replaced the `reauth_needed` bool with `reauth_connections` list in all 9 template context call sites in `ui/server.py`
- Updated `base.html` banner to render one inline form per broken connection with a **"Reconnect [Bank Name] →"** submit button that POSTs directly to `/profile` with `action=reconnect_bank` — no navigation detour needed

### Fix 2: Tailscale IP Instead of Localhost

Previously `get_ui_url()`, `start_link()`, `refresh_connection()`, and `reset_ui_password()` all returned `http://127.0.0.1:6789` which breaks when Ridvan accesses from another device on Tailscale VPN.

- Added `_get_ui_base_url()` helper in `server/main.py` that reads `FRIDAY_BP_PUBLIC_URL` from the environment first, falling back to `http://127.0.0.1:<port>`
- All URL-returning tools now use this helper
- Changed daemon default bind host from `127.0.0.1` → `0.0.0.0` so the server accepts connections from all interfaces
- `.env` already has `FRIDAY_BP_PUBLIC_URL=http://100.117.47.113:6789`

## Tests

All 50 relevant tests pass. The `test_list_ledgers` integration failure is pre-existing (unrelated `_register_openclaw_cron` attribute error).