### PR TITLE
fix: load .env in server/main.py so MCP tools see FRIDAY_BP_PUBLIC_URL

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -10,6 +10,15 @@ from __future__ import annotations
 import json as _json
 import logging
 import os
+
+# Load .env early so FRIDAY_BP_PUBLIC_URL and other settings are available
+# when tools are called via the MCP framework (which doesn't go through daemon.py).
+try:
+    from pathlib import Path as _Path
+    from dotenv import load_dotenv as _load_dotenv
+    _load_dotenv(_Path(__file__).parent.parent / ".env")
+except ImportError:
+    pass
 import secrets
 import subprocess as _subprocess
 import tempfile

--- a/tests/test_get_ui_url.py
+++ b/tests/test_get_ui_url.py
@@ -13,41 +13,67 @@ class TestGetUiUrl:
     def test_no_args_returns_base_url(self, monkeypatch):
         """Calling get_ui_url() with no args returns the base URL on default port."""
         monkeypatch.delenv("FRIDAY_BP_UI_PORT", raising=False)
+        monkeypatch.delenv("FRIDAY_BP_PUBLIC_URL", raising=False)
         result = get_ui_url()
         assert result == {"url": "http://127.0.0.1:6789"}
 
     def test_no_args_respects_env_port(self, monkeypatch):
-        """FRIDAY_BP_UI_PORT env var is honoured."""
+        """FRIDAY_BP_UI_PORT env var is honoured when no PUBLIC_URL is set."""
+        monkeypatch.delenv("FRIDAY_BP_PUBLIC_URL", raising=False)
         monkeypatch.setenv("FRIDAY_BP_UI_PORT", "9000")
         result = get_ui_url()
         assert result == {"url": "http://127.0.0.1:9000"}
 
+    def test_public_url_overrides_localhost(self, monkeypatch):
+        """FRIDAY_BP_PUBLIC_URL takes precedence over the localhost fallback."""
+        monkeypatch.setenv("FRIDAY_BP_PUBLIC_URL", "http://100.117.47.113:6789")
+        result = get_ui_url()
+        assert result == {"url": "http://100.117.47.113:6789"}
+
+    def test_public_url_with_page(self, monkeypatch):
+        """Page path is appended to FRIDAY_BP_PUBLIC_URL correctly."""
+        monkeypatch.setenv("FRIDAY_BP_PUBLIC_URL", "http://100.117.47.113:6789")
+        result = get_ui_url(page="dashboard")
+        assert result == {"url": "http://100.117.47.113:6789/dashboard"}
+
+    def test_public_url_trailing_slash_stripped(self, monkeypatch):
+        """Trailing slash in FRIDAY_BP_PUBLIC_URL is stripped before appending page."""
+        monkeypatch.setenv("FRIDAY_BP_PUBLIC_URL", "http://100.117.47.113:6789/")
+        result = get_ui_url(page="ledgers")
+        assert result == {"url": "http://100.117.47.113:6789/ledgers"}
+
     def test_page_ledgers(self, monkeypatch):
         """page='ledgers' appends /ledgers to the URL."""
         monkeypatch.delenv("FRIDAY_BP_UI_PORT", raising=False)
+        monkeypatch.delenv("FRIDAY_BP_PUBLIC_URL", raising=False)
         result = get_ui_url(page="ledgers")
         assert result == {"url": "http://127.0.0.1:6789/ledgers"}
 
     def test_page_accounts(self, monkeypatch):
         monkeypatch.delenv("FRIDAY_BP_UI_PORT", raising=False)
+        monkeypatch.delenv("FRIDAY_BP_PUBLIC_URL", raising=False)
         assert get_ui_url(page="accounts") == {"url": "http://127.0.0.1:6789/accounts"}
 
     def test_page_profile(self, monkeypatch):
         monkeypatch.delenv("FRIDAY_BP_UI_PORT", raising=False)
+        monkeypatch.delenv("FRIDAY_BP_PUBLIC_URL", raising=False)
         assert get_ui_url(page="profile") == {"url": "http://127.0.0.1:6789/profile"}
 
     def test_page_dashboard(self, monkeypatch):
         monkeypatch.delenv("FRIDAY_BP_UI_PORT", raising=False)
+        monkeypatch.delenv("FRIDAY_BP_PUBLIC_URL", raising=False)
         assert get_ui_url(page="dashboard") == {"url": "http://127.0.0.1:6789/dashboard"}
 
     def test_invalid_page_raises(self, monkeypatch):
         """An invalid page argument raises ValueError."""
         monkeypatch.delenv("FRIDAY_BP_UI_PORT", raising=False)
+        monkeypatch.delenv("FRIDAY_BP_PUBLIC_URL", raising=False)
         with pytest.raises(ValueError, match="page must be one of"):
             get_ui_url(page="settings")
 
     def test_invalid_port_env_falls_back_to_default(self, monkeypatch):
         """A non-integer FRIDAY_BP_UI_PORT silently falls back to 6789."""
+        monkeypatch.delenv("FRIDAY_BP_PUBLIC_URL", raising=False)
         monkeypatch.setenv("FRIDAY_BP_UI_PORT", "not-a-number")
         result = get_ui_url()
         assert result == {"url": "http://127.0.0.1:6789"}


### PR DESCRIPTION
## Problem

`server/main.py` is loaded directly by the MCP framework without going through `daemon.py`, which means `FRIDAY_BP_PUBLIC_URL` and other `.env` values were **not** in `os.environ` when MCP tools ran. So `get_ui_url()` kept returning `http://127.0.0.1:6789` even after PR #351 added the `_get_ui_base_url()` helper.

## Fix

Add dotenv loading at the top of `server/main.py` (guarded by `try/except ImportError`) so the env vars are available regardless of how the module is loaded.

## Test updates

Updated `tests/test_get_ui_url.py`:
- Added `monkeypatch.delenv('FRIDAY_BP_PUBLIC_URL')` to all existing tests so they aren't affected by the real `.env` value
- Added 3 new test cases: `FRIDAY_BP_PUBLIC_URL` precedence, page path appending, trailing-slash stripping

All 11 tests pass.