### PR TITLE
fix: reauth banner direct Plaid Update Mode via GET /reconnect/{id}

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -672,16 +672,39 @@ def get_connections_needing_attention() -> dict:
 def refresh_connection(id: str) -> dict:
     """Trigger an Update Mode Plaid Link for an existing connection.
 
-    Generates a new Plaid Link token for Update Mode.  The plaid-python SDK
-    supports passing an access_token to create_link_token() for proper Update
-    Mode, but our wrapper does not yet expose that parameter — see TODO below.
-
-    TODO: Pass the decrypted access_token to create_link_token() for a true
-    Update Mode link token (requires plaid_client.create_link_token to accept
-    an optional access_token kwarg).  Tracked in issue #34.
+    Looks up the connection's encrypted access token, decrypts it, and passes
+    it to ``create_link_token()`` so Plaid opens Link in **Update Mode** for
+    that specific institution — the user sees their bank pre-loaded and does
+    not have to select from the full institution list.
     """
-    # For now, generate a fresh link token (same as start_link)
-    link_token = _plaid.create_link_token()
+    db = get_db(server.paths.DB_PATH)
+    try:
+        row = db.execute(
+            "SELECT plaid_access_token_encrypted, plaid_env FROM bank_connections WHERE id = ?",
+            (id,),
+        ).fetchone()
+    finally:
+        db.close()
+
+    if row is None:
+        raise ValueError(f"No bank connection found with id={id!r}")
+
+    try:
+        access_token = server.crypto.decrypt(row["plaid_access_token_encrypted"])
+        plaid_env = row["plaid_env"] or os.environ.get("PLAID_ENV", "sandbox")
+        provider = PlaidProvider(env=plaid_env)
+        link_token = provider.create_link_token(access_token=access_token)
+    except Exception:
+        # Fall back to fresh link token if decryption or Plaid call fails
+        import logging as _logging
+        _logging.getLogger(__name__).warning(
+            "refresh_connection: failed to get Update Mode token for id=%s, "
+            "falling back to fresh link token",
+            id,
+            exc_info=True,
+        )
+        link_token = _plaid.create_link_token()
+
     return {"url": f"{_get_ui_base_url()}/link?token={link_token}"}
 
 

--- a/server/providers/plaid.py
+++ b/server/providers/plaid.py
@@ -120,9 +120,24 @@ class PlaidProvider(BankProvider):
     # BankProvider interface
     # ------------------------------------------------------------------
 
-    def create_link_token(self, user_id: str = "friday-bp-user") -> str:
+    def create_link_token(
+        self,
+        user_id: str = "friday-bp-user",
+        access_token: str | None = None,
+    ) -> str:
         """
         Create a Plaid Link token for the given *user_id*.
+
+        Parameters
+        ----------
+        user_id:
+            Stable client user ID (default: "friday-bp-user").
+        access_token:
+            Plaintext Plaid access token for an existing connection.  When
+            provided, Plaid opens Link in **Update Mode** for that specific
+            institution — the user sees their bank pre-loaded and does not
+            have to choose from the full institution list.  Omit (or pass
+            ``None``) to launch the standard new-connection flow.
 
         Returns the ``link_token`` string that the frontend passes to Plaid Link.
 
@@ -133,13 +148,19 @@ class PlaidProvider(BankProvider):
 
         # CA only — matches old working test app; US+CA causes OAuth issues with Canadian banks
         _redirect_uri = _os.environ.get("PLAID_REDIRECT_URI")
-        _kwargs = dict(
+        _kwargs: dict = dict(
             user=LinkTokenCreateRequestUser(client_user_id=user_id),
             client_name=_APP_NAME,
-            products=[Products("transactions")],
             country_codes=[CountryCode("CA")],
             language="en",
         )
+        if access_token:
+            # Update Mode: pass the existing access_token so Plaid pre-loads
+            # the specific institution (no "choose your bank" screen).
+            # When in Update Mode, `products` must be omitted per Plaid docs.
+            _kwargs["access_token"] = access_token
+        else:
+            _kwargs["products"] = [Products("transactions")]
         if _redirect_uri:
             _kwargs["redirect_uri"] = _redirect_uri
         request = LinkTokenCreateRequest(**_kwargs)

--- a/ui/server.py
+++ b/ui/server.py
@@ -2022,6 +2022,42 @@ async def account_description_patch(request: Request, account_id: str):
     return JSONResponse({"status": "ok", "account_id": account_id})
 
 
+# ── /reconnect/{connection_id} ────────────────────────────────────────────────
+
+
+@app.get("/reconnect/{connection_id}")
+def reconnect_bank(request: Request, connection_id: str):
+    """Direct reauth route for a specific bank connection.
+
+    Requires authentication.  Generates a Plaid Link token in Update Mode
+    for the given connection and redirects straight to the Plaid Link page.
+    The user sees their bank pre-loaded — no "choose your bank" screen, no
+    extra navigation, no re-login.
+
+    Used by the global reauth banner in base.html so reconnecting from any
+    page goes directly to Plaid without touching the profile form flow.
+    """
+    if not _is_authenticated(request):
+        return _redirect("/login")
+
+    import server.main as _sm
+
+    try:
+        result = _sm.refresh_connection(id=connection_id)
+        url = result.get("url", "")
+    except Exception as exc:  # noqa: BLE001
+        import logging
+
+        logging.getLogger(__name__).error("reconnect_bank failed: %s", exc)
+        return _redirect("/accounts?error=reconnect_failed")
+
+    if not url:
+        return _redirect("/accounts?error=reconnect_no_url")
+
+    # The URL points to /link?token=... on this same server; redirect there.
+    return _redirect(url)
+
+
 # ── /ledgers ─────────────────────────────────────────────────────────────────
 
 

--- a/ui/templates/base.html
+++ b/ui/templates/base.html
@@ -87,11 +87,7 @@
     <span>⚠️ One or more bank connections need to be re-authenticated.</span>
     <span class="reauth-banner-actions">
       {% for conn in reauth_connections %}
-      <form method="post" action="/profile" style="display:inline">
-        <input type="hidden" name="action" value="reconnect_bank">
-        <input type="hidden" name="bank_id" value="{{ conn.id }}">
-        <button type="submit" class="btn-warning btn-sm">Reconnect {{ conn.institution_name or 'Bank' }} →</button>
-      </form>
+      <a href="/reconnect/{{ conn.id }}" class="btn-warning btn-sm">Reconnect {{ conn.institution_name or 'Bank' }} →</a>
       {% endfor %}
     </span>
     <button type="button" class="reauth-banner-dismiss" onclick="document.getElementById('reauth-banner').remove()" aria-label="Dismiss">✕</button>


### PR DESCRIPTION
## Summary

Fixes the bank re-authentication (verification) flow so users go directly into Plaid Update Mode for their specific institution rather than the full 'choose your bank' flow.

## Problem

The old banner used a form POST to `/profile` with `action=reconnect_bank`, which rendered the profile page with an `action_result` URL the user had to click. `refresh_connection()` also generated a fresh link token (not Update Mode), so users saw the full 'choose your bank' screen instead of their bank pre-loaded.

## Fix

**Fix 1 — True Plaid Update Mode** (`server/providers/plaid.py`):
- `create_link_token()` now accepts optional `access_token` parameter
- When `access_token` is supplied, it is passed to Plaid's `LinkTokenCreateRequest` to open Link in Update Mode for the specific institution
- `products` list is omitted in Update Mode per Plaid API requirements

**Fix 2 — refresh_connection uses Update Mode** (`server/main.py`):
- Looks up and decrypts the access_token for the given connection
- Passes it to `create_link_token()` for a true Update Mode token
- Falls back to a fresh link token if decryption/Plaid call fails

**Fix 3 — Dedicated GET /reconnect/{connection_id} route** (`ui/server.py`):
- Requires authentication (redirects to /login if not logged in)
- Calls `refresh_connection(id)` to generate an Update Mode Plaid link token
- Redirects directly to `/link?token=...` — no form, no extra page

**Fix 4 — Banner uses direct link** (`ui/templates/base.html`):
- Replace POST form buttons with simple `<a href='/reconnect/{conn.id}'>`
- Clicking goes directly to Plaid Update Mode for that specific bank