### PR TITLE
fix: resolve two failing tests on main

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -712,16 +712,16 @@ def refresh_connection(id: str) -> dict:
     finally:
         db.close()
 
-    if row is None:
-        raise ValueError(f"No bank connection found with id={id!r}")
-
     try:
+        if row is None:
+            raise ValueError(f"No bank connection found with id={id!r}")
         access_token = server.crypto.decrypt(row["plaid_access_token_encrypted"])
         plaid_env = row["plaid_env"] or os.environ.get("PLAID_ENV", "sandbox")
         provider = PlaidProvider(env=plaid_env)
         link_token = provider.create_link_token(access_token=access_token)
     except Exception:
-        # Fall back to fresh link token if decryption or Plaid call fails
+        # Fall back to fresh link token if connection not found, decryption,
+        # or Plaid call fails
         import logging as _logging
         _logging.getLogger(__name__).warning(
             "refresh_connection: failed to get Update Mode token for id=%s, "

--- a/tests/test_ledger_mcp_tools.py
+++ b/tests/test_ledger_mcp_tools.py
@@ -56,7 +56,7 @@ def _seed_personal(monkeypatch):
     """Call apply_initial_setup with a mocked _register_openclaw_cron."""
     from server.main import apply_initial_setup
 
-    monkeypatch.setattr("server.main._register_openclaw_cron", lambda: False)
+    monkeypatch.setattr("server.main._register_openclaw_cron_file", lambda: False)
     apply_initial_setup(banks_to_link=[], extra_ledgers=[], hints=[])
 
 


### PR DESCRIPTION
## Summary

Fixes two pre-existing failing tests on `main`.

### Fix 1: `test_refresh_connection_returns_url_with_link_token`

**Root cause:** `refresh_connection()` raised `ValueError` when the given connection ID didn't exist in the database. The test passed a nonexistent ID (`"any-connection-id"`) and expected the function to fall back to a fresh link token (same behavior as when decryption or the Plaid API call fails).

**Fix:** Move the `if row is None` check inside the existing `try/except` block so it falls through to the same fallback path that handles decryption and Plaid errors.

### Fix 2: `test_list_ledgers_returns_personal`

**Root cause:** `_register_openclaw_cron` was renamed to `_register_openclaw_cron_file` in `server/main.py`, but the test still monkeypatched the old name, causing `AttributeError`.

**Fix:** Update the monkeypatch target in `tests/test_ledger_mcp_tools.py` to use `_register_openclaw_cron_file`.